### PR TITLE
feat: Actionable Side Information (ASI) — structured annotations per experiment

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -39,6 +39,14 @@ const EXPERIMENT_MAX_BYTES = 4 * 1024; // 4KB
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Actionable Side Information (ASI) — free-form diagnostics per experiment run.
+ * The agent decides what to record. Any key/value pair is valid.
+ */
+interface ASI {
+  [key: string]: unknown;
+}
+
 interface ExperimentResult {
   commit: string;
   metric: number;
@@ -51,6 +59,8 @@ interface ExperimentResult {
   segment: number;
   /** Session-level confidence score at the time this result was logged. null if insufficient data. */
   confidence: number | null;
+  /** Actionable Side Information — structured diagnostics for this run */
+  asi?: ASI;
 }
 
 interface MetricDef {
@@ -96,6 +106,7 @@ interface RunDetails {
   /** Name of the primary metric (for display) */
   metricName: string;
   metricUnit: string;
+
 }
 
 interface LogDetails {
@@ -181,6 +192,12 @@ const LogParams = Type.Object({
     Type.Boolean({
       description:
         "Set to true to allow adding a new secondary metric that wasn't tracked before. Only use for metrics that have proven very valuable to watch.",
+    })
+  ),
+  asi: Type.Optional(
+    Type.Record(Type.String(), Type.Unknown(), {
+      description:
+        'Actionable Side Information — structured diagnostics for this run. Free-form key/value pairs. Parsed ASI from run_experiment output is merged automatically; use this to add or override fields.',
     })
   ),
 });
@@ -926,6 +943,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               timestamp: entry.timestamp ?? 0,
               segment,
               confidence: entry.confidence ?? null,
+              asi: entry.asi ?? undefined,
             });
 
             // Register secondary metrics
@@ -1352,6 +1370,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "Use run_experiment instead of bash when running experiment commands — it handles timing and output capture automatically.",
       "After run_experiment, always call log_experiment to record the result.",
       "If the benchmark script outputs structured METRIC lines (e.g. 'METRIC total_µs=15200'), run_experiment will parse them automatically and suggest exact values for log_experiment. Use these parsed values directly instead of extracting them manually from the output.",
+
     ],
     parameters: RunParams,
 
@@ -1867,6 +1886,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "Use status 'keep' if the PRIMARY metric improved. 'discard' if worse or unchanged. 'crash' if it failed. Secondary metrics are for monitoring — they almost never affect keep/discard. Only discard a primary improvement if a secondary metric degraded catastrophically, and explain why in the description.",
       "log_experiment reports a confidence score after 3+ runs (best improvement as a multiple of the noise floor). ≥2.0× = likely real, <1.0× = within noise. If confidence is below 1.0×, consider re-running the same experiment to confirm before keeping. The score is advisory — it never auto-discards.",
       "If you discover complex but promising optimizations you won't pursue immediately, append them as bullet points to autoresearch.ideas.md. Don't let good ideas get lost.",
+      "Always include the asi parameter. At minimum: {\"hypothesis\": \"what you tried\"}. On discard/crash, also include rollback_reason and next_action_hint. Add any other key/value pairs that capture what you learned — dead ends, surprising findings, error details, bottlenecks. This is the only structured memory that survives reverts.",
     ],
     parameters: LogParams,
 
@@ -1926,6 +1946,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         }
       }
 
+      // ASI: agent-supplied free-form diagnostics
+      const mergedASI = (params.asi && Object.keys(params.asi).length > 0)
+        ? params.asi as ASI
+        : undefined;
+
       const experiment: ExperimentResult = {
         commit: params.commit.slice(0, 7),
         metric: params.metric,
@@ -1935,6 +1960,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         timestamp: Date.now(),
         segment: state.currentSegment,
         confidence: null,
+        asi: mergedASI,
       };
 
       state.results.push(experiment);
