### PR TITLE
Add autoresearch-export and autoresearch-seed skills

### DIFF
--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -19,7 +19,8 @@ Autonomous experiment loop: try ideas, keep what works, discard what doesn't, ne
 2. `git checkout -b autoresearch/<goal>-<date>`
 3. Read the source files. Understand the workload deeply before writing anything.
 4. Write `autoresearch.md` and `autoresearch.sh` (see below). Commit both.
-5. `init_experiment` → run baseline → `log_experiment` → start looping immediately.
+5. **Seed with prior work:** Run `bash <AUTORESEARCH_SEED_SKILL_DIR>/seed.sh`. If it outputs anything, append it to `autoresearch.md` before the "What's Been Tried" section. This discovers seeder plugins and queries them for relevant prior wins (techniques, dead ends, metrics). Skip silently if no seeders are installed or no results found.
+6. `init_experiment` → run baseline → `log_experiment` → start looping immediately.
 
 ### `autoresearch.md`
 

--- a/skills/autoresearch-export/SKILL.md
+++ b/skills/autoresearch-export/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: autoresearch-export
+context: fork
+description: Export autoresearch session data through pluggable exporter scripts. Use when asked to "export autoresearch", "publish results", or "share session".
+---
+
+# Autoresearch Export
+
+Pipe session data through pluggable exporter scripts. Each exporter decides where the data goes — a markdown report, a database, a dashboard, anything.
+
+## When to run
+
+At the end of an autoresearch session, or on explicit `/skill:autoresearch-export`. This is intentionally a one-time export, not a per-run hook — the LLM has the full picture of the session and can reason about what's worth exporting.
+
+## Curating before export
+
+Before running the export, review the session:
+
+1. Read `autoresearch.jsonl` and `autoresearch.md`.
+2. Look at the full history — keeps, discards, crashes.
+3. Identify what's actually worth recording:
+   - Skip noise (tiny improvements within the noise floor).
+   - Skip superseded keeps (early keep replaced by a better version later).
+   - Note dead ends — "tried X, made things worse" is valuable knowledge too.
+   - Consider what the user kept vs discarded — some agent keeps are too complex or wrong.
+4. Write a curated summary into the session payload's `curated_wins` field.
+
+Each win in `curated_wins` should be a generalizable technique, not a commit-level description.
+
+## Search path
+
+The skill discovers exporters from three directories, in order:
+
+```
+1. ./autoresearch-exporters/             ← project-local
+2. ~/.pi/agent/autoresearch-exporters/   ← user-installed
+3. <skill-dir>/exporters/                ← bundled defaults
+```
+
+Each directory contains subdirectories — one per exporter:
+
+```
+autoresearch-exporters/
+├── my-exporter/
+│   ├── exporter.json
+│   └── export.sh
+```
+
+Duplicates by name: first match wins (project-local overrides user-installed overrides bundled).
+
+## Exporter contract
+
+### Manifest: `exporter.json`
+
+```json
+{
+  "name": "markdown",
+  "description": "Append a formatted session report to autoresearch-report.md",
+  "run": "export.sh"
+}
+```
+
+### Script
+
+The script declared in `run` receives session JSON on stdin. Exit 0 = success, non-zero = failure (does not block other exporters).
+
+### stdin JSON shape
+
+```json
+{
+  "session": {
+    "name": "Optimizing liquid parse+render",
+    "metric_name": "total_µs",
+    "metric_unit": "µs",
+    "direction": "lower",
+    "baseline": 18200,
+    "best": 8500,
+    "improvement_pct": 53.3,
+    "total_runs": 42,
+    "kept": 12,
+    "discarded": 28,
+    "crashed": 2
+  },
+  "results": [],
+  "keeps": [],
+  "curated_wins": [],
+  "context": {
+    "branch": "autoresearch/liquid-perf-20260320",
+    "repo": "org/my-project",
+    "autoresearch_md": "..."
+  }
+}
+```
+
+### Result object shape
+
+Each entry in `results` and `keeps`:
+
+```json
+{
+  "commit": "abc1234",
+  "metric": 15200,
+  "metrics": { "compile_µs": 4200, "render_µs": 9800 },
+  "status": "keep",
+  "description": "Switch to lazy initialization for parser",
+  "timestamp": 1711000000000,
+  "segment": 0,
+  "confidence": 2.1
+}
+```
+
+### Curated win shape
+
+Each entry in `curated_wins` (populated by the LLM before export):
+
+```json
+{
+  "technique": "Replace linear scan with binary search in sorted data",
+  "description": "The hot loop iterated a sorted array linearly. Switching to binary search reduced iterations from O(n) to O(log n). Applies to any sorted-array lookup.",
+  "metric_before": 18200,
+  "metric_after": 8500,
+  "commits": ["abc1234", "def5678"],
+  "files": ["lib/parser.rb", "lib/scanner.rb"],
+  "dead_ends": ["Tried regex caching — no improvement", "Tried memoizing AST nodes — 2% gain but added complexity"]
+}
+```
+
+## Workflow
+
+### Step 1 — Curate
+
+Read the full session. Build `curated_wins` as described above. Ask the user to confirm what should be exported.
+
+### Step 2 — Write curated wins
+
+Write the curated wins array to `autoresearch-wins.json`:
+
+```json
+[
+  {
+    "technique": "Replace linear scan with binary search in sorted data",
+    "description": "...",
+    "metric_before": 18200,
+    "metric_after": 8500,
+    "commits": ["abc1234"],
+    "files": ["lib/parser.rb"],
+    "dead_ends": ["Tried regex caching — no improvement"]
+  }
+]
+```
+
+### Step 3 — Build session payload
+
+The script reads `autoresearch.jsonl`, `autoresearch.md`, `autoresearch-wins.json`, and git context to build the payload automatically.
+
+### Step 4 — Discover exporters
+
+Scan the search path directories. For each subdirectory containing an `exporter.json`:
+- Parse the manifest.
+- Validate required fields: `name`, `run`.
+- Skip if an exporter with the same name was already found (first match wins).
+
+### Step 5 — Choose exporters
+
+Show the user the list of discovered exporters with their descriptions. Let the user pick which ones to run. Example:
+
+```
+Found 3 exporters:
+  1. markdown — Append a formatted session report to autoresearch-report.md
+  2. sqlite — Append curated wins to the local SQLite knowledge store
+  3. slack — Post session summary to Slack
+
+Which exporters should I run?
+```
+
+### Step 6 — Run exporters
+
+For each matched exporter:
+1. Serialize the session payload to JSON.
+2. Pipe it to the exporter script via stdin.
+3. Set `EXPORTER_DIR` and `TRIGGER_MODE` env vars.
+4. Capture exit code. Log success or failure.
+5. Continue to next exporter regardless of result.
+
+### Step 7 — Report
+
+```
+Exported via 2 exporters:
+  ✓ markdown — wrote autoresearch-report.md
+  ✗ slack — failed (exit 1): missing SLACK_WEBHOOK_URL
+```

