### PR TITLE
Fix: Update extension for pi v0.65.0 compatibility

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1212,8 +1212,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   pi.on("session_start", async (_e, ctx) => reconstructState(ctx));
-  pi.on("session_switch", async (_e, ctx) => reconstructState(ctx));
-  pi.on("session_fork", async (_e, ctx) => reconstructState(ctx));
   pi.on("session_tree", async (_e, ctx) => reconstructState(ctx));
   pi.on("session_before_switch", async () => {
     clearOverlay();

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     ]
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*",
+    "@mariozechner/pi-ai": "^0.65.0",
+    "@mariozechner/pi-coding-agent": "^0.65.0",
+    "@mariozechner/pi-tui": "^0.65.0",
     "@sinclair/typebox": "*"
   }
 }


### PR DESCRIPTION
Resolves #36.

This PR updates the extension and package dependencies to ensure compatibility with the  v0.65.0 release:

- Removes the deprecated `session_switch` and `session_fork` event listeners. In v0.65.0, these lifecycle transitions are unified under `session_start` with an `event.reason`. The existing `session_start` listener correctly rebuilds the dashboard state, making the removed listeners unnecessary.
- Bumps peer dependencies for `@mariozechner/pi-coding-agent`, `@mariozechner/pi-ai`, and `@mariozechner/pi-tui` to `^0.65.0` to avoid runtime or typing mismatches.