### PR TITLE
Fix pi 0.65 session lifecycle hooks

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1212,8 +1212,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   pi.on("session_start", async (_e, ctx) => reconstructState(ctx));
-  pi.on("session_switch", async (_e, ctx) => reconstructState(ctx));
-  pi.on("session_fork", async (_e, ctx) => reconstructState(ctx));
   pi.on("session_tree", async (_e, ctx) => reconstructState(ctx));
   pi.on("session_before_switch", async () => {
     clearOverlay();


### PR DESCRIPTION
With 0.65, pi doesnt support session_switch or fork anymore. Only session start.