### PR TITLE
fix: use endsWith for secondary metric unit detection

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -648,7 +648,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
             for (const name of Object.keys(entry.metrics ?? {})) {
               if (!state.secondaryMetrics.find((m) => m.name === name)) {
                 let unit = "";
-                if (name.endsWith("_µs") || name.endsWith("µs")) unit = "µs";
+                if (name.endsWith("µs")) unit = "µs";
                 else if (name.endsWith("_ms")) unit = "ms";
                 else if (name.endsWith("_s") || name.endsWith("_sec")) unit = "s";
                 else if (name.endsWith("_kb")) unit = "kb";
@@ -1328,7 +1328,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       for (const name of Object.keys(secondaryMetrics)) {
         if (!state.secondaryMetrics.find((m) => m.name === name)) {
           let unit = "";
-          if (name.endsWith("_µs") || name.endsWith("µs")) unit = "µs";
+          if (name.endsWith("µs")) unit = "µs";
           else if (name.endsWith("_ms")) unit = "ms";
           else if (name.endsWith("_s") || name.endsWith("_sec")) unit = "s";
           else if (name.endsWith("_kb")) unit = "kb";


### PR DESCRIPTION
## Summary
- Replace `name.includes("ms")` with `name.endsWith("_ms")` in secondary metric unit detection to prevent false positives (e.g. "submissions" was matching "ms")
- Same fix applied to both occurrences (JSONL reload path and log_experiment path)
- Also tighten `includes("µs")` -> `endsWith("µs")` and `includes("sec")` -> `endsWith("_sec")`
- Add `_kb` and `_mb` unit suffix detection

## Test plan
- [ ] Log an experiment with a secondary metric named "submissions" — verify it does NOT get unit "ms"
- [ ] Log an experiment with a secondary metric named "latency_ms" — verify it gets unit "ms"
- [ ] Verify `_kb` and `_mb` suffixed metrics are detected correctly