### PR TITLE
fix(autoresearch): clear widget when turning mode off

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -2823,12 +2823,16 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       if (command === "off") {
         runtime.autoresearchMode = false;
+        runtime.dashboardExpanded = false;
         runtime.lastAutoResumeTime = 0;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
+        runtime.pendingCompactResume = false;
         runtime.lastRunChecks = null;
+        runtime.lastRunDuration = null;
         runtime.runningExperiment = null;
         stopDashboardServer();
+        clearSessionUi(ctx);
         ctx.ui.notify("Autoresearch mode OFF", "info");
         return;
       }


### PR DESCRIPTION
## Summary

Clears the autoresearch widget immediately when `/autoresearch off` is used.

## Why

Turning autoresearch mode off currently disables the mode, but the widget/dashboard can remain visible because the command does not explicitly clear the existing UI state.

That makes it look like autoresearch is still active even after the user has explicitly left the mode.

## What changed

When `/autoresearch off` runs, it now also:
- clears the widget/UI immediately
- resets expanded dashboard state
- clears pending compact-resume state
- clears last run duration

## Result

After `/autoresearch off`, the autoresearch UI no longer lingers on screen.

## Testing

Tested manually by:
- entering autoresearch mode
- ensuring the widget was visible
- running `/autoresearch off`
- confirming the widget disappears immediately
