### PR TITLE
run_experiment: streaming output with timer, truncateTail, autoresearch.sh guard

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -239,11 +239,36 @@ function killTree(pid: number): void {
   }
 }
 
-/** Check if a command string is running autoresearch.sh (or ./autoresearch.sh) */
+/**
+ * Check if a command's primary purpose is running autoresearch.sh.
+ *
+ * Strategy: strip common harmless prefixes (env vars, env/time/nice wrappers)
+ * then check that the core command is autoresearch.sh invoked via a known
+ * pattern. Rejects chaining tricks like "evil.py; autoresearch.sh" because
+ * we require autoresearch.sh to be the *first* real command.
+ */
 function isAutoresearchShCommand(command: string): boolean {
-  const trimmed = command.trim();
-  // Match: autoresearch.sh as first token, or preceded by bash/sh/source/./ 
-  return /(?:^|&&|;|\|)\s*(?:bash\s+|sh\s+|source\s+|\.\/)?autoresearch\.sh(?:\s|$)/.test(trimmed);
+  let cmd = command.trim();
+
+  // Strip leading env variable assignments: FOO=bar BAZ="qux" ...
+  cmd = cmd.replace(/^(?:\w+=\S*\s+)+/, "");
+
+  // Strip known harmless command wrappers (env, time, nice, nohup) repeatedly
+  // Allows flags and their numeric values: e.g. "nice -n 10 time env ..."
+  let prev: string;
+  do {
+    prev = cmd;
+    cmd = cmd.replace(/^(?:env|time|nice|nohup)(?:\s+-\S+(?:\s+\d+)?)*\s+/, "");
+  } while (cmd !== prev);
+
+  // Now the core command must be autoresearch.sh via a known invocation:
+  //   autoresearch.sh
+  //   ./autoresearch.sh
+  //   /path/to/autoresearch.sh
+  //   bash [-flags] autoresearch.sh
+  //   bash [-flags] ./autoresearch.sh
+  //   bash [-flags] /path/to/autoresearch.sh
+  return /^(?:(?:bash|sh|source)\s+(?:-\w+\s+)*)?(?:\.\/|\/[\w/.-]*\/)?autoresearch\.sh(?:\s|$)/.test(cmd);
 }
 
 function isBetter(
@@ -1252,11 +1277,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       // Spawn the process directly (like the bash tool) for streaming output
       const getTempFile = createTempFileAllocator();
-      const { exitCode, killed: timedOut, output, tempFilePath: streamTempFile } = await new Promise<{
+      const { exitCode, killed: timedOut, output, tempFilePath: streamTempFile, actualTotalBytes } = await new Promise<{
         exitCode: number | null;
         killed: boolean;
         output: string;
         tempFilePath: string | undefined;
+        actualTotalBytes: number;
       }>((resolve, reject) => {
         let processTimedOut = false;
 
@@ -1397,6 +1423,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
             killed: processTimedOut,
             output: fullBuffer.toString("utf-8"),
             tempFilePath,
+            actualTotalBytes: totalBytes,
           });
         });
       }).finally(() => {
@@ -1442,9 +1469,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       // Reuse streaming temp file if it exists, otherwise create one for large output
       let fullOutputPath: string | undefined = streamTempFile;
-      const totalBytes = Buffer.byteLength(output, "utf-8");
       const totalLines = output.split("\n").length;
-      if (!fullOutputPath && (totalBytes > EXPERIMENT_MAX_BYTES || totalLines > EXPERIMENT_MAX_LINES)) {
+      if (!fullOutputPath && (actualTotalBytes > EXPERIMENT_MAX_BYTES || totalLines > EXPERIMENT_MAX_LINES)) {
         fullOutputPath = getTempFile();
         fs.writeFileSync(fullOutputPath, output);
       }


### PR DESCRIPTION
Improvements to `run_experiment` tool and dashboard rendering.

### Streaming output with live timer
- Replaced `pi.exec()` with raw `spawn()` — just like the built-in bash tool
- Streams output via `onUpdate` every second with a rolling buffer
- Timer counts up in `Xm XXs` format (e.g. `1m 03s`, `42s`), updating every second
- Rolling buffer keeps last 2× `DEFAULT_MAX_BYTES` of output for tail truncation
- Full output written to temp file when it exceeds threshold
- Always shows 5-line output preview (collapsed) or 20 lines (expanded) during streaming

### `truncateTail()` for output (matching bash tool)
- Uses pi's `truncateTail()` with tight limits for LLM context: 10 lines / 4KB
- Full output saved to temp file when truncated, path included in response
- Actionable truncation notices with line ranges and temp file paths
- TUI display uses wider limits (`DEFAULT_MAX_LINES`/`DEFAULT_MAX_BYTES`) for expanded view
- Completed results always show 5-line tail preview (like bash tool's `BASH_PREVIEW_LINES`)

### `autoresearch.sh` guard
- If `autoresearch.sh` exists in cwd, refuse to run any other command
- Clear error message directing agent to use `autoresearch.sh`
- Regex matches: `bash autoresearch.sh`, `./autoresearch.sh`, `sh autoresearch.sh`, etc.

### Dashboard rendering fixes
- **Color bleed**: Secondary metric deltas (e.g. `+0.4%`, `-6.9%`) no longer lose their color after the first one. Each value and delta are separate `th.fg()` calls instead of nesting colored text inside `th.fg('muted', ...)`.
- **Baseline readability**: Changed from `dim` to `text` color for baseline summary line and baseline table rows.
- **Secondary metrics wrapping**: Progress summary flow-wraps metrics onto multiple indented lines when they don't fit on one line. All metrics are always visible.
- **25% minimum for description**: Table guarantees at least 25% of terminal width for the description column. Secondary metric columns are dropped from the right when space is tight, rather than squeezing description to nothing.