### PR TITLE
feat: add max_experiments support

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -57,6 +57,8 @@ interface ExperimentState {
   name: string | null;
   /** Current segment index (incremented on each init_experiment) */
   currentSegment: number;
+  /** Maximum number of experiments before auto-stopping. null = unlimited. */
+  maxExperiments: number | null;
 }
 
 interface RunDetails {
@@ -109,6 +111,13 @@ const InitParams = Type.Object({
     Type.String({
       description:
         'Whether "lower" or "higher" is better for the primary metric. Default: "lower".',
+    })
+  ),
+  max_experiments: Type.Optional(
+    Type.Integer({
+      description:
+        "Maximum number of experiments (including the baseline run) before auto-stopping. Omit for unlimited.",
+      minimum: 1,
     })
   ),
 });
@@ -492,6 +501,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     secondaryMetrics: [],
     name: null,
     currentSegment: 0,
+    maxExperiments: null,
   };
 
   // -----------------------------------------------------------------------
@@ -508,6 +518,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       secondaryMetrics: [],
       name: null,
       currentSegment: 0,
+      maxExperiments: null,
     };
 
     // Primary: read from autoresearch.jsonl (alongside autoresearch.md/sh)
@@ -527,6 +538,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               if (entry.metricName) state.metricName = entry.metricName;
               if (entry.metricUnit !== undefined) state.metricUnit = entry.metricUnit;
               if (entry.bestDirection) state.bestDirection = entry.bestDirection;
+              state.maxExperiments =
+                typeof entry.maxExperiments === "number" && entry.maxExperiments > 0
+                  ? entry.maxExperiments
+                  : null;
               // Increment segment (first config = 0, second = 1, etc.)
               if (state.results.length > 0) segment++;
               state.currentSegment = segment;
@@ -759,7 +774,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     let extra =
       "\n\n## Autoresearch Mode (ACTIVE)" +
       "\nYou are in autoresearch mode. Optimize the primary metric through an autonomous experiment loop." +
-      "\nUse init_experiment, run_experiment, and log_experiment tools. NEVER STOP until interrupted." +
+      "\nUse init_experiment, run_experiment, and log_experiment tools." +
+      (state.maxExperiments !== null
+        ? `\nMax experiments: ${state.maxExperiments}. STOP the loop when log_experiment tells you the limit is reached.`
+        : "\nNEVER STOP until interrupted.") +
       `\nExperiment rules: ${mdPath} — read this file at the start of every session and after compaction.` +
       "\nWrite promising but deferred optimizations as bullet points to autoresearch.ideas.md — don't let good ideas get lost." +
       "\nIf the user sends a follow-on message while an experiment is running, finish the current run_experiment + log_experiment cycle first, then address their message in the next iteration.";
@@ -788,6 +806,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "Call init_experiment exactly once at the start of an autoresearch session, before the first run_experiment.",
       "If autoresearch.jsonl already exists with a config, do NOT call init_experiment again.",
       "If the optimization target changes (different benchmark, metric, or workload), call init_experiment again to insert a new config header and reset the baseline.",
+      "Set max_experiments to limit the number of experiments. When the limit is reached, the loop auto-stops.",
     ],
     parameters: InitParams,
 
@@ -800,6 +819,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       if (params.direction === "lower" || params.direction === "higher") {
         state.bestDirection = params.direction;
       }
+      state.maxExperiments = params.max_experiments ?? null;
 
       // Reset results for new baseline segment
       state.results = [];
@@ -815,6 +835,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           metricName: state.metricName,
           metricUnit: state.metricUnit,
           bestDirection: state.bestDirection,
+          maxExperiments: state.maxExperiments,
         });
         if (isReinit) {
           fs.appendFileSync(jsonlPath, config + "\n");
@@ -835,10 +856,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       updateWidget(ctx);
 
       const reinitNote = isReinit ? " (re-initialized — previous results archived, new baseline needed)" : "";
+      const limitNote =
+        state.maxExperiments !== null ? `\nMax experiments: ${state.maxExperiments}` : "";
       return {
         content: [{
           type: "text",
-          text: `✅ Experiment initialized: "${state.name}"${reinitNote}\nMetric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)\nConfig written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
+          text: `✅ Experiment initialized: "${state.name}"${reinitNote}\nMetric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)${limitNote}\nConfig written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
         }],
         details: { state: { ...state } },
       };
@@ -874,6 +897,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     parameters: RunParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      if (state.maxExperiments !== null) {
+        const segmentCount = currentResults(state.results, state.currentSegment).length;
+        if (segmentCount >= state.maxExperiments) {
+          return {
+            content: [{
+              type: "text",
+              text: `🛑 Maximum experiments reached (${state.maxExperiments}). The experiment loop is done. To continue, call init_experiment to start a new segment.`,
+            }],
+            details: {},
+          };
+        }
+      }
+
       const timeout = (params.timeout_seconds ?? 600) * 1000;
 
       runningExperiment = { startedAt: Date.now(), command: params.command };