@@ -1992,6 +2018,18 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           parts.push(part);
         }
         text += `\nSecondary: ${parts.join("  ")}`;
+      }
+
+      // Show ASI summary
+      if (mergedASI) {
+        const asiParts: string[] = [];
+        for (const [k, v] of Object.entries(mergedASI)) {
+          const s = typeof v === "string" ? v : JSON.stringify(v);
+          asiParts.push(`${k}: ${s.length > 80 ? s.slice(0, 77) + "…" : s}`);
+        }
+        if (asiParts.length > 0) {
+          text += `\n📋 ASI: ${asiParts.join(" | ")}`;
+        }
       }
 
       // Show confidence score
@@ -2061,10 +2099,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       // Persist to autoresearch.jsonl (always, regardless of status)
       try {
         const jsonlPath = path.join(workDir, "autoresearch.jsonl");
-        fs.appendFileSync(jsonlPath, JSON.stringify({
+        const jsonlEntry: Record<string, unknown> = {
           run: state.results.length,
           ...experiment,
-        }) + "\n");
+        };
+        // Only write asi if present (keep lines compact when no ASI)
+        if (!mergedASI) delete jsonlEntry.asi;
+        fs.appendFileSync(jsonlPath, JSON.stringify(jsonlEntry) + "\n");
       } catch (e) {
         text += `\n⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}`;
       }
@@ -2086,6 +2127,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       runtime.runningExperiment = null;
       runtime.lastRunChecks = null;
       runtime.lastRunDuration = null;
+
 
       // Check if max experiments limit reached
       const limitReached = state.maxExperiments !== null && segmentCount >= state.maxExperiments;

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -32,8 +32,8 @@ This is the heart of the session. A fresh agent with no context should be able t
 <Specific description of what we're optimizing and the workload.>
 
 ## Metrics
-- **Primary**: <name> (<unit>, lower/higher is better)
-- **Secondary**: <name>, <name>, ...
+- **Primary**: <name> (<unit>, lower/higher is better) — the optimization target
+- **Secondary**: <name>, <name>, ... — independent tradeoff monitors
 
 ## How to Run
 `./autoresearch.sh` — outputs `METRIC name=number` lines.
@@ -56,9 +56,30 @@ Update `autoresearch.md` periodically — especially the "What's Been Tried" sec
 
 ### `autoresearch.sh`
 