--- a/skills/autoresearch-export/export.sh
+++ b/skills/autoresearch-export/export.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# autoresearch-export — discover and run exporter scripts
+#
+# Usage:
+#   export.sh <exporter-name> [exporter-name...]
+#   export.sh --list
+#   export.sh --help
+#
+# Reads autoresearch.jsonl + autoresearch.md, builds a session JSON payload,
+# and pipes it to the named exporters.
+#
+# Search path (first match by name wins):
+#   1. ./autoresearch-exporters/
+#   2. ~/.pi/agent/autoresearch-exporters/
+#   3. <script-dir>/exporters/
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIST_MODE=false
+NAMES=()
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <exporter-name> [exporter-name...]
+       $(basename "$0") --list
+
+Options:
+  --list             List all discovered exporters and exit
+  --help             Show this help message
+
+Arguments:
+  exporter-name      One or more exporters to run (required)
+
+Search path (first match by name wins):
+  1. ./autoresearch-exporters/
+  2. ~/.pi/agent/autoresearch-exporters/
+  3. <skill>/exporters/
+EOF
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h) usage ;;
+    --list) LIST_MODE=true; shift ;;
+    -*) echo -e "${RED}ERROR: unknown option '$1'${NC}" >&2; exit 1 ;;
+    *) NAMES+=("$1"); shift ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Build session payload
+# ---------------------------------------------------------------------------
+
+build_payload() {
+  local jsonl_file="autoresearch.jsonl"
+  local md_file="autoresearch.md"
+
+  [ -f "$jsonl_file" ] || { echo -e "${RED}ERROR: $jsonl_file not found${NC}" >&2; return 1; }
+
+  local branch repo md_content
+  branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+  repo=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||' || echo "unknown")
+  md_content=""
+  [ -f "$md_file" ] && md_content=$(cat "$md_file")
+
+  JSONL_FILE="$jsonl_file" MD_FILE="$md_file" BRANCH="$branch" REPO="$repo" MD_CONTENT="$md_content" node -e '
+const fs = require("fs");
+const lines = fs.readFileSync(process.env.JSONL_FILE, "utf-8").trim().split("\n").map(l => {
+  try { return JSON.parse(l); } catch { return null; }
+}).filter(Boolean);
+
+const config = lines.find(l => l.type === "config") || {};
+const results = lines.filter(l => l.type !== "config");
+const keeps = results.filter(r => r.status === "keep");
+const baseline = results.length > 0 ? results[0].metric : 0;
+const direction = config.direction || "lower";
+
+let best = baseline;
+for (const r of keeps) {
+  if (direction === "lower" && r.metric < best) best = r.metric;
+  if (direction === "higher" && r.metric > best) best = r.metric;
+}
+
+const delta = direction === "lower" ? baseline - best : best - baseline;
+const improvement_pct = baseline !== 0 ? parseFloat((delta / baseline * 100).toFixed(1)) : 0;
+
+// curated_wins — read from file if it exists
+let curated_wins = [];
+const winsFile = "autoresearch-wins.json";
+try {
+  if (require("fs").existsSync(winsFile)) {
+    curated_wins = JSON.parse(require("fs").readFileSync(winsFile, "utf-8"));
+  }
+} catch {}
+
+const payload = {
+  session: {
+    name: config.name || "",
+    metric_name: config.metric_name || "",
+    metric_unit: config.metric_unit || "",
+    direction,
+    baseline,
+    best,
+    improvement_pct,
+    total_runs: results.length,
+    kept: keeps.length,
+    discarded: results.filter(r => r.status === "discard").length,
+    crashed: results.filter(r => r.status === "crash").length,
+  },
+  results,
+  keeps,
+  curated_wins,
+  context: {
+    branch: process.env.BRANCH,
+    repo: process.env.REPO,
+    autoresearch_md: process.env.MD_CONTENT,
+  },
+};
+
+process.stdout.write(JSON.stringify(payload, null, 2));
+'
+}
+
+# ---------------------------------------------------------------------------
+# Discover exporters
+# ---------------------------------------------------------------------------
+
+EXPORTER_DIRS=()
+EXPORTER_NAMES=()
+EXPORTER_DESCS=()
+EXPORTER_SCRIPTS=()
+
+name_already_seen() {
+  local name="$1"
+  for existing in "${EXPORTER_NAMES[@]+"${EXPORTER_NAMES[@]}"}"; do
+    [ "$existing" = "$name" ] && return 0
+  done
+  return 1
+}
+
+discover_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+
+  for exporter_dir in "$dir"/*/; do
+    [ -d "$exporter_dir" ] || continue
+    local manifest="${exporter_dir}exporter.json"
+    [ -f "$manifest" ] || continue
+
+    local parsed name desc run_script
+    parsed=$(MANIFEST="$manifest" node -e '
+      const m = JSON.parse(require("fs").readFileSync(process.env.MANIFEST, "utf-8"));
+      process.stdout.write([m.name || "", m.description || "", m.run || ""].join("\n"));
+    ' 2>/dev/null) || continue
+
+    name=$(echo "$parsed" | sed -n '1p')
+    desc=$(echo "$parsed" | sed -n '2p')
+    run_script=$(echo "$parsed" | sed -n '3p')
+
+    [ -n "$name" ] && [ -n "$run_script" ] || continue
+
+    if name_already_seen "$name"; then
+      continue
+    fi
+
+    EXPORTER_DIRS+=("$exporter_dir")
+    EXPORTER_NAMES+=("$name")
+    EXPORTER_DESCS+=("$desc")
+    EXPORTER_SCRIPTS+=("$run_script")
+  done
+}
+
+discover_exporters() {
+  discover_dir "./autoresearch-exporters"
+  discover_dir "${HOME}/.pi/agent/autoresearch-exporters"
+  discover_dir "${SCRIPT_DIR}/exporters"
+}
+
+# ---------------------------------------------------------------------------
+# List mode
+# ---------------------------------------------------------------------------
+
+list_exporters() {
+  if [ ${#EXPORTER_NAMES[@]} -eq 0 ]; then
+    echo -e "${YELLOW}No exporters found.${NC}"
+    exit 0
+  fi
+
+  for i in "${!EXPORTER_NAMES[@]}"; do
+    echo "  ${EXPORTER_NAMES[$i]} — ${EXPORTER_DESCS[$i]}"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Run exporters
+# ---------------------------------------------------------------------------
+
+run_exporters() {
+  local payload="$1"
+  shift
+  local names=("$@")
+  local ran=0
+  local succeeded=0
+  local failed=0
+
+  for name in "${names[@]}"; do
+    # Find the exporter by name
+    local found=false
+    for i in "${!EXPORTER_NAMES[@]}"; do
+      if [ "${EXPORTER_NAMES[$i]}" = "$name" ]; then
+        found=true
+        local script="${EXPORTER_SCRIPTS[$i]}"
+        local dir="${EXPORTER_DIRS[$i]}"
+        local clean_dir="${dir%/}"
+
+        ran=$((ran + 1))
+        echo -n "  Running $name... "
+
+        local exit_code=0
+        local output
+        output=$(echo "$payload" | EXPORTER_DIR="$clean_dir" bash "${clean_dir}/${script}" 2>&1) || exit_code=$?
+
+        if [ $exit_code -eq 0 ]; then
+          echo -e "${GREEN}✓${NC} ${output}"
+          succeeded=$((succeeded + 1))
+        else
+          echo -e "${RED}✗${NC} (exit $exit_code): ${output}"
+          failed=$((failed + 1))
+        fi
+        break
+      fi
+    done
+
+    if [ "$found" = false ]; then
+      echo -e "  ${RED}✗${NC} $name — not found"
+      failed=$((failed + 1))
+      ran=$((ran + 1))
+    fi
+  done
+
+  echo ""
+  echo "Exported via $ran exporter(s): $succeeded succeeded, $failed failed."
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  echo ""
+  echo -e "${GREEN}═══ Autoresearch Export ═══${NC}"
+  echo ""
+
+  discover_exporters
+
+  if [ "$LIST_MODE" = true ]; then
+    list_exporters
+    exit 0
+  fi
+
+  if [ ${#NAMES[@]} -eq 0 ]; then
+    echo -e "${RED}ERROR: specify which exporters to run${NC}" >&2
+    echo "" >&2
+    if [ ${#EXPORTER_NAMES[@]} -gt 0 ]; then
+      echo "Available exporters:" >&2
+      list_exporters >&2
+    fi
+    echo "" >&2
+    echo "Usage: $(basename "$0") <name> [name...]" >&2
+    exit 1
+  fi
+
+  echo "Found ${#EXPORTER_NAMES[@]} exporter(s): ${EXPORTER_NAMES[*]}"
+  echo ""
+
+  local payload
+  payload=$(build_payload) || exit 1
+
+  run_exporters "$payload" "${NAMES[@]}"
+}
+
+main

--- a/skills/autoresearch-export/exporters/sqlite/export.sh
+++ b/skills/autoresearch-export/exporters/sqlite/export.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SQLite exporter — appends curated wins to ~/.pi/agent/autoresearch.db
+#
+# Reads session JSON from stdin. Upserts a session row, then appends
+# each curated_win as a separate row linked to the session.
+# FTS is kept in sync automatically via triggers.
+
+DB_PATH="${AUTORESEARCH_DB:-${HOME}/.pi/agent/autoresearch.db}"
+
+if ! command -v sqlite3 &>/dev/null; then
+  echo "sqlite3 not found, skipping" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DB_PATH")"
+
+sqlite3 "$DB_PATH" <<'SQL'
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  goal TEXT,
+  metric_name TEXT,
+  metric_unit TEXT,
+  direction TEXT,
+  baseline REAL,
+  best REAL,
+  improvement_pct REAL,
+  total_runs INTEGER,
+  kept INTEGER,
+  repo TEXT,
+  branch TEXT,
+  autoresearch_md TEXT,
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS wins (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT REFERENCES sessions(id),
+  technique TEXT NOT NULL,
+  description TEXT NOT NULL,
+  metric_before REAL,
+  metric_after REAL,
+  commits TEXT,
+  files TEXT,
+  dead_ends TEXT,
+  session_name TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS wins_fts USING fts5(
+  technique,
+  description,
+  files,
+  dead_ends,
+  session_name,
+  content=wins,
+  content_rowid=id,
+  tokenize='porter'
+);
+
+-- Triggers to keep FTS in sync
+CREATE TRIGGER IF NOT EXISTS wins_ai AFTER INSERT ON wins BEGIN
+  INSERT INTO wins_fts(rowid, technique, description, files, dead_ends, session_name)
+  VALUES(NEW.id, NEW.technique, NEW.description, NEW.files, NEW.dead_ends, NEW.session_name);
+END;
+
+CREATE TRIGGER IF NOT EXISTS wins_ad AFTER DELETE ON wins BEGIN
+  INSERT INTO wins_fts(wins_fts, rowid, technique, description, files, dead_ends, session_name)
+  VALUES('delete', OLD.id, OLD.technique, OLD.description, OLD.files, OLD.dead_ends, OLD.session_name);
+END;
+SQL
+
+INPUT=$(cat)
+
+# Check if there are any curated wins
+COUNT=$(echo "$INPUT" | node -e "process.stdout.write(String((JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).curated_wins || []).length))")
+
+if [ "$COUNT" = "0" ]; then
+  echo "no curated wins to export"
+  exit 0
+fi
+
+echo "$INPUT" | node -e '
+const d = JSON.parse(require("fs").readFileSync("/dev/stdin", "utf-8"));
+const wins = d.curated_wins || [];
+const s = d.session;
+const ctx = d.context;
+
+const esc = (v) => v == null ? "NULL" : "\x27" + String(v).replace(/\x27/g, "\x27\x27") + "\x27";
+const sessionId = `${ctx.repo}:${ctx.branch}`;
+
+const sql = [];
+
+// Upsert session
+sql.push(`INSERT INTO sessions (id, goal, metric_name, metric_unit, direction, baseline, best, improvement_pct, total_runs, kept, repo, branch, autoresearch_md)
+VALUES (
+  ${esc(sessionId)}, ${esc(s.name)}, ${esc(s.metric_name)}, ${esc(s.metric_unit)},
+  ${esc(s.direction)}, ${s.baseline}, ${s.best}, ${s.improvement_pct},
+  ${s.total_runs}, ${s.kept}, ${esc(ctx.repo)}, ${esc(ctx.branch)}, ${esc(ctx.autoresearch_md)}
+)
+ON CONFLICT(id) DO UPDATE SET
+  goal=excluded.goal, metric_name=excluded.metric_name, metric_unit=excluded.metric_unit,
+  direction=excluded.direction, baseline=excluded.baseline, best=excluded.best,
+  improvement_pct=excluded.improvement_pct, total_runs=excluded.total_runs, kept=excluded.kept,
+  autoresearch_md=excluded.autoresearch_md, updated_at=datetime(\x27now\x27);`);
+
+// Insert wins — FTS is updated automatically via trigger
+for (const w of wins) {
+  sql.push(`INSERT INTO wins (session_id, technique, description, metric_before, metric_after, commits, files, dead_ends, session_name)
+VALUES (
+  ${esc(sessionId)}, ${esc(w.technique)}, ${esc(w.description)},
+  ${w.metric_before ?? "NULL"}, ${w.metric_after ?? "NULL"},
+  ${esc(JSON.stringify(w.commits || []))}, ${esc(JSON.stringify(w.files || []))},
+  ${esc(JSON.stringify(w.dead_ends || []))}, ${esc(s.name)}
+);`);
+}
+
+process.stdout.write(sql.join("\n"));
+' | sqlite3 "$DB_PATH"
+
+echo "wrote $COUNT win(s) to $DB_PATH"

--- a/skills/autoresearch-export/exporters/sqlite/exporter.json
+++ b/skills/autoresearch-export/exporters/sqlite/exporter.json
@@ -1,0 +1,5 @@
+{
+  "name": "sqlite",
+  "description": "Append curated wins to the local SQLite knowledge store",
+  "run": "export.sh"
+}

--- a/skills/autoresearch-seed/SKILL.md
+++ b/skills/autoresearch-seed/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: autoresearch-seed
+context: fork
+description: Seed an autoresearch session with relevant prior work from the local knowledge store. Use at the start of a session, or when asked to "find prior work", "seed ideas", or "what worked before".
+---
+
+# Autoresearch Seed
+
+Search the local knowledge store (`~/.pi/agent/autoresearch.db`) for prior experiments relevant to the current session. Appends a "Prior work" section to `autoresearch.md` so the agent starts with context from past sessions.
+
+## When to run
+
+- Automatically after `autoresearch-create` writes `autoresearch.md` and before the first experiment.
+- Manually via `/skill:autoresearch-seed` at any point during a session.
+
+## Workflow
+
+### Step 1 — Read session context
+
+Read `autoresearch.md`. Extract the goal (from the `# Autoresearch: <goal>` heading) and files in scope.
+
+### Step 2 — Search the knowledge store
+
+Run:
+
+```bash
+bash <SKILL_DIR>/seed.sh
+```
+
+The script:
+1. Builds an FTS5 query from the goal text.
+2. Queries the local SQLite store, ranked by BM25, limit 10.
+3. Groups results by session.
+4. Outputs a markdown section to stdout.
+
+If the database doesn't exist or has no results, the script exits 0 with no output. This is expected for first-ever sessions.
+
+### Step 3 — Append to autoresearch.md
+
+If the script produced output, append it to `autoresearch.md` before the "What's Been Tried" section (or at the end if that section doesn't exist).
+
+### Step 4 — Report
+
+Tell the user how many prior sessions and wins were found:
+
+```
+Seeded with 3 prior sessions, 7 relevant wins.
+```
+
+If nothing was found, say so and move on. Don't block.

--- a/skills/autoresearch-seed/seed.sh
+++ b/skills/autoresearch-seed/seed.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# seed.sh — search the local knowledge store for relevant prior work
+#
+# Usage: seed.sh [query-override]
+#
+# Reads autoresearch.md to build a query, searches ~/.pi/agent/autoresearch.db,
+# outputs a markdown section to stdout. Exit 0 with no output = nothing found.
+
+DB_PATH="${AUTORESEARCH_DB:-${HOME}/.pi/agent/autoresearch.db}"
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if ! command -v sqlite3 &>/dev/null; then
+  exit 0
+fi
+
+if [ ! -f "$DB_PATH" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+normalize_repo() {
+  sed 's|.*github.com[:/]||; s|\.git$||'
+}
+
+# ---------------------------------------------------------------------------
+# Build query context
+# ---------------------------------------------------------------------------
+
+QUERY_OVERRIDE="${1:-}"
+GOAL=""
+FILES="[]"
+
+if [ -f "autoresearch.md" ]; then
+  GOAL=$(head -5 autoresearch.md | sed -n 's/^#.*Autoresearch[: ]*//Ip' | head -1)
+
+  local_files=$(awk '/^## Files in Scope/,/^## /' autoresearch.md \
+    | grep -E '^\s*-' \
+    | sed 's/^\s*-\s*//' \
+    | sed 's/\s*—.*//' 2>/dev/null || true)
+
+  if [ -n "$local_files" ]; then
+    FILES=$(echo "$local_files" | node -e '
+      const lines = require("fs").readFileSync("/dev/stdin","utf-8").trim().split("\n").filter(Boolean);
+      process.stdout.write(JSON.stringify(lines));
+    ' 2>/dev/null || echo "[]")
+  fi
+fi
+
+[ -n "$QUERY_OVERRIDE" ] && GOAL="$QUERY_OVERRIDE"
+[ -n "$GOAL" ] || exit 0
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+REPO=$(git remote get-url origin 2>/dev/null | normalize_repo || echo "unknown")
+
+# ---------------------------------------------------------------------------
+# Query and format
+# ---------------------------------------------------------------------------
+
+GOAL="$GOAL" REPO="$REPO" BRANCH="$BRANCH" DB_PATH="$DB_PATH" node -e '
+const { execSync } = require("child_process");
+
+const goal = process.env.GOAL;
+const currentRepo = process.env.REPO;
+const currentBranch = process.env.BRANCH;
+const dbPath = process.env.DB_PATH;
+
+// Build FTS5 query — strip punctuation, drop short words, join with OR
+const terms = goal
+  .replace(/[^\w\s]/g, " ")
+  .split(/\s+/)
+  .filter(t => t.length > 2)
+  .map(t => `"${t}"`)
+  .join(" OR ");
+
+if (!terms) process.exit(0);
+
+const esc = (s) => String(s).replace(/\x27/g, "\x27\x27");
+
+const sql = `
+SELECT json_group_array(json_object(
+  '"'"'technique'"'"', w.technique,
+  '"'"'description'"'"', w.description,
+  '"'"'metric_before'"'"', w.metric_before,
+  '"'"'metric_after'"'"', w.metric_after,
+  '"'"'metric_name'"'"', s.metric_name,
+  '"'"'metric_unit'"'"', s.metric_unit,
+  '"'"'files'"'"', w.files,
+  '"'"'dead_ends'"'"', w.dead_ends,
+  '"'"'session_name'"'"', s.goal,
+  '"'"'repo'"'"', s.repo,
+  '"'"'branch'"'"', s.branch,
+  '"'"'created_at'"'"', w.created_at
+))
+FROM wins w
+JOIN sessions s ON s.id = w.session_id
+WHERE w.id IN (SELECT rowid FROM wins_fts WHERE wins_fts MATCH '"'"'${esc(terms)}'"'"')
+  AND NOT (s.repo = '"'"'${esc(currentRepo)}'"'"' AND s.branch = '"'"'${esc(currentBranch)}'"'"')
+ORDER BY w.created_at DESC
+LIMIT 15;
+`;
+
+let raw;
+try {
+  raw = execSync(`sqlite3 "${dbPath}" "${sql.replace(/"/g, "\\\"")}"`, {
+    encoding: "utf-8",
+    timeout: 5000,
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+if (!raw) process.exit(0);
+
+let rows;
+try { rows = JSON.parse(raw); } catch { process.exit(0); }
+if (!rows || rows.length === 0) process.exit(0);
+
+// Group by session
+const sessions = new Map();
+for (const r of rows) {
+  const key = `${r.repo}:${r.branch}`;
+  if (!sessions.has(key)) {
+    sessions.set(key, { session_name: r.session_name, created_at: r.created_at, wins: [] });
+  }
+  sessions.get(key).wins.push(r);
+}
+
+const lines = [];
+for (const [, s] of sessions) {
+  const date = s.created_at ? s.created_at.split(" ")[0] : "unknown";
+  lines.push(`### ${s.session_name} (${date})`);
+  lines.push("");
+
+  for (const w of s.wins) {
+    const metric = (w.metric_before && w.metric_after)
+      ? ` — ${w.metric_name}: ${w.metric_before} → ${w.metric_after}${w.metric_unit}`
+      : "";
+    lines.push(`- **${w.technique}**${metric}`);
+    lines.push(`  ${w.description}`);
+
+    let files = [];
+    try { files = JSON.parse(w.files); } catch {}
+    if (Array.isArray(files) && files.length > 0) lines.push(`  Files: ${files.join(", ")}`);
+
+    let dead_ends = [];
+    try { dead_ends = JSON.parse(w.dead_ends); } catch {}
+    if (Array.isArray(dead_ends) && dead_ends.length > 0) {
+      for (const de of dead_ends) lines.push(`  ⚠ Dead end: ${de}`);
+    }
+  }
+  lines.push("");
+}
+
+if (lines.length > 0) process.stdout.write(lines.join("\n"));
+'

--- a/tests/export_test.sh
+++ b/tests/export_test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for autoresearch-export
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXPORT_SCRIPT="${SCRIPT_DIR}/../skills/autoresearch-export/export.sh"
+PASS=0
+FAIL=0
+
+setup_tmpdir() {
+  TMPDIR=$(mktemp -d)
+  cd "$TMPDIR"
+  git init --quiet
+  git remote add origin https://github.com/test/repo.git 2>/dev/null || true
+  git checkout -b autoresearch/test-session --quiet 2>/dev/null || true
+}
+
+teardown_tmpdir() {
+  cd /
+  rm -rf "$TMPDIR"
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label (exit $actual, expected $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+write_jsonl() {
+  cat > autoresearch.jsonl << 'EOF'
+{"type":"config","name":"Test Session","metric_name":"total_ms","metric_unit":"ms","direction":"lower"}
+{"commit":"aaa1111","metric":100,"metrics":{},"status":"keep","description":"baseline","timestamp":1711000000000,"segment":0,"confidence":null}
+{"commit":"bbb2222","metric":120,"metrics":{},"status":"discard","description":"made it worse","timestamp":1711000001000,"segment":0,"confidence":null}
+{"commit":"ccc3333","metric":80,"metrics":{},"status":"keep","description":"improved parsing","timestamp":1711000002000,"segment":0,"confidence":2.1}
+{"commit":"ddd4444","metric":0,"metrics":{},"status":"crash","description":"broke everything","timestamp":1711000003000,"segment":0,"confidence":null}
+EOF
+  echo "# Test" > autoresearch.md
+}
+
+write_higher_jsonl() {
+  cat > autoresearch.jsonl << 'EOF'
+{"type":"config","name":"Test Session","metric_name":"score","metric_unit":"pts","direction":"higher"}
+{"commit":"aaa1111","metric":50,"metrics":{},"status":"keep","description":"baseline","timestamp":1711000000000,"segment":0,"confidence":null}
+{"commit":"bbb2222","metric":75,"metrics":{},"status":"keep","description":"improved","timestamp":1711000001000,"segment":0,"confidence":2.0}
+EOF
+  echo "# Test" > autoresearch.md
+}
+
+# ---------------------------------------------------------------------------
+# Test: no args exits with error and lists available exporters
+# ---------------------------------------------------------------------------
+
+echo "Test: no args exits with error"
+setup_tmpdir
+write_jsonl
+git add -A && git commit -m "init" --quiet
+exit_code=0
+output=$(bash "$EXPORT_SCRIPT" 2>&1) || exit_code=$?
+assert_exit "exits non-zero without args" "1" "$exit_code"
+assert_contains "shows usage hint" "specify which exporters" "$output"
+assert_contains "lists available exporters" "sqlite" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: --list shows available exporters
+# ---------------------------------------------------------------------------
+
+echo "Test: --list shows available exporters"
+setup_tmpdir
+output=$(bash "$EXPORT_SCRIPT" --list 2>&1)
+assert_contains "lists sqlite" "sqlite" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: missing jsonl exits non-zero
+# ---------------------------------------------------------------------------
+
+echo "Test: missing jsonl"
+setup_tmpdir
+exit_code=0
+bash "$EXPORT_SCRIPT" sqlite 2>/dev/null || exit_code=$?
+assert_exit "exits non-zero without jsonl" "1" "$exit_code"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: runs named exporter
+# ---------------------------------------------------------------------------
+
+echo "Test: runs named exporter"
+setup_tmpdir
+write_jsonl
+git add -A && git commit -m "init" --quiet
+output=$(bash "$EXPORT_SCRIPT" sqlite 2>&1)
+assert_contains "runs sqlite exporter" "sqlite" "$output"
+assert_contains "reports 1 exporter" "1 exporter" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: unknown exporter name reports error
+# ---------------------------------------------------------------------------
+
+echo "Test: unknown exporter name"
+setup_tmpdir
+write_jsonl
+git add -A && git commit -m "init" --quiet
+output=$(bash "$EXPORT_SCRIPT" nonexistent 2>&1)
+assert_contains "reports not found" "not found" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: project-local exporters take priority
+# ---------------------------------------------------------------------------
+
+echo "Test: project-local overrides bundled"
+setup_tmpdir
+write_jsonl
+mkdir -p autoresearch-exporters/sqlite
+cat > autoresearch-exporters/sqlite/exporter.json << 'EOF'
+{"name": "sqlite", "run": "export.sh"}
+EOF
+cat > autoresearch-exporters/sqlite/export.sh << 'EOF'
+#!/bin/bash
+echo "LOCAL_OVERRIDE"
+EOF
+chmod +x autoresearch-exporters/sqlite/export.sh
+git add -A && git commit -m "init" --quiet
+output=$(bash "$EXPORT_SCRIPT" sqlite 2>&1)
+assert_contains "uses local exporter" "LOCAL_OVERRIDE" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: exporter failure doesn't block others
+# ---------------------------------------------------------------------------
+
+echo "Test: exporter failure isolation"
+setup_tmpdir
+write_jsonl
+mkdir -p autoresearch-exporters/failing
+cat > autoresearch-exporters/failing/exporter.json << 'EOF'
+{"name": "failing", "run": "export.sh"}
+EOF
+cat > autoresearch-exporters/failing/export.sh << 'EOF'
+#!/bin/bash
+echo "BOOM" >&2
+exit 1
+EOF
+chmod +x autoresearch-exporters/failing/export.sh
+
+mkdir -p autoresearch-exporters/working
+cat > autoresearch-exporters/working/exporter.json << 'EOF'
+{"name": "working", "run": "export.sh"}
+EOF
+cat > autoresearch-exporters/working/export.sh << 'EOF'
+#!/bin/bash
+echo "WORKED"
+EOF
+chmod +x autoresearch-exporters/working/export.sh
+
+git add -A && git commit -m "init" --quiet
+output=$(bash "$EXPORT_SCRIPT" failing working 2>&1)
+assert_contains "working exporter still runs" "WORKED" "$output"
+assert_contains "reports failure" "exit 1" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: direction=higher improvement_pct
+# ---------------------------------------------------------------------------
+
+echo "Test: direction=higher improvement_pct"
+setup_tmpdir
+write_higher_jsonl
+git add -A && git commit -m "init" --quiet
+
+mkdir -p autoresearch-exporters/dump
+cat > autoresearch-exporters/dump/exporter.json << 'EOF'
+{"name": "dump", "run": "export.sh"}
+EOF
+cat > autoresearch-exporters/dump/export.sh << 'EOF'
+#!/bin/bash
+node -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf-8")); console.log("PCT=" + d.session.improvement_pct)'
+EOF
+chmod +x autoresearch-exporters/dump/export.sh
+
+output=$(bash "$EXPORT_SCRIPT" dump 2>&1)
+assert_contains "improvement is 50%" "PCT=50" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: EXPORTER_DIR env var passed to exporters
+# ---------------------------------------------------------------------------
+
+echo "Test: EXPORTER_DIR env var passed"
+setup_tmpdir
+write_jsonl
+mkdir -p autoresearch-exporters/env-check
+cat > autoresearch-exporters/env-check/exporter.json << 'EOF'
+{"name": "env-check", "run": "export.sh"}
+EOF
+cat > autoresearch-exporters/env-check/export.sh << 'EOF'
+#!/bin/bash
+echo "DIR=${EXPORTER_DIR}"
+EOF
+chmod +x autoresearch-exporters/env-check/export.sh
+
+git add -A && git commit -m "init" --quiet
+output=$(bash "$EXPORT_SCRIPT" env-check 2>&1)
+assert_contains "EXPORTER_DIR is set" "DIR=" "$output"
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "  ${GREEN}$PASS passed${NC}, ${RED}$FAIL failed${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+[ $FAIL -eq 0 ] || exit 1

--- a/tests/knowledge_store_test.sh
+++ b/tests/knowledge_store_test.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for SQLite exporter + seed.sh
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SQLITE_EXPORTER="${SCRIPT_DIR}/../skills/autoresearch-export/exporters/sqlite/export.sh"
+SEED_SCRIPT="${SCRIPT_DIR}/../skills/autoresearch-seed/seed.sh"
+PASS=0
+FAIL=0
+
+setup_tmpdir() {
+  TMPDIR=$(mktemp -d)
+  export AUTORESEARCH_DB="${TMPDIR}/test.db"
+  cd "$TMPDIR"
+  git init --quiet
+  git remote add origin https://github.com/test/my-project.git 2>/dev/null || true
+}
+
+teardown_tmpdir() {
+  cd /
+  rm -rf "$TMPDIR"
+  unset AUTORESEARCH_DB
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label"
+    echo "    expected to contain: $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo -e "  ${RED}✗${NC} $label"
+    echo "    should not contain: $needle"
+    FAIL=$((FAIL + 1))
+  else
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  fi
+}
+
+make_export_payload() {
+  local session_name="${1:-Test Session}"
+  local curated_wins="${2:-[]}"
+  cat << EOJSON
+{
+  "session": {
+    "name": "$session_name",
+    "metric_name": "total_ms",
+    "metric_unit": "ms",
+    "direction": "lower",
+    "baseline": 100,
+    "best": 70,
+    "improvement_pct": 30,
+    "total_runs": 10,
+    "kept": 3,
+    "discarded": 6,
+    "crashed": 1
+  },
+  "results": [],
+  "keeps": [],
+  "curated_wins": $curated_wins,
+  "context": {
+    "branch": "autoresearch/test-session",
+    "repo": "test/my-project",
+    "autoresearch_md": "# Autoresearch: $session_name"
+  }
+}
+EOJSON
+}
+
+LIQUID_WINS='[
+  {
+    "technique": "Replace regex tokenizer with hand-rolled state machine",
+    "description": "The regex engine was the bottleneck. A hand-rolled state machine avoids backtracking and runs in a single pass.",
+    "metric_before": 100,
+    "metric_after": 68,
+    "commits": ["aaa1111", "bbb2222"],
+    "files": ["lib/liquid/tokenizer.rb"],
+    "dead_ends": ["Tried memoizing regex matches — no improvement"]
+  },
+  {
+    "technique": "Cache parsed AST between renders",
+    "description": "Templates are parsed on every render. Caching the AST avoids redundant parsing for repeated renders.",
+    "metric_before": 68,
+    "metric_after": 55,
+    "commits": ["ccc3333"],
+    "files": ["lib/liquid/ast_cache.rb"],
+    "dead_ends": []
+  }
+]'
+
+# ---------------------------------------------------------------------------
+# Test: SQLite exporter creates DB, sessions table, and wins
+# ---------------------------------------------------------------------------
+
+echo "Test: SQLite exporter writes session and wins"
+setup_tmpdir
+
+output=$(make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" 2>&1)
+assert_contains "reports success" "wrote 2 win" "$output"
+
+session_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM sessions")
+assert_eq "one session in DB" "1" "$session_count"
+
+session_goal=$(sqlite3 "$AUTORESEARCH_DB" "SELECT goal FROM sessions LIMIT 1")
+assert_eq "session goal stored" "Optimize liquid parsing" "$session_goal"
+
+win_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM wins")
+assert_eq "two wins in DB" "2" "$win_count"
+
+# Verify wins have session_id FK
+session_id=$(sqlite3 "$AUTORESEARCH_DB" "SELECT session_id FROM wins LIMIT 1")
+assert_eq "win linked to session" "test/my-project:autoresearch/test-session" "$session_id"
+
+# Verify FTS populated via trigger
+fts_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM wins_fts")
+assert_eq "FTS has two entries (via trigger)" "2" "$fts_count"
+
+technique=$(sqlite3 "$AUTORESEARCH_DB" "SELECT technique FROM wins LIMIT 1")
+assert_eq "technique stored" "Replace regex tokenizer with hand-rolled state machine" "$technique"
+
+# Verify autoresearch_md stored once in sessions, not in wins
+md_in_session=$(sqlite3 "$AUTORESEARCH_DB" "SELECT LENGTH(autoresearch_md) FROM sessions LIMIT 1")
+[ "$md_in_session" -gt 0 ] && echo -e "  ${GREEN}✓${NC} autoresearch_md in sessions" && PASS=$((PASS+1)) || { echo -e "  ${RED}✗${NC} autoresearch_md not in sessions"; FAIL=$((FAIL+1)); }
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: SQLite exporter is append-only for wins
+# ---------------------------------------------------------------------------
+
+echo "Test: SQLite exporter appends wins on re-run"
+setup_tmpdir
+
+make_export_payload "Session 1" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+make_export_payload "Session 1" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+win_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM wins")
+assert_eq "four wins after two exports (append-only)" "4" "$win_count"
+
+# But still one session (upsert)
+session_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM sessions")
+assert_eq "still one session (upsert)" "1" "$session_count"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: SQLite exporter handles empty curated_wins
+# ---------------------------------------------------------------------------
+
+echo "Test: SQLite exporter with no curated wins"
+setup_tmpdir
+
+output=$(make_export_payload "Empty Session" "[]" | bash "$SQLITE_EXPORTER" 2>&1)
+assert_contains "reports no wins" "no curated wins" "$output"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: FTS trigger keeps index in sync
+# ---------------------------------------------------------------------------
+
+echo "Test: FTS trigger keeps index in sync"
+setup_tmpdir
+
+make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+# FTS should find by technique
+fts_result=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM wins_fts WHERE wins_fts MATCH '\"tokenizer\"'")
+assert_eq "FTS finds by technique" "1" "$fts_result"
+
+# FTS should find by description
+fts_result=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM wins_fts WHERE wins_fts MATCH '\"backtracking\"'")
+assert_eq "FTS finds by description" "1" "$fts_result"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: seed finds relevant wins
+# ---------------------------------------------------------------------------
+
+echo "Test: seed finds relevant wins"
+setup_tmpdir
+
+make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+# Switch to a different branch for the seed
+git checkout -b autoresearch/different-session --quiet 2>/dev/null || true
+cat > autoresearch.md << 'EOF'
+# Autoresearch: Optimize liquid rendering
+EOF
+git add -A && git commit -m "init" --quiet
+
+output=$(bash "$SEED_SCRIPT" 2>&1)
+assert_contains "finds technique" "hand-rolled state machine" "$output"
+assert_contains "finds second technique" "Cache parsed AST" "$output"
+assert_contains "includes dead ends" "Dead end" "$output"
+assert_contains "includes files" "tokenizer.rb" "$output"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: seed excludes current session
+# ---------------------------------------------------------------------------
+
+echo "Test: seed excludes current session"
+setup_tmpdir
+
+make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+# Query from the same repo+branch
+git checkout -b autoresearch/test-session --quiet 2>/dev/null || true
+cat > autoresearch.md << 'EOF'
+# Autoresearch: Optimize liquid parsing
+EOF
+git add -A && git commit -m "init" --quiet
+
+output=$(bash "$SEED_SCRIPT" 2>&1)
+assert_eq "no output for same session" "" "$output"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: seed returns nothing for unrelated query
+# ---------------------------------------------------------------------------
+
+echo "Test: seed returns nothing for unrelated query"
+setup_tmpdir
+
+make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+git checkout -b autoresearch/other --quiet 2>/dev/null || true
+cat > autoresearch.md << 'EOF'
+# Autoresearch: Reduce memory footprint of image thumbnailing
+EOF
+git add -A && git commit -m "init" --quiet
+
+output=$(bash "$SEED_SCRIPT" 2>&1)
+assert_not_contains "no results for unrelated query" "hand-rolled" "$output"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: seed exits cleanly without DB
+# ---------------------------------------------------------------------------
+
+echo "Test: seed exits cleanly without DB"
+setup_tmpdir
+export AUTORESEARCH_DB="${TMPDIR}/nonexistent.db"
+
+cat > autoresearch.md << 'EOF'
+# Autoresearch: Something
+EOF
+
+output=$(bash "$SEED_SCRIPT" 2>&1)
+assert_eq "no output" "" "$output"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: seed with query override
+# ---------------------------------------------------------------------------
+
+echo "Test: seed with query override"
+setup_tmpdir
+
+make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+git checkout -b autoresearch/other --quiet 2>/dev/null || true
+git commit --allow-empty -m "init" --quiet
+
+output=$(bash "$SEED_SCRIPT" "liquid tokenizer" 2>&1)
+assert_contains "finds via query override" "hand-rolled state machine" "$output"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Test: multiple sessions coexist
+# ---------------------------------------------------------------------------
+
+echo "Test: multiple sessions coexist"
+setup_tmpdir
+
+TEST_WINS='[{"technique":"Parallelize workers","description":"Split work across cores","metric_before":60,"metric_after":30,"commits":["eee5555"],"files":["config/workers.rb"],"dead_ends":[]}]'
+
+make_export_payload "Optimize liquid parsing" "$LIQUID_WINS" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+# Different session
+PAYLOAD=$(make_export_payload "Speed up test suite" "$TEST_WINS")
+PAYLOAD=$(echo "$PAYLOAD" | node -e '
+  const d = JSON.parse(require("fs").readFileSync("/dev/stdin","utf-8"));
+  d.context.branch = "autoresearch/test-speed";
+  process.stdout.write(JSON.stringify(d));
+')
+echo "$PAYLOAD" | bash "$SQLITE_EXPORTER" >/dev/null 2>&1
+
+session_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM sessions")
+assert_eq "two sessions in DB" "2" "$session_count"
+
+win_count=$(sqlite3 "$AUTORESEARCH_DB" "SELECT COUNT(*) FROM wins")
+assert_eq "three total wins" "3" "$win_count"
+
+teardown_tmpdir
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "  ${GREEN}$PASS passed${NC}, ${RED}$FAIL failed${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+[ $FAIL -eq 0 ] || exit 1


### PR DESCRIPTION
## Why

Autoresearch sessions produce valuable knowledge — what techniques worked, what dead ends to avoid, on which files, with what improvement — that is lost when the session ends. There is also no standard way to export session data to external systems.

Consider: someone runs autoresearch on test speed and discovers that swapping `ProgressReporter` for `DefaultReporter` saves 15% because ANSI escape codes are expensive across parallel workers. That insight applies to any Ruby test suite using Minitest reporters — but today it lives in a Slack thread or a branch that gets merged and forgotten.

Or: three different teams independently discover that `insert_all!` is faster than N individual inserts. Each spends 10+ experiments rediscovering the same pattern because there's no way for an agent starting a new session to know what's already been tried.

This PR adds two pluggable systems that mirror each other: **export** (write) and **seed** (read), with shared storage in the middle.

<img width="1408" height="768" alt="autoresearch-export-architecture" src="https://github.com/user-attachments/assets/f9b3d214-b92d-4e9f-b459-a6f9831b5a6a" />

## How it works

### Export (write side)

At session end, the LLM reviews the full history — keeps, discards, crashes — and curates what's worth recording. Early keeps that got superseded, noise within the noise floor, and complexity the user wouldn't merge are filtered out. Dead ends ("tried X, made things worse") are preserved as valuable knowledge — they prevent future sessions from wasting experiments on the same failed approaches.

The skill discovers available exporters, shows them to the user, and the user chooses which ones to run. The curated payload is piped to each selected exporter:

```
autoresearch.jsonl → export skill (parse, summarize, curate) → user picks exporters → storage
```

### Seed (read side)

At session start, seeder plugins query whatever storage the exporters wrote to and surface relevant prior work. A new session optimizing "liquid template rendering" automatically finds that a previous session on "liquid tokenizer speed" discovered hand-rolled state machines beat regex — and that memoizing AST nodes was a dead end. The agent starts with context instead of from scratch.

```
storage → seeder plugin → seed skill → autoresearch.md (Prior work section)
```

### Plugin search path

Both systems use the same discovery pattern (first match by name wins):

```
1. ./autoresearch-{exporters,seeders}/             ← project-local
2. ~/.pi/agent/autoresearch-{exporters,seeders}/   ← user-installed
3. <skill>/{exporters,seeders}/                    ← bundled defaults
```

This means organizations can ship their own exporters (internal dashboards, team APIs, Slack integrations) without forking the repo — just drop them in the user or project-local directory and they light up automatically.

### Exporter contract

Each exporter is a directory with `exporter.json` + script. Receives session JSON on stdin (including `curated_wins`). The user explicitly chooses which exporters to run.

### Seeder contract

Each seeder is a directory with `seeder.json` + script. Receives query JSON on stdin (`{ goal, files, repo, branch }`). Outputs markdown to stdout.

### Bundled plugins

| Plugin | Type | What it does |
|--------|------|-------------|
| **sqlite** | exporter | Append-only wins to `~/.pi/agent/autoresearch.db` (FTS5) |
| **sqlite** | seeder | BM25-ranked search over prior wins, grouped by session |

Custom plugins (dashboards, APIs, Slack, etc.) are installed into the user or project-local directories.

### Usage

```
/skill:autoresearch-export                  # curate + user picks exporters to run
/skill:autoresearch-export sqlite            # run specific exporters by name
/skill:autoresearch-export --list           # show all discovered exporters
/skill:autoresearch-seed                    # search all seeders for prior work
```

## Tests

36 tests across both systems:

- **Export (13)**: no-args error with available list, --list discovery, named exporter execution, unknown name handling, project-local override, failure isolation, direction=higher math, env var passing
- **Knowledge store + seed (23)**: session + wins creation, session_id FK, FTS via triggers, autoresearch_md stored once in sessions, append-only wins, session upsert, empty wins handling, FTS search by technique and description, seed relevance, current session exclusion, unrelated query, clean exit without DB, query override, multiple sessions coexist
