### PR TITLE
fix: avoid shell injection in git commit message

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1388,7 +1388,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           const commitMsg = `${params.description}\n\nResult: ${trailerJson}`;
 
           const execOpts = { cwd: workDir, timeout: 10000 };
-          await pi.exec("git", ["add", "-A"], execOpts);
+          const addResult = await pi.exec("git", ["add", "-A"], execOpts);
+          if (addResult.code !== 0) {
+            const addErr = (addResult.stdout + addResult.stderr).trim();
+            throw new Error(`git add failed (exit ${addResult.code}): ${addErr.slice(0, 200)}`);
+          }
 
           const diffResult = await pi.exec("git", ["diff", "--cached", "--quiet"], execOpts);
           if (diffResult.code === 0) {


### PR DESCRIPTION
## Summary
- The `log_experiment` git commit used `bash -c` with `JSON.stringify(commitMsg)`, which allows shell metacharacter injection in experiment descriptions (e.g. `$(rm -rf /)` would be interpreted by bash)
- Split the single `bash -c "git add && git diff && git commit"` pipeline into three separate `pi.exec("git", [...])` calls, so the commit message is passed as a direct argument and never interpreted by a shell

## Test plan
- [ ] Run an experiment with shell metacharacters in the description (e.g. `$(echo injected)`, backticks, `&&`)
- [ ] Verify the commit message contains the literal metacharacters, not their evaluated output
- [ ] Verify normal experiments still commit correctly
- [ ] Verify "nothing to commit" detection still works