@@ -1074,12 +1110,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       state.bestMetric = findBaselineMetric(state.results, state.currentSegment);
 
       // Build response text
-      const curCount = currentResults(state.results, state.currentSegment).length;
+      const segmentCount = currentResults(state.results, state.currentSegment).length;
       let text = `Logged #${state.results.length}: ${experiment.status} — ${experiment.description}`;
 
       if (state.bestMetric !== null) {
         text += `\nBaseline ${state.metricName}: ${formatNum(state.bestMetric, state.metricUnit)}`;
-        if (curCount > 1 && params.status === "keep" && params.metric > 0) {
+        if (segmentCount > 1 && params.status === "keep" && params.metric > 0) {
           const delta = params.metric - state.bestMetric;
           const pct = ((delta / state.bestMetric) * 100).toFixed(1);
           const sign = delta > 0 ? "+" : "";
@@ -1107,7 +1143,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         text += `\nSecondary: ${parts.join("  ")}`;
       }
 
-      text += `\n(${state.results.length} experiments total)`;
+      text += `\n(${segmentCount} experiments`;
+      if (state.maxExperiments !== null) {
+        text += ` / ${state.maxExperiments} max`;
+      }
+      text += `)`;
 
       // Auto-commit only on keep — discards/crashes get reverted anyway
       if (params.status === "keep") {
@@ -1164,6 +1204,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       // Clear running experiment (log_experiment consumes the run)
       runningExperiment = null;
+
+      const limitReached =
+        state.maxExperiments !== null && segmentCount >= state.maxExperiments;
+      if (limitReached) {
+        text += `\n\n🛑 Maximum experiments reached (${state.maxExperiments}). STOP the experiment loop now.`;
+        autoresearchMode = false;
+      }
 
       updateWidget(ctx);
 

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -9,13 +9,13 @@ Autonomous experiment loop: try ideas, keep what works, discard what doesn't, ne
 
 ## Tools
 
-- **`init_experiment`** — configure session (name, metric, unit, direction). Call again to re-initialize with a new baseline when the optimization target changes.
+- **`init_experiment`** — configure session (name, metric, unit, direction, max_experiments). Call again to re-initialize with a new baseline when the optimization target changes.
 - **`run_experiment`** — runs command, times it, captures output.
 - **`log_experiment`** — records result. `keep` auto-commits. `discard`/`crash` → `git checkout -- .` to revert. Always include secondary `metrics` dict. Dashboard: ctrl+x.
 
 ## Setup
 
-1. Ask (or infer): **Goal**, **Command**, **Metric** (+ direction), **Files in scope**, **Constraints**.
+1. Ask (or infer): **Goal**, **Command**, **Metric** (+ direction), **Files in scope**, **Constraints**, **Max experiments** (optional — limit how many experiments to run before stopping; omit for unlimited).
 2. `git checkout -b autoresearch/<goal>-<date>`
 3. Read the source files. Understand the workload deeply before writing anything.
 4. Write `autoresearch.md` and `autoresearch.sh` (see below). Commit both.
@@ -69,7 +69,7 @@ Bash script (`set -euo pipefail`) that: pre-checks fast (syntax errors in <1s), 
 - **Think longer when stuck.** Re-read source files, study the profiling data, reason about what the CPU is actually doing. The best ideas come from deep understanding, not from trying random variations.
 - **Resuming:** if `autoresearch.md` exists, read it + git log, continue looping.
 
-**NEVER STOP.** The user may be away for hours. Keep going until interrupted.
+**NEVER STOP** (unless `max_experiments` is set). The user may be away for hours. Keep going until interrupted or the experiment limit is reached.
 
 ## Ideas Backlog
 


### PR DESCRIPTION
## Summary

This supersedes #1 with the same `max_experiments` feature rebased onto current `main`.

The experiment loop currently runs forever unless interrupted. This PR adds an optional `max_experiments` parameter to `init_experiment` so an autoresearch session can stop automatically after N experiments in the current segment.

Changes:
- add optional `max_experiments` to `init_experiment`
- persist and reconstruct the limit from `autoresearch.jsonl`
- block `run_experiment` once the current segment has reached the limit
- have `log_experiment` announce when the limit is reached and disable autoresearch mode
- update the autoresearch system prompt and skill docs to reflect bounded vs unbounded runs

## Why a new PR

#1 is currently marked dirty against `main`. This branch carries the same feature forward on top of the newer ideas-backlog and auto-resume changes already merged upstream.

## Test plan

- [ ] Run `init_experiment` with `max_experiments: 3` and confirm the config line in `autoresearch.jsonl` includes `maxExperiments: 3`
- [ ] Run 3 experiments and confirm `log_experiment` reports the limit on the 3rd run
- [ ] Confirm `run_experiment` refuses a 4th run in the same segment
- [ ] Restart the session and confirm the limit reconstructs from `autoresearch.jsonl`
- [ ] Confirm omitting `max_experiments` preserves existing unlimited behavior

## Notes

I did not run a full end-to-end behavioral test locally because this repo does not include a standalone test harness for the Pi extension runtime.