-Bash script (`set -euo pipefail`) that: pre-checks fast (syntax errors in <1s), runs the benchmark, outputs `METRIC name=value` lines to stdout. These lines are automatically parsed by `run_experiment` — the primary metric (matching `init_experiment`'s `metric_name`) and any secondary metrics are extracted, shown in the TUI, and suggested as exact values for `log_experiment`. If no METRIC lines are found, the agent falls back to manually extracting values from the output. Keep the script fast — every second is multiplied by hundreds of runs. Update it during the loop as needed.
+Bash script (`set -euo pipefail`) that: pre-checks fast (syntax errors in <1s), runs the benchmark, and outputs structured lines to stdout. Keep the script fast — every second is multiplied by hundreds of runs.
 
 **For fast, noisy benchmarks** (< 5s), run the workload multiple times inside the script and report the median. This produces stable data points and makes the confidence score reliable from the start. Slow workloads (ML training, large builds) don't need this — single runs are fine.
+
+#### Structured output
+
+- `METRIC name=value` — primary metric (must match `init_experiment`'s `metric_name`) and any secondary metrics. Parsed automatically by `run_experiment`.
+
+#### Design the script to inform optimization
+
+The script should output **whatever data helps you make better decisions in the next iteration.** Think about what you'll need to see after each run to know where to focus:
+
+- Phase timings when the workload has distinct stages
+- Error counts, failure categories, or test names when checks can fail in different ways
+- Memory usage, cache hit rates, or other runtime diagnostics when relevant
+- Anything domain-specific that would help localize regressions or identify bottlenecks
+
+The script runs the same code every iteration — but you can **update it during the loop** if you discover you need more signal. Add instrumentation as you learn what matters.
+
+#### Agent-supplied ASI via `log_experiment`
+
+Use `log_experiment`'s `asi` parameter to annotate each run with **whatever would help the next iteration make a better decision.** Free-form key/value pairs — you decide what's worth recording. Don't repeat the description or raw output; capture what you'd lose after a context reset.
+
+**Annotate failures and crashes heavily.** Discarded and crashed runs are reverted — the code changes are gone. The only record that survives is the description and ASI in `autoresearch.jsonl`. If you don't capture what you tried and why it failed, future iterations will waste time re-discovering the same dead ends.
 
 ### `autoresearch.config.json` (optional)
 
@@ -102,6 +123,7 @@ pnpm typecheck 2>&1 | grep -i error || true
 **LOOP FOREVER.** Never ask "should I continue?" — the user expects autonomous work.
 
 - **Primary metric is king.** Improved → `keep`. Worse/equal → `discard`. Secondary metrics rarely affect this.
+- **Annotate every run with `asi`.** Record what you learned — not what you did. What would help the next iteration or a fresh agent resuming this session?
 - **Watch the confidence score.** After 3+ runs, `log_experiment` reports a confidence score (best improvement as a multiple of the session noise floor). ≥2.0× means the improvement is likely real. <1.0× means it's within noise — consider re-running to confirm before keeping. The score is advisory — it never auto-discards.
 - **Simpler is better.** Removing code for equal perf = keep. Ugly complexity for tiny gain = probably discard.
 - **Don't thrash.** Repeatedly reverting the same idea? Try something structurally different.


### PR DESCRIPTION
## What is ASI?

**Actionable Side Information** is a concept from [GEPA's `optimize_anything`](https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/) (UC Berkeley, 2026). In GEPA, the evaluator returns not just a score but structured diagnostics — *why* something succeeded or failed — so the next proposal can be targeted instead of blind. ASI is described as "the text-optimization analogue of the gradient."

We adapt the idea for autoresearch: instead of requiring a specific evaluator contract, we let the agent annotate each experiment with free-form key/value pairs via `log_experiment`. The agent decides what's worth recording based on the domain — phase timings, error details, dead ends, surprising findings, or anything else.

## Why

Discarded and crashed experiments are reverted — the code changes are gone. Without ASI, the only surviving record is a short description in `autoresearch.jsonl`. With ASI, structured diagnostics persist: what was tried, why it failed, and what to try next.

This prevents future iterations from re-discovering the same dead ends, especially after context resets or when continuing an existing session with a new pi instance.

## What changed

### Extension (+47 lines)
- `ASI` interface: free-form `{ [key: string]: unknown }`
- `asi?` field on `ExperimentResult` — persisted in autoresearch.jsonl
- `asi` parameter on `log_experiment` — agent supplies per run
- ASI summary in LLM response after logging
- Backward compatible: old logs without asi load fine

### Skill (+22 lines)
- Guidance to design benchmark scripts that output useful diagnostics
- Guidance to annotate every run, especially failures
- Free-form: agent decides what to record, not the schema

## What it looks like

```json
{
  "asi": {
    "hypothesis": "tuples instead of dicts for record storage",
    "parse_improvement": "38.6->16.3ms (58%)",
    "insight": "only revenue feeds into aggregate, rest is dead code",
    "rollback_reason": "finalize step creates new dicts anyway, net slower",
    "next_action_hint": "keep dict-based aggregate, try merging parse+validate"
  }
}
```

No prescribed schema — the agent records whatever helps the next iteration.

## What it doesn't do

- No UI changes (no dashboard columns, no TUI widgets)
- No new parsers (agent writes ASI, not the benchmark script)
- No required fields (all optional, free-form)
- No breaking changes (old jsonl loads fine)