### PR TITLE
chore: ignore node_modules and npm debug logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store


### PR DESCRIPTION
## Summary
- add a root .gitignore with 
ode_modules/ and common npm/pnpm/yarn debug logs
- prevent future accidental commits of local install artifacts
- keep scope intentionally narrow and non-destructive

## Why
Issue #3 points out that the heavy 	ree-on-experiment-log branch likely came from committed install artifacts. This PR does not try to rewrite branch history from a fork, but it does close the easy prevention gap so the repo is less likely to regress.

## Testing
- verified .gitignore is now tracked at the repo root
- no runtime or package behavior changes

Refs #3