### PR TITLE
Fix Cloud Code Assist 400 from patternProperties in log_experiment

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -181,7 +181,7 @@ const InitParams = Type.Object({
   ),
 });
 
-const LogParams = Type.Object({
+export const LogParams = Type.Object({
   commit: Type.String({ description: "Git commit hash (short, 7 chars)" }),
   metric: Type.Number({
     description:
@@ -192,7 +192,8 @@ const LogParams = Type.Object({
     description: "Short description of what this experiment tried",
   }),
   metrics: Type.Optional(
-    Type.Record(Type.String(), Type.Number(), {
+    Type.Object({}, {
+      additionalProperties: Type.Number(),
       description:
         'Additional metrics to track as { name: value } pairs, e.g. { "compile_µs": 4200, "render_µs": 9800 }. These are shown alongside the primary metric for tradeoff monitoring.',
     })
@@ -204,7 +205,8 @@ const LogParams = Type.Object({
     })
   ),
   asi: Type.Optional(
-    Type.Record(Type.String(), Type.Unknown(), {
+    Type.Object({}, {
+      additionalProperties: Type.Unknown(),
       description:
         'Actionable Side Information — structured diagnostics for this run. Free-form key/value pairs. Parsed ASI from run_experiment output is merged automatically; use this to add or override fields.',
     })

--- a/tests/log-params-schema.test.mjs
+++ b/tests/log-params-schema.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LogParams } from "../extensions/pi-autoresearch/index.ts";
+
+function collectKeyPaths(value, targetKey, path = "$", hits = []) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectKeyPaths(item, targetKey, `${path}[${index}]`, hits));
+    return hits;
+  }
+
+  if (!value || typeof value !== "object") {
+    return hits;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (key === targetKey) {
+      hits.push(childPath);
+    }
+    collectKeyPaths(child, targetKey, childPath, hits);
+  }
+
+  return hits;
+}
+
+test("log_experiment schema should avoid patternProperties for Cloud Code Assist compatibility", () => {
+  const patternPropertyPaths = collectKeyPaths(LogParams, "patternProperties");
+
+  assert.equal(
+    patternPropertyPaths.length,
+    0,
+    `unexpected patternProperties found in LogParams schema at: ${patternPropertyPaths.join(", ")}`,
+  );
+
+  const serialized = JSON.stringify(LogParams);
+  assert.match(
+    serialized,
+    /"additionalProperties"/,
+    "expected LogParams schema to keep dynamic object support via additionalProperties",
+  );
+});


### PR DESCRIPTION
## Summary
Fixes Cloud Code Assist request validation failures when `pi-autoresearch` is loaded with Antigravity Claude models.

Closes #43.

## Root cause
`log_experiment` used `Type.Record(...)` for `metrics` and `asi`.
TypeBox emits `patternProperties` for record schemas, and Cloud Code Assist function declaration validation rejects `patternProperties`.

## Changes
1. `extensions/pi-autoresearch/index.ts`
   - `metrics` schema changed from `Type.Record(Type.String(), Type.Number(), ...)` to
     `Type.Object({}, { additionalProperties: Type.Number(), ... })`
   - `asi` schema changed from `Type.Record(Type.String(), Type.Unknown(), ...)` to
     `Type.Object({}, { additionalProperties: Type.Unknown(), ... })`
   - Exported `LogParams` for regression testing.

2. `tests/log-params-schema.test.mjs`
   - Added a regression test that recursively inspects `LogParams` and fails if any `patternProperties` key appears.
   - Also asserts dynamic key support remains present via `additionalProperties`.

## Verification
### Repro before fix (same commit baseline)
```bash
pi --no-session --no-extensions \
  -e ~/.pi/agent/git/github.com/davebcn87/pi-autoresearch/extensions/pi-autoresearch/index.ts \
  --model google-antigravity/claude-opus-4-6-thinking \
  -p "say OK"
```
Returned:
```text
Cloud Code Assist API error (400): Invalid JSON payload received. Unknown name "patternProperties" ...
```

### Behavior after fix
Same command no longer returns schema validation error. In my environment the request now proceeds to provider quota validation and returns:
```text
Cloud Code Assist API error (429): You have exhausted your capacity on this model...
```
This confirms the request payload now passes function schema validation.

### Tests run
```bash
node --experimental-strip-types --test tests/log-params-schema.test.mjs
bash tests/finalize_test.sh
```
Both passed.
