### PR TITLE
refactor(ui): extract dashboard layout helpers and shared types

### DIFF
--- a/extensions/pi-autoresearch/dashboard.ts
+++ b/extensions/pi-autoresearch/dashboard.ts
@@ -1,0 +1,440 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+
+import type { ExperimentResult, ExperimentState, MetricDef } from "./types";
+
+/** Format a number with comma-separated thousands: 15586 → "15,586" */
+function commas(n: number): string {
+  const s = String(Math.round(n));
+  const parts: string[] = [];
+  for (let i = s.length; i > 0; i -= 3) {
+    parts.unshift(s.slice(Math.max(0, i - 3), i));
+  }
+  return parts.join(",");
+}
+
+/** Format number with commas, preserving one decimal for fractional values */
+function fmtNum(n: number, decimals: number = 0): string {
+  if (decimals > 0) {
+    const int = Math.floor(Math.abs(n));
+    const frac = (Math.abs(n) - int).toFixed(decimals).slice(1); // ".3"
+    return (n < 0 ? "-" : "") + commas(int) + frac;
+  }
+  return commas(n);
+}
+
+export function formatNum(value: number | null, unit: string): string {
+  if (value === null) return "—";
+  const u = unit || "";
+  // Integers: no decimals
+  if (value === Math.round(value)) return fmtNum(value) + u;
+  // Fractional: 2 decimal places
+  return fmtNum(value, 2) + u;
+}
+
+export function isBetter(
+  current: number,
+  best: number,
+  direction: "lower" | "higher"
+): boolean {
+  return direction === "lower" ? current < best : current > best;
+}
+
+/** Get results in the current segment only */
+export function currentResults(results: ExperimentResult[], segment: number): ExperimentResult[] {
+  return results.filter((r) => r.segment === segment);
+}
+
+/** Baseline = first experiment in current segment */
+export function findBaselineMetric(results: ExperimentResult[], segment: number): number | null {
+  const cur = currentResults(results, segment);
+  return cur.length > 0 ? cur[0].metric : null;
+}
+
+/**
+ * Find secondary metric baselines from the first experiment in current segment.
+ * For metrics that didn't exist at baseline time, falls back to the first
+ * occurrence of that metric in the current segment.
+ */
+export function findBaselineSecondary(
+  results: ExperimentResult[],
+  segment: number,
+  knownMetrics?: MetricDef[]
+): Record<string, number> {
+  const cur = currentResults(results, segment);
+  const base: Record<string, number> = cur.length > 0
+    ? { ...(cur[0].metrics ?? {}) }
+    : {};
+
+  // Fill in any known metrics missing from baseline with their first occurrence
+  if (knownMetrics) {
+    for (const sm of knownMetrics) {
+      if (base[sm.name] === undefined) {
+        for (const r of cur) {
+          const val = (r.metrics ?? {})[sm.name];
+          if (val !== undefined) {
+            base[sm.name] = val;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return base;
+}
+
+export function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+export function getTuiSize(tui: unknown): { width: number; height: number } {
+  const maybe = tui as { width?: number; height?: number } | undefined;
+  return {
+    width: maybe?.width ?? process.stdout.columns ?? 120,
+    height: maybe?.height ?? process.stdout.rows ?? 40,
+  };
+}
+
+export function truncateDisplayText(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (visibleWidth(text) <= maxWidth) return text;
+
+  let out = "";
+  for (const ch of text) {
+    if (visibleWidth(out + ch + "…") > maxWidth) break;
+    out += ch;
+  }
+  return out + "…";
+}
+
+export function joinPartsToWidth(parts: string[], width: number): string {
+  let out = "";
+  for (const part of parts) {
+    if (!part) continue;
+    const next = out + part;
+    if (visibleWidth(next) > width) break;
+    out = next;
+  }
+  return truncateToWidth(out, width);
+}
+
+export function appendRightAlignedAdaptiveHint(
+  baseLine: string,
+  width: number,
+  theme: Theme,
+  hintCandidates: string[]
+): string {
+  const currentWidth = visibleWidth(baseLine);
+  const available = width - currentWidth;
+  if (available <= 0) return truncateToWidth(baseLine, width);
+
+  let chosenHint: string | null = null;
+  for (const candidate of hintCandidates) {
+    if (visibleWidth(candidate) <= available) {
+      chosenHint = candidate;
+      break;
+    }
+  }
+
+  if (!chosenHint) return truncateToWidth(baseLine, width);
+
+  const hintStyled = theme.fg("dim", chosenHint);
+  const hintWidth = visibleWidth(hintStyled);
+  return truncateToWidth(
+    baseLine + " ".repeat(Math.max(0, available - hintWidth)) + hintStyled,
+    width
+  );
+}
+
+export function renderDashboardLines(
+  st: ExperimentState,
+  width: number,
+  th: Theme,
+  maxRows: number = 6,
+  headerHint?: string
+): string[] {
+  const lines: string[] = [];
+
+  if (st.results.length === 0) {
+    lines.push(`  ${th.fg("dim", "No experiments yet.")}`);
+    return lines;
+  }
+
+  const cur = currentResults(st.results, st.currentSegment);
+  const kept = cur.filter((r) => r.status === "keep").length;
+  const discarded = cur.filter((r) => r.status === "discard").length;
+  const crashed = cur.filter((r) => r.status === "crash").length;
+  const checksFailed = cur.filter((r) => r.status === "checks_failed").length;
+
+  const baseline = st.bestMetric;
+  const baselineSec = findBaselineSecondary(st.results, st.currentSegment, st.secondaryMetrics);
+
+  // Find best kept primary metric and its run number (current segment only)
+  let bestPrimary: number | null = null;
+  let bestSecondary: Record<string, number> = {};
+  let bestRunNum = 0;
+  for (let i = st.results.length - 1; i >= 0; i--) {
+    const r = st.results[i];
+    if (r.segment !== st.currentSegment) continue;
+    if (r.status === "keep" && r.metric > 0) {
+      if (bestPrimary === null || isBetter(r.metric, bestPrimary, st.bestDirection)) {
+        bestPrimary = r.metric;
+        bestSecondary = r.metrics ?? {};
+        bestRunNum = i + 1;
+      }
+    }
+  }
+
+  // Runs summary
+  lines.push(
+    truncateToWidth(
+      `  ${th.fg("muted", "Runs:")} ${th.fg("text", String(st.results.length))}` +
+        `  ${th.fg("success", `${kept} kept`)}` +
+        (discarded > 0 ? `  ${th.fg("warning", `${discarded} discarded`)}` : "") +
+        (crashed > 0 ? `  ${th.fg("error", `${crashed} crashed`)}` : "") +
+        (checksFailed > 0 ? `  ${th.fg("error", `${checksFailed} checks failed`)}` : ""),
+      width
+    )
+  );
+
+  // Baseline: first run's primary metric
+  lines.push(
+    truncateToWidth(
+      `  ${th.fg("muted", "Baseline:")} ${th.fg("dim", `★ ${st.metricName}: ${formatNum(baseline, st.metricUnit)} #1`)}`,
+      width
+    )
+  );
+
+
+  // Progress: best primary metric with delta + run number
+  if (bestPrimary !== null) {
+    let progressLine = `  ${th.fg("muted", "Progress:")} ${th.fg("warning", th.bold(`★ ${st.metricName}: ${formatNum(bestPrimary, st.metricUnit)}`))}${th.fg("dim", ` #${bestRunNum}`)}`;
+
+    if (baseline !== null && baseline !== 0 && bestPrimary !== baseline) {
+      const pct = ((bestPrimary - baseline) / baseline) * 100;
+      const sign = pct > 0 ? "+" : "";
+      const color = isBetter(bestPrimary, baseline, st.bestDirection) ? "success" : "error";
+      progressLine += th.fg(color, ` (${sign}${pct.toFixed(1)}%)`);
+    }
+
+    lines.push(truncateToWidth(progressLine, width));
+
+    // Progress secondary metrics on next line with deltas
+    if (st.secondaryMetrics.length > 0) {
+      const secParts: string[] = [];
+      for (const sm of st.secondaryMetrics) {
+        const val = bestSecondary[sm.name];
+        const bv = baselineSec[sm.name];
+        if (val !== undefined) {
+          let part = `${sm.name}: ${formatNum(val, sm.unit)}`;
+          if (bv !== undefined && bv !== 0 && val !== bv) {
+            const p = ((val - bv) / bv) * 100;
+            const s = p > 0 ? "+" : "";
+            const c = val <= bv ? "success" : "error";
+            part += th.fg(c, ` ${s}${p.toFixed(1)}%`);
+          }
+          secParts.push(part);
+        }
+      }
+      if (secParts.length > 0) {
+        lines.push(
+          truncateToWidth(
+            `  ${th.fg("dim", "          ")}${th.fg("muted", secParts.join("  "))}`,
+            width
+          )
+        );
+      }
+    }
+  }
+
+  lines.push("");
+
+  // Determine visible rows for column pruning
+  const effectiveMax = maxRows <= 0 ? st.results.length : maxRows;
+  const startIdx = Math.max(0, st.results.length - effectiveMax);
+  const visibleRows = st.results.slice(startIdx);
+
+  // Only show secondary metric columns that have at least one value in visible rows
+  const secMetrics = st.secondaryMetrics.filter((sm) =>
+    visibleRows.some((r) => (r.metrics ?? {})[sm.name] !== undefined)
+  );
+
+  // Column definitions
+  const col = { idx: 3, commit: 8, primary: 11, status: 15 };
+  const secColWidth = 11;
+  const minDescWidth = 10;
+  const leftPad = 2;
+  const baseWithIdxAndDesc = leftPad + col.idx + col.commit + col.primary + col.status + minDescWidth;
+  const baseWithoutIdx = leftPad + col.commit + col.primary + col.status + minDescWidth;
+
+  // Resize behavior order: secondary metrics -> # column -> description
+  let includeIndex = true;
+  let includeDescription = true;
+  if (width < baseWithIdxAndDesc) includeIndex = false;
+  if (width < (includeIndex ? baseWithIdxAndDesc : baseWithoutIdx)) includeDescription = false;
+
+  const spaceForSecondaries = Math.max(
+    0,
+    width -
+      leftPad -
+      (includeIndex ? col.idx : 0) -
+      col.commit -
+      col.primary -
+      col.status -
+      (includeDescription ? minDescWidth : 0)
+  );
+  const maxSecCols = Math.max(0, Math.floor(spaceForSecondaries / secColWidth));
+  const shownSecMetrics = secMetrics.slice(0, maxSecCols);
+  const hiddenSecMetrics = secMetrics.length - shownSecMetrics.length;
+  const totalSecWidth = shownSecMetrics.length * secColWidth;
+  const descW = includeDescription
+    ? Math.max(
+      minDescWidth,
+      width -
+        leftPad -
+        (includeIndex ? col.idx : 0) -
+        col.commit -
+        col.primary -
+        totalSecWidth -
+        col.status
+    )
+    : 0;
+
+  // Table header — primary metric name bolded with ★
+  let headerLine = "  ";
+  if (includeIndex) {
+    headerLine += th.fg("muted", "#".padEnd(col.idx));
+  }
+  headerLine +=
+    `${th.fg("muted", "commit".padEnd(col.commit))}` +
+    `${th.fg("warning", th.bold(("★ " + st.metricName).slice(0, col.primary - 1).padEnd(col.primary)))}`;
+
+  for (const sm of shownSecMetrics) {
+    headerLine += th.fg(
+      "muted",
+      sm.name.slice(0, secColWidth - 1).padEnd(secColWidth)
+    );
+  }
+
+  headerLine += th.fg("muted", "status".padEnd(col.status));
+  if (includeDescription) {
+    headerLine += th.fg("muted", "description");
+  }
+  if (headerHint) {
+    headerLine = appendRightAlignedAdaptiveHint(headerLine, width, th, [
+      headerHint,
+      "ctrl+x collapse • full: c-s-x",
+      "ctrl+x • c-s-x",
+    ]);
+  }
+
+  lines.push(truncateToWidth(headerLine, width));
+  lines.push(
+    truncateToWidth(
+      `  ${th.fg("borderMuted", "─".repeat(width - 4))}`,
+      width
+    )
+  );
+
+  if (hiddenSecMetrics > 0) {
+    lines.push(
+      truncateToWidth(
+        `  ${th.fg("dim", `+${hiddenSecMetrics} metric column${hiddenSecMetrics === 1 ? "" : "s"} hidden at this width`)}`,
+        width
+      )
+    );
+  }
+
+  // Baseline values for delta display (current segment only)
+  const baselinePrimary = findBaselineMetric(st.results, st.currentSegment);
+  const baselineSecondary = findBaselineSecondary(
+    st.results,
+    st.currentSegment,
+    st.secondaryMetrics
+  );
+
+  // Show max 6 recent runs, with a note about hidden earlier ones
+  if (startIdx > 0) {
+    lines.push(
+      truncateToWidth(
+        `  ${th.fg("dim", `… ${startIdx} earlier run${startIdx === 1 ? "" : "s"}`)}`,
+        width
+      )
+    );
+  }
+
+  for (let i = startIdx; i < st.results.length; i++) {
+    const r = st.results[i];
+    const isOld = r.segment !== st.currentSegment;
+    const isBaseline = !isOld && i === st.results.findIndex((x) => x.segment === st.currentSegment);
+
+    const color = isOld
+      ? "dim"
+      : r.status === "keep"
+        ? "success"
+        : r.status === "crash" || r.status === "checks_failed"
+          ? "error"
+          : "warning";
+
+    // Primary metric with color coding
+    const primaryStr = formatNum(r.metric, st.metricUnit);
+    let primaryColor: Parameters<typeof th.fg>[0] = isOld ? "dim" : "text";
+    if (!isOld) {
+      if (isBaseline) {
+        primaryColor = "muted"; // baseline row
+      } else if (
+        baselinePrimary !== null &&
+        r.status === "keep" &&
+        r.metric > 0
+      ) {
+        if (isBetter(r.metric, baselinePrimary, st.bestDirection)) {
+          primaryColor = "success";
+        } else if (r.metric !== baselinePrimary) {
+          primaryColor = "error";
+        }
+      }
+    }
+
+    const idxStr = th.fg("dim", String(i + 1).padEnd(col.idx));
+    const commitStr = isOld ? "(old)".padEnd(col.commit) : r.commit.padEnd(col.commit);
+
+    let rowLine = "  ";
+    if (includeIndex) {
+      rowLine += idxStr;
+    }
+    rowLine +=
+      `${th.fg(isOld ? "dim" : "accent", commitStr)}` +
+      `${th.fg(primaryColor, isOld ? primaryStr.padEnd(col.primary) : th.bold(primaryStr.padEnd(col.primary)))}`;
+
+    // Secondary metrics
+    const rowMetrics = r.metrics ?? {};
+    for (const sm of shownSecMetrics) {
+      const val = rowMetrics[sm.name];
+      if (val !== undefined) {
+        const secStr = formatNum(val, sm.unit);
+        let secColor: Parameters<typeof th.fg>[0] = "dim";
+        if (!isOld) {
+          const bv = baselineSecondary[sm.name];
+          if (isBaseline) {
+            secColor = "muted"; // baseline row
+          } else if (bv !== undefined && bv !== 0) {
+            secColor = val <= bv ? "success" : "error";
+          }
+        }
+        rowLine += th.fg(secColor, secStr.padEnd(secColWidth));
+      } else {
+        rowLine += th.fg("dim", "—".padEnd(secColWidth));
+      }
+    }
+
+    rowLine += th.fg(color, r.status.padEnd(col.status));
+    if (includeDescription) {
+      rowLine += th.fg("muted", truncateToWidth(r.description, descW));
+    }
+
+    lines.push(truncateToWidth(rowLine, width));
+  }
+
+  return lines;
+}

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -12,11 +12,7 @@
  * - Injects autoresearch.md into context on every turn via before_agent_start
  */
 
-import type {
-  ExtensionAPI,
-  ExtensionContext,
-  Theme,
-} from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { truncateTail } from "@mariozechner/pi-coding-agent";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { Text, truncateToWidth, matchesKey, visibleWidth } from "@mariozechner/pi-tui";
@@ -24,62 +20,26 @@ import { Type } from "@sinclair/typebox";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import {
+  appendRightAlignedAdaptiveHint,
+  clamp,
+  currentResults,
+  findBaselineMetric,
+  findBaselineSecondary,
+  formatNum,
+  getTuiSize,
+  isBetter,
+  joinPartsToWidth,
+  renderDashboardLines,
+  truncateDisplayText,
+} from "./dashboard";
+import type {
+  ExperimentResult,
+  ExperimentState,
+  LogDetails,
+  RunDetails,
+} from "./types";
 
-interface ExperimentResult {
-  commit: string;
-  metric: number;
-  /** Additional tracked metrics: { name: value } */
-  metrics: Record<string, number>;
-  status: "keep" | "discard" | "crash" | "checks_failed";
-  description: string;
-  timestamp: number;
-  /** Segment index — increments on each config header. Current segment = highest. */
-  segment: number;
-}
-
-interface MetricDef {
-  name: string;
-  unit: string;
-}
-
-interface ExperimentState {
-  results: ExperimentResult[];
-  /** Baseline primary metric (from first experiment in current segment) */
-  bestMetric: number | null;
-  bestDirection: "lower" | "higher";
-  metricName: string;
-  metricUnit: string;
-  /** Definitions for secondary metrics (order preserved) */
-  secondaryMetrics: MetricDef[];
-  name: string | null;
-  /** Current segment index (incremented on each init_experiment) */
-  currentSegment: number;
-  /** Maximum number of experiments before auto-stopping. null = unlimited. */
-  maxExperiments: number | null;
-}
-
-interface RunDetails {
-  command: string;
-  exitCode: number | null;
-  durationSeconds: number;
-  passed: boolean;
-  crashed: boolean;
-  timedOut: boolean;
-  tailOutput: string;
-  /** null = checks not run (no file or benchmark failed), true/false = ran */
-  checksPass: boolean | null;
-  checksTimedOut: boolean;
-  checksOutput: string;
-  checksDuration: number;
-}
-
-interface LogDetails {
-  experiment: ExperimentResult;
-  state: ExperimentState;
-}
 
 // ---------------------------------------------------------------------------
 // Tool Schemas
@@ -150,52 +110,6 @@ const LogParams = Type.Object({
   ),
 });
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Format a number with comma-separated thousands: 15586 → "15,586" */
-function commas(n: number): string {
-  const s = String(Math.round(n));
-  const parts: string[] = [];
-  for (let i = s.length; i > 0; i -= 3) {
-    parts.unshift(s.slice(Math.max(0, i - 3), i));
-  }
-  return parts.join(",");
-}
-
-/** Format number with commas, preserving one decimal for fractional values */
-function fmtNum(n: number, decimals: number = 0): string {
-  if (decimals > 0) {
-    const int = Math.floor(Math.abs(n));
-    const frac = (Math.abs(n) - int).toFixed(decimals).slice(1); // ".3"
-    return (n < 0 ? "-" : "") + commas(int) + frac;
-  }
-  return commas(n);
-}
-
-function formatNum(value: number | null, unit: string): string {
-  if (value === null) return "—";
-  const u = unit || "";
-  // Integers: no decimals
-  if (value === Math.round(value)) return fmtNum(value) + u;
-  // Fractional: 2 decimal places
-  return fmtNum(value, 2) + u;
-}
-
-function isBetter(
-  current: number,
-  best: number,
-  direction: "lower" | "higher"
-): boolean {
-  return direction === "lower" ? current < best : current > best;
-}
-
-/** Get results in the current segment only */
-function currentResults(results: ExperimentResult[], segment: number): ExperimentResult[] {
-  return results.filter((r) => r.segment === segment);
-}
-
 interface AutoresearchConfig {
   maxIterations?: number;
   workingDir?: string;
@@ -250,292 +164,6 @@ function validateWorkDir(ctxCwd: string): string | null {
   }
   return null;
 }
-
-/** Baseline = first experiment in current segment */
-function findBaselineMetric(results: ExperimentResult[], segment: number): number | null {
-  const cur = currentResults(results, segment);
-  return cur.length > 0 ? cur[0].metric : null;
-}
-
-/**
- * Find secondary metric baselines from the first experiment in current segment.
- * For metrics that didn't exist at baseline time, falls back to the first
- * occurrence of that metric in the current segment.
- */
-function findBaselineSecondary(
-  results: ExperimentResult[],
-  segment: number,
-  knownMetrics?: MetricDef[]
-): Record<string, number> {
-  const cur = currentResults(results, segment);
-  const base: Record<string, number> = cur.length > 0
-    ? { ...(cur[0].metrics ?? {}) }
-    : {};
-
-  // Fill in any known metrics missing from baseline with their first occurrence
-  if (knownMetrics) {
-    for (const sm of knownMetrics) {
-      if (base[sm.name] === undefined) {
-        for (const r of cur) {
-          const val = (r.metrics ?? {})[sm.name];
-          if (val !== undefined) {
-            base[sm.name] = val;
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  return base;
-}
-
-// ---------------------------------------------------------------------------
-// Extension
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Dashboard table renderer (pure function, no UI deps)
-// ---------------------------------------------------------------------------
-
-function renderDashboardLines(
-  st: ExperimentState,
-  width: number,
-  th: Theme,
-  maxRows: number = 6
-): string[] {
-  const lines: string[] = [];
-
-  if (st.results.length === 0) {
-    lines.push(`  ${th.fg("dim", "No experiments yet.")}`);
-    return lines;
-  }
-
-  const cur = currentResults(st.results, st.currentSegment);
-  const kept = cur.filter((r) => r.status === "keep").length;
-  const discarded = cur.filter((r) => r.status === "discard").length;
-  const crashed = cur.filter((r) => r.status === "crash").length;
-  const checksFailed = cur.filter((r) => r.status === "checks_failed").length;
-
-  const baseline = st.bestMetric;
-  const baselineSec = findBaselineSecondary(st.results, st.currentSegment, st.secondaryMetrics);
-
-  // Find best kept primary metric and its run number (current segment only)
-  let bestPrimary: number | null = null;
-  let bestSecondary: Record<string, number> = {};
-  let bestRunNum = 0;
-  for (let i = st.results.length - 1; i >= 0; i--) {
-    const r = st.results[i];
-    if (r.segment !== st.currentSegment) continue;
-    if (r.status === "keep" && r.metric > 0) {
-      if (bestPrimary === null || isBetter(r.metric, bestPrimary, st.bestDirection)) {
-        bestPrimary = r.metric;
-        bestSecondary = r.metrics ?? {};
-        bestRunNum = i + 1;
-      }
-    }
-  }
-
-  // Runs summary
-  lines.push(
-    truncateToWidth(
-      `  ${th.fg("muted", "Runs:")} ${th.fg("text", String(st.results.length))}` +
-        `  ${th.fg("success", `${kept} kept`)}` +
-        (discarded > 0 ? `  ${th.fg("warning", `${discarded} discarded`)}` : "") +
-        (crashed > 0 ? `  ${th.fg("error", `${crashed} crashed`)}` : "") +
-        (checksFailed > 0 ? `  ${th.fg("error", `${checksFailed} checks failed`)}` : ""),
-      width
-    )
-  );
-
-  // Baseline: first run's primary metric
-  lines.push(
-    truncateToWidth(
-      `  ${th.fg("muted", "Baseline:")} ${th.fg("dim", `★ ${st.metricName}: ${formatNum(baseline, st.metricUnit)} #1`)}`,
-      width
-    )
-  );
-
-
-  // Progress: best primary metric with delta + run number
-  if (bestPrimary !== null) {
-    let progressLine = `  ${th.fg("muted", "Progress:")} ${th.fg("warning", th.bold(`★ ${st.metricName}: ${formatNum(bestPrimary, st.metricUnit)}`))}${th.fg("dim", ` #${bestRunNum}`)}`;
-
-    if (baseline !== null && baseline !== 0 && bestPrimary !== baseline) {
-      const pct = ((bestPrimary - baseline) / baseline) * 100;
-      const sign = pct > 0 ? "+" : "";
-      const color = isBetter(bestPrimary, baseline, st.bestDirection) ? "success" : "error";
-      progressLine += th.fg(color, ` (${sign}${pct.toFixed(1)}%)`);
-    }
-
-    lines.push(truncateToWidth(progressLine, width));
-
-    // Progress secondary metrics on next line with deltas
-    if (st.secondaryMetrics.length > 0) {
-      const secParts: string[] = [];
-      for (const sm of st.secondaryMetrics) {
-        const val = bestSecondary[sm.name];
-        const bv = baselineSec[sm.name];
-        if (val !== undefined) {
-          let part = `${sm.name}: ${formatNum(val, sm.unit)}`;
-          if (bv !== undefined && bv !== 0 && val !== bv) {
-            const p = ((val - bv) / bv) * 100;
-            const s = p > 0 ? "+" : "";
-            const c = val <= bv ? "success" : "error";
-            part += th.fg(c, ` ${s}${p.toFixed(1)}%`);
-          }
-          secParts.push(part);
-        }
-      }
-      if (secParts.length > 0) {
-        lines.push(
-          truncateToWidth(
-            `  ${th.fg("dim", "          ")}${th.fg("muted", secParts.join("  "))}`,
-            width
-          )
-        );
-      }
-    }
-  }
-
-  lines.push("");
-
-  // Determine visible rows for column pruning
-  const effectiveMax = maxRows <= 0 ? st.results.length : maxRows;
-  const startIdx = Math.max(0, st.results.length - effectiveMax);
-  const visibleRows = st.results.slice(startIdx);
-
-  // Only show secondary metric columns that have at least one value in visible rows
-  const secMetrics = st.secondaryMetrics.filter((sm) =>
-    visibleRows.some((r) => (r.metrics ?? {})[sm.name] !== undefined)
-  );
-
-  // Column definitions
-  const col = { idx: 3, commit: 8, primary: 11, status: 15 };
-  const secColWidth = 11;
-  const totalSecWidth = secMetrics.length * secColWidth;
-  const descW = Math.max(
-    10,
-    width - col.idx - col.commit - col.primary - totalSecWidth - col.status - 6
-  );
-
-  // Table header — primary metric name bolded with ★
-  let headerLine =
-    `  ${th.fg("muted", "#".padEnd(col.idx))}` +
-    `${th.fg("muted", "commit".padEnd(col.commit))}` +
-    `${th.fg("warning", th.bold(("★ " + st.metricName).slice(0, col.primary - 1).padEnd(col.primary)))}`;
-
-  for (const sm of secMetrics) {
-    headerLine += th.fg(
-      "muted",
-      sm.name.slice(0, secColWidth - 1).padEnd(secColWidth)
-    );
-  }
-
-  headerLine +=
-    `${th.fg("muted", "status".padEnd(col.status))}` +
-    `${th.fg("muted", "description")}`;
-
-  lines.push(truncateToWidth(headerLine, width));
-  lines.push(
-    truncateToWidth(
-      `  ${th.fg("borderMuted", "─".repeat(width - 4))}`,
-      width
-    )
-  );
-
-  // Baseline values for delta display (current segment only)
-  const baselinePrimary = findBaselineMetric(st.results, st.currentSegment);
-  const baselineSecondary = findBaselineSecondary(
-    st.results,
-    st.currentSegment,
-    st.secondaryMetrics
-  );
-
-  // Show max 6 recent runs, with a note about hidden earlier ones
-  if (startIdx > 0) {
-    lines.push(
-      truncateToWidth(
-        `  ${th.fg("dim", `… ${startIdx} earlier run${startIdx === 1 ? "" : "s"}`)}`,
-        width
-      )
-    );
-  }
-
-  for (let i = startIdx; i < st.results.length; i++) {
-    const r = st.results[i];
-    const isOld = r.segment !== st.currentSegment;
-    const isBaseline = !isOld && i === st.results.findIndex((x) => x.segment === st.currentSegment);
-
-    const color = isOld
-      ? "dim"
-      : r.status === "keep"
-        ? "success"
-        : r.status === "crash" || r.status === "checks_failed"
-          ? "error"
-          : "warning";
-
-    // Primary metric with color coding
-    const primaryStr = formatNum(r.metric, st.metricUnit);
-    let primaryColor: Parameters<typeof th.fg>[0] = isOld ? "dim" : "text";
-    if (!isOld) {
-      if (isBaseline) {
-        primaryColor = "muted"; // baseline row
-      } else if (
-        baselinePrimary !== null &&
-        r.status === "keep" &&
-        r.metric > 0
-      ) {
-        if (isBetter(r.metric, baselinePrimary, st.bestDirection)) {
-          primaryColor = "success";
-        } else if (r.metric !== baselinePrimary) {
-          primaryColor = "error";
-        }
-      }
-    }
-
-    const idxStr = th.fg("dim", String(i + 1).padEnd(col.idx));
-    const commitStr = isOld ? "(old)".padEnd(col.commit) : r.commit.padEnd(col.commit);
-
-    let rowLine =
-      `  ${idxStr}` +
-      `${th.fg(isOld ? "dim" : "accent", commitStr)}` +
-      `${th.fg(primaryColor, isOld ? primaryStr.padEnd(col.primary) : th.bold(primaryStr.padEnd(col.primary)))}`;
-
-    // Secondary metrics
-    const rowMetrics = r.metrics ?? {};
-    for (const sm of secMetrics) {
-      const val = rowMetrics[sm.name];
-      if (val !== undefined) {
-        const secStr = formatNum(val, sm.unit);
-        let secColor: Parameters<typeof th.fg>[0] = "dim";
-        if (!isOld) {
-          const bv = baselineSecondary[sm.name];
-          if (isBaseline) {
-            secColor = "muted"; // baseline row
-          } else if (bv !== undefined && bv !== 0) {
-            secColor = val <= bv ? "success" : "error";
-          }
-        }
-        rowLine += th.fg(secColor, secStr.padEnd(secColWidth));
-      } else {
-        rowLine += th.fg("dim", "—".padEnd(secColWidth));
-      }
-    }
-
-    rowLine +=
-      `${th.fg(color, r.status.padEnd(col.status))}` +
-      `${th.fg("muted", r.description.slice(0, descW))}`;
-
-    lines.push(truncateToWidth(rowLine, width));
-  }
-
-  return lines;
-}
-
-// ---------------------------------------------------------------------------
-// Extension
-// ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
   let dashboardExpanded = false;
@@ -708,108 +336,124 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     }
 
     if (dashboardExpanded) {
-      // Expanded: full dashboard table rendered as widget
-      ctx.ui.setWidget("autoresearch", (_tui, theme) => {
-        const width = process.stdout.columns || 120;
-        const lines: string[] = [];
+      ctx.ui.setWidget("autoresearch", (tui, theme) => ({
+        render(width: number): string[] {
+          const safeWidth = Math.max(40, width || getTuiSize(tui).width);
+          const tableHint = "ctrl+x collapse • ctrl+shift+x fullscreen";
+          const labelRaw = `🔬 autoresearch${state.name ? `: ${state.name}` : ""}`;
+          const maxLabelWidth = Math.max(12, safeWidth - 3 - 2);
+          const label = truncateDisplayText(labelRaw, maxLabelWidth);
+          const fillLen = Math.max(0, safeWidth - 3 - 1 - visibleWidth(label) - 1);
 
-        const hintText = " ctrl+x collapse • ctrl+shift+x fullscreen ";
-        const labelPrefix = "🔬 autoresearch";
-        const nameStr = state.name ? `: ${state.name}` : "";
-        // 3 leading dashes + space + label + space + fill + hint
-        const maxLabelLen = width - 3 - 2 - hintText.length - 1;
-        let label = labelPrefix + nameStr;
-        if (label.length > maxLabelLen) {
-          label = label.slice(0, maxLabelLen - 1) + "…";
-        }
-        const fillLen = Math.max(0, width - 3 - 1 - label.length - 1 - hintText.length);
-        lines.push(
-          truncateToWidth(
-            theme.fg("borderMuted", "───") +
-              theme.fg("accent", " " + label + " ") +
-              theme.fg("borderMuted", "─".repeat(fillLen)) +
-              theme.fg("dim", hintText),
-            width
-          )
-        );
-
-        lines.push(...renderDashboardLines(state, width, theme));
-
-        return new Text(lines.join("\n"), 0, 0);
-      });
+          const rows = safeWidth < 95 ? 4 : 6;
+          const lines: string[] = [
+            truncateToWidth(
+              theme.fg("borderMuted", "───") +
+                theme.fg("accent", ` ${label} `) +
+                theme.fg("borderMuted", "─".repeat(fillLen)),
+              safeWidth
+            ),
+            ...renderDashboardLines(state, safeWidth, theme, rows, tableHint),
+          ];
+          return lines;
+        },
+        invalidate(): void {},
+      }));
     } else {
-      // Collapsed: compact one-liner — compute everything inside render
-      ctx.ui.setWidget("autoresearch", (_tui, theme) => {
-        const cur = currentResults(state.results, state.currentSegment);
-        const kept = cur.filter((r) => r.status === "keep").length;
-        const crashed = cur.filter((r) => r.status === "crash").length;
-        const checksFailed = cur.filter((r) => r.status === "checks_failed").length;
-        const baseline = state.bestMetric;
-        const baselineSec = findBaselineSecondary(state.results, state.currentSegment, state.secondaryMetrics);
+      ctx.ui.setWidget("autoresearch", (tui, theme) => ({
+        render(width: number): string[] {
+          const safeWidth = Math.max(30, width || getTuiSize(tui).width);
+          const cur = currentResults(state.results, state.currentSegment);
+          const kept = cur.filter((r) => r.status === "keep").length;
+          const crashed = cur.filter((r) => r.status === "crash").length;
+          const checksFailed = cur.filter((r) => r.status === "checks_failed").length;
+          const baseline = state.bestMetric;
+          const baselineSec = findBaselineSecondary(
+            state.results,
+            state.currentSegment,
+            state.secondaryMetrics
+          );
 
-        // Find best kept primary metric, its secondary values, and run number
-        let bestPrimary: number | null = null;
-        let bestSec: Record<string, number> = {};
-        let bestRunNum = 0;
-        for (let i = state.results.length - 1; i >= 0; i--) {
-          const r = state.results[i];
-          if (r.segment !== state.currentSegment) continue;
-          if (r.status === "keep" && r.metric > 0) {
-            if (bestPrimary === null || isBetter(r.metric, bestPrimary, state.bestDirection)) {
-              bestPrimary = r.metric;
-              bestSec = r.metrics ?? {};
-              bestRunNum = i + 1;
+          let bestPrimary: number | null = null;
+          let bestSec: Record<string, number> = {};
+          let bestRunNum = 0;
+          for (let i = state.results.length - 1; i >= 0; i--) {
+            const r = state.results[i];
+            if (r.segment !== state.currentSegment) continue;
+            if (r.status === "keep" && r.metric > 0) {
+              if (bestPrimary === null || isBetter(r.metric, bestPrimary, state.bestDirection)) {
+                bestPrimary = r.metric;
+                bestSec = r.metrics ?? {};
+                bestRunNum = i + 1;
+              }
             }
           }
-        }
 
-        const displayVal = bestPrimary ?? baseline;
-        const parts = [
-          theme.fg("accent", "🔬"),
-          theme.fg("muted", ` ${state.results.length} runs`),
-          theme.fg("success", ` ${kept} kept`),
-          crashed > 0 ? theme.fg("error", ` ${crashed}💥`) : "",
-          checksFailed > 0 ? theme.fg("error", ` ${checksFailed}⚠`) : "",
-          theme.fg("dim", " │ "),
-          theme.fg("warning", theme.bold(`★ ${state.metricName}: ${formatNum(displayVal, state.metricUnit)}`)),
-          bestRunNum > 0 ? theme.fg("dim", ` #${bestRunNum}`) : "",
-        ];
+          const displayVal = bestPrimary ?? baseline;
+          const essential: string[] = [
+            theme.fg("accent", "🔬"),
+            theme.fg("muted", ` ${state.results.length} runs`),
+            theme.fg("success", ` ${kept} kept`),
+            theme.fg("dim", " │ "),
+            theme.fg(
+              "warning",
+              theme.bold(`★ ${state.metricName}: ${formatNum(displayVal, state.metricUnit)}`)
+            ),
+            bestRunNum > 0 ? theme.fg("dim", ` #${bestRunNum}`) : "",
+          ];
 
-        // Show delta % vs baseline for primary
-        if (baseline !== null && bestPrimary !== null && baseline !== 0 && bestPrimary !== baseline) {
-          const pct = ((bestPrimary - baseline) / baseline) * 100;
-          const sign = pct > 0 ? "+" : "";
-          const deltaColor = isBetter(bestPrimary, baseline, state.bestDirection) ? "success" : "error";
-          parts.push(theme.fg(deltaColor, ` (${sign}${pct.toFixed(1)}%)`));
-        }
+          const optional: string[] = [];
+          if (crashed > 0) optional.push(theme.fg("error", ` ${crashed}💥`));
+          if (checksFailed > 0) optional.push(theme.fg("error", ` ${checksFailed}⚠`));
 
-        // Show secondary metrics with delta %
-        if (state.secondaryMetrics.length > 0) {
+          if (
+            baseline !== null &&
+            bestPrimary !== null &&
+            baseline !== 0 &&
+            bestPrimary !== baseline
+          ) {
+            const pct = ((bestPrimary - baseline) / baseline) * 100;
+            const sign = pct > 0 ? "+" : "";
+            const deltaColor = isBetter(bestPrimary, baseline, state.bestDirection)
+              ? "success"
+              : "error";
+            optional.push(theme.fg(deltaColor, ` (${sign}${pct.toFixed(1)}%)`));
+          }
+
           for (const sm of state.secondaryMetrics) {
             const val = bestSec[sm.name];
             const bv = baselineSec[sm.name];
-            if (val !== undefined) {
-              parts.push(theme.fg("dim", "  "));
-              let secText = `${sm.name}: ${formatNum(val, sm.unit)}`;
-              if (bv !== undefined && bv !== 0 && val !== bv) {
-                const p = ((val - bv) / bv) * 100;
-                const s = p > 0 ? "+" : "";
-                const c = val <= bv ? "success" : "error";
-                secText += theme.fg(c, ` ${s}${p.toFixed(1)}%`);
-              }
-              parts.push(theme.fg("muted", secText));
+            if (val === undefined) continue;
+            let secText = `${sm.name}: ${formatNum(val, sm.unit)}`;
+            if (bv !== undefined && bv !== 0 && val !== bv) {
+              const p = ((val - bv) / bv) * 100;
+              const s = p > 0 ? "+" : "";
+              const c = val <= bv ? "success" : "error";
+              secText += theme.fg(c, ` ${s}${p.toFixed(1)}%`);
             }
+            optional.push(theme.fg("dim", "  "));
+            optional.push(theme.fg("muted", secText));
+            break; // only first secondary metric in collapsed mode
           }
-        }
 
-        if (state.name) {
-          parts.push(theme.fg("dim", ` │ ${state.name}`));
-        }
+          if (state.name) optional.push(theme.fg("dim", ` │ ${state.name}`));
 
-        parts.push(theme.fg("dim", "  (ctrl+x expand • ctrl+shift+x fullscreen)"));
+          const leftLine = joinPartsToWidth([...essential, ...optional], safeWidth);
+          const line = appendRightAlignedAdaptiveHint(
+            leftLine,
+            safeWidth,
+            theme,
+            [
+              "ctrl+x expand • ctrl+shift+x fullscreen",
+              "ctrl+x expand • full: c-s-x",
+              "ctrl+x • c-s-x",
+            ]
+          );
 
-        return new Text(parts.join(""), 0, 0);
-      });
+          return [line];
+        },
+        invalidate(): void {},
+      }));
     }
   };
 
@@ -1554,6 +1198,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       await ctx.ui.custom<void>(
         (tui, theme, _kb, done) => {
           let scrollOffset = 0;
+          let lastViewportRows = 8;
+          let lastTotalRows = 0;
+
           // Store tui ref so run_experiment can trigger re-renders
           overlayTui = tui;
 
@@ -1570,75 +1217,71 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
             return m > 0 ? `${m}m${String(sec).padStart(2, "0")}s` : `${sec}s`;
           }
 
+          function buildOverlayContent(renderWidth: number): string[] {
+            const content = renderDashboardLines(state, renderWidth, theme, 0);
+            if (runningExperiment) {
+              const elapsed = formatElapsed(Date.now() - runningExperiment.startedAt);
+              const frame = SPINNER[spinnerFrame % SPINNER.length];
+              const nextIdx = state.results.length + 1;
+              content.push(
+                truncateToWidth(
+                  `  ${theme.fg("dim", String(nextIdx).padEnd(3))}` +
+                    theme.fg("warning", `${frame} running… ${elapsed}`),
+                  renderWidth
+                )
+              );
+            }
+            return content;
+          }
+
           return {
             render(width: number): string[] {
-              const termH = process.stdout.rows || 40;
-              // Content gets the full width — no box borders
-              const content = renderDashboardLines(state, width, theme, 0);
-
-              // Add running experiment as next row in the list
-              if (runningExperiment) {
-                const elapsed = formatElapsed(Date.now() - runningExperiment.startedAt);
-                const frame = SPINNER[spinnerFrame % SPINNER.length];
-                const nextIdx = state.results.length + 1;
-                content.push(
-                  truncateToWidth(
-                    `  ${theme.fg("dim", String(nextIdx).padEnd(3))}` +
-                    theme.fg("warning", `${frame} running… ${elapsed}`),
-                    width
-                  )
-                );
-              }
+              const safeWidth = Math.max(40, width || getTuiSize(tui).width);
+              const { height } = getTuiSize(tui);
+              const viewportRows = Math.max(4, height - 4); // header + footer
+              const content = buildOverlayContent(safeWidth);
 
               const totalRows = content.length;
-              const viewportRows = Math.max(4, termH - 4); // leave room for header/footer
-
-              // Clamp scroll
               const maxScroll = Math.max(0, totalRows - viewportRows);
-              if (scrollOffset > maxScroll) scrollOffset = maxScroll;
-              if (scrollOffset < 0) scrollOffset = 0;
+              scrollOffset = clamp(scrollOffset, 0, maxScroll);
+              lastViewportRows = viewportRows;
+              lastTotalRows = totalRows;
 
               const out: string[] = [];
 
-              // Header line
-              const titlePrefix = "🔬 autoresearch";
-              const nameStr = state.name ? `: ${state.name}` : "";
-              const maxTitleLen = width - 6;
-              let title = titlePrefix + nameStr;
-              if (title.length > maxTitleLen) {
-                title = title.slice(0, maxTitleLen - 1) + "…";
-              }
-              const fillLen = Math.max(0, width - 3 - 1 - title.length - 1);
+              const titleRaw = `🔬 autoresearch${state.name ? `: ${state.name}` : ""}`;
+              const title = truncateDisplayText(titleRaw, Math.max(8, safeWidth - 6));
+              const fillLen = Math.max(0, safeWidth - 3 - 1 - visibleWidth(title) - 1);
               out.push(
                 truncateToWidth(
                   theme.fg("borderMuted", "───") +
-                  theme.fg("accent", " " + title + " ") +
-                  theme.fg("borderMuted", "─".repeat(fillLen)),
-                  width
+                    theme.fg("accent", ` ${title} `) +
+                    theme.fg("borderMuted", "─".repeat(fillLen)),
+                  safeWidth
                 )
               );
 
-              // Content rows
               const visible = content.slice(scrollOffset, scrollOffset + viewportRows);
               for (const line of visible) {
-                out.push(truncateToWidth(line, width));
+                out.push(truncateToWidth(line, safeWidth));
               }
-              // Fill remaining viewport
+
               for (let i = visible.length; i < viewportRows; i++) {
                 out.push("");
               }
 
-              // Footer line
               const scrollInfo = totalRows > viewportRows
                 ? ` ${scrollOffset + 1}-${Math.min(scrollOffset + viewportRows, totalRows)}/${totalRows}`
                 : "";
-              const helpText = ` ↑↓/j/k scroll • esc close${scrollInfo} `;
-              const footFill = Math.max(0, width - helpText.length);
+              const helpText = safeWidth >= 85
+                ? ` ↑↓/j/k scroll • pgup/pgdn • g/G • esc close${scrollInfo} `
+                : ` j/k scroll • esc close${scrollInfo} `;
+              const footFill = Math.max(0, safeWidth - visibleWidth(helpText));
               out.push(
                 truncateToWidth(
                   theme.fg("borderMuted", "─".repeat(footFill)) +
-                  theme.fg("dim", helpText),
-                  width
+                    theme.fg("dim", helpText),
+                  safeWidth
                 )
               );
 
@@ -1646,10 +1289,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
             },
 
             handleInput(data: string): void {
-              const termH = process.stdout.rows || 40;
-              const viewportRows = Math.max(4, termH - 4);
-              const totalRows = state.results.length + (runningExperiment ? 1 : 0) + 15; // rough estimate
-              const maxScroll = Math.max(0, totalRows - viewportRows);
+              const maxScroll = Math.max(0, lastTotalRows - lastViewportRows);
 
               if (matchesKey(data, "escape") || data === "q") {
                 done(undefined);
@@ -1660,9 +1300,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               } else if (matchesKey(data, "down") || data === "j") {
                 scrollOffset = Math.min(maxScroll, scrollOffset + 1);
               } else if (matchesKey(data, "pageUp") || data === "u") {
-                scrollOffset = Math.max(0, scrollOffset - viewportRows);
+                scrollOffset = Math.max(0, scrollOffset - lastViewportRows);
               } else if (matchesKey(data, "pageDown") || data === "d") {
-                scrollOffset = Math.min(maxScroll, scrollOffset + viewportRows);
+                scrollOffset = Math.min(maxScroll, scrollOffset + lastViewportRows);
               } else if (data === "g") {
                 scrollOffset = 0;
               } else if (data === "G") {

--- a/extensions/pi-autoresearch/types.ts
+++ b/extensions/pi-autoresearch/types.ts
@@ -1,0 +1,52 @@
+export interface ExperimentResult {
+  commit: string;
+  metric: number;
+  /** Additional tracked metrics: { name: value } */
+  metrics: Record<string, number>;
+  status: "keep" | "discard" | "crash" | "checks_failed";
+  description: string;
+  timestamp: number;
+  /** Segment index — increments on each config header. Current segment = highest. */
+  segment: number;
+}
+
+export interface MetricDef {
+  name: string;
+  unit: string;
+}
+
+export interface ExperimentState {
+  results: ExperimentResult[];
+  /** Baseline primary metric (from first experiment in current segment) */
+  bestMetric: number | null;
+  bestDirection: "lower" | "higher";
+  metricName: string;
+  metricUnit: string;
+  /** Definitions for secondary metrics (order preserved) */
+  secondaryMetrics: MetricDef[];
+  name: string | null;
+  /** Current segment index (incremented on each init_experiment) */
+  currentSegment: number;
+  /** Maximum number of experiments before auto-stopping. null = unlimited. */
+  maxExperiments: number | null;
+}
+
+export interface RunDetails {
+  command: string;
+  exitCode: number | null;
+  durationSeconds: number;
+  passed: boolean;
+  crashed: boolean;
+  timedOut: boolean;
+  tailOutput: string;
+  /** null = checks not run (no file or benchmark failed), true/false = ran */
+  checksPass: boolean | null;
+  checksTimedOut: boolean;
+  checksOutput: string;
+  checksDuration: number;
+}
+
+export interface LogDetails {
+  experiment: ExperimentResult;
+  state: ExperimentState;
+}


### PR DESCRIPTION
Hello!

First off, thanks for this extension, it's been really useful with some experiments and evals i've been running on some projects :)

While using it this weekend, I noticed a few issues / annoyance around the ui, so I took a pass at updating / refactoring the UI. This is quite a massive PR so I'll open it as draft and if there are some items you agree with I can open smaller PRs with those.

Here's the implementation session: https://pi.dev/session/#16df8742fe4c216142f780a9cb4e756f

Below are some screenshots of the before/after, mostly no changes except when resizing the window and a summary of gpt-5.3-codex.

Again, no worries if this is not a change you want in the code!

------

<details><summary>Default view</summary>
<p>
Before: <img width="2788" height="1668" alt="Screenshot 2026-03-16 at 12 27 01 PM@2x" src="https://github.com/user-attachments/assets/f4290835-ef07-4d23-ac2c-9c431e8d8f13" /> 

After: <img width="2788" height="1668" alt="Screenshot 2026-03-16 at 12 27 26 PM@2x" src="https://github.com/user-attachments/assets/c101a2cd-c1d6-4d78-8557-19456c420f20" />
</p>
</details> 

<details><summary>Expanded</summary>
<p>
Before: <img width="2788" height="1668" alt="Screenshot 2026-03-16 at 12 27 06 PM@2x" src="https://github.com/user-attachments/assets/1ac42f18-a4d7-4920-b69c-fffb60b0126b" />
After: <img width="2788" height="1668" alt="Screenshot 2026-03-16 at 12 27 35 PM@2x" src="https://github.com/user-attachments/assets/200d00d9-3117-40ac-acbb-bcfd7b0cfb7e" />
</p>
</details> 

<details><summary>Expanded after resize to a smaller window</summary>
<p>
<img width="2276" height="1380" alt="Screenshot 2026-03-16 at 12 27 13 PM@2x" src="https://github.com/user-attachments/assets/990a6936-f86b-4821-966e-8e213ad73469" />

<img width="2276" height="1380" alt="Screenshot 2026-03-16 at 12 27 43 PM@2x" src="https://github.com/user-attachments/assets/96102635-b125-44ab-98b8-dfdef1b627b8" /

</p>
</details> 

<details><summary>Expanded after resize to a larger window</summary>

<img width="3300" height="1956" alt="Screenshot 2026-03-16 at 12 27 22 PM@2x" src="https://github.com/user-attachments/assets/96b1f5e1-98c3-44ef-adc9-f6b47a7e73a1" />
<img width="3300" height="1956" alt="Screenshot 2026-03-16 at 12 27 48 PM@2x" src="https://github.com/user-attachments/assets/e3713f33-c003-41a4-939a-cde53fecd5a2" />

<p>



</p>
</details> 

<details><summary>Summary by gpt-5.3-codex</summary>
<p>

## Changes made

### Refactor and extraction for maintainability

- **Extracted shared types** from `extensions/pi-autoresearch/index.ts` into:
  - `extensions/pi-autoresearch/types.ts`
  - Includes:
    - `ExperimentResult`
    - `MetricDef`
    - `ExperimentState` (with `maxExperiments` support)
    - `RunDetails`
    - `LogDetails`

- **Extracted dashboard/rendering helpers** into:
  - `extensions/pi-autoresearch/dashboard.ts`
  - Includes:
    - formatting + comparison helpers (`formatNum`, `isBetter`)
    - segment/baseline helpers (`currentResults`, `findBaselineMetric`, `findBaselineSecondary`)
    - sizing/truncation helpers (`clamp`, `getTuiSize`, `truncateDisplayText`, `joinPartsToWidth`)
    - expanded dashboard table renderer (`renderDashboardLines`)

- Updated `extensions/pi-autoresearch/index.ts` to import and use the shared modules instead of inline implementations.

---

### Responsive layout and resize behavior improvements

- Switched expanded and fullscreen rendering to width/height-driven behavior (live TUI dimensions), avoiding stale startup column assumptions.
- Added/used helpers to safely clamp dimensions, truncate content, and compose width-bounded lines.
- Updated expanded dashboard table to degrade columns in this priority order at narrow widths:
  1. hide secondary metric columns (last → first),
  2. hide `#` run index column,
  3. hide description column.
- Ensured minimum useful columns remain visible at very small widths (commit + primary metric + status).
- Added hidden-column notice when secondary metric columns are pruned.
- Description truncation now uses `truncateToWidth(...)` (ellipsis-aware behavior).

---

### Header and shortcut hint UX updates

- Moved expanded shortcuts hint to the **table header row** (instead of the decorative top title border).
- Implemented right-aligned hint rendering with adaptive behavior:
  - right-aligned when space exists,
  - auto-shortens through candidate forms on narrower widths,
  - hides when no candidate fits.
- Reintroduced shortcut hint in **collapsed widget** with the same behavior:
  - right-aligned,
  - adaptive shortening,
  - hidden when insufficient space.
- Extracted this as a reusable shared helper in `dashboard.ts`:
  - `appendRightAlignedAdaptiveHint(...)`
- Reused that helper in:
  - expanded table header hint (`renderDashboardLines`)
  - collapsed widget hint (`index.ts`)

---

### Fullscreen overlay improvements

- Fullscreen overlay now:
  - computes viewport from live width/height,
  - clamps scroll bounds to actual rendered content length,
  - adapts footer/help text by width,
  - keeps spinner and running-experiment updates responsive.

---

### Upstream integration and rebase work

- Fetched and rebased branch on top of latest `upstream/main`.
- Resolved `index.ts` conflicts by preserving both:
  - upstream additions (`autoresearch.config.json` handling, `workingDir`, `maxIterations/maxExperiments`, auto-revert flow),
  - local UI/refactor improvements (shared files + responsive/hint behavior).
- Final refactor commit created:
  - `refactor: extract dashboard layout helpers and shared types`

</p>
</details> 