### PR TITLE
Fix agent_end auto-resume race condition

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1369,7 +1369,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     resumeMsg += ` ${BENCHMARK_GUARDRAIL}`;
 
     runtime.autoResumeTurns++;
-    pi.sendUserMessage(resumeMsg);
+    setTimeout(() => pi.sendUserMessage(resumeMsg), 0);
   });
 
   // When in autoresearch mode, add a static note to the system prompt.


### PR DESCRIPTION
## Summary

- Fix "Agent is already processing" error that breaks unattended autoresearch loops by deferring the resume message with `setTimeout(0)`

## Problem

During long-running autoresearch sessions, the `agent_end` handler calls `pi.sendUserMessage()` to auto-resume the experiment loop. However, `agent_end` fires from inside the agent loop — before `finishRun()` clears `activeRun` and `isStreaming` in its `finally` block. This means the agent is still technically "processing" when the resume message is sent, causing:

```
Extension "<runtime>" error: Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.
```

This silently stops the loop and requires manual intervention, defeating the purpose of overnight autonomous runs.

## Fix

Wrap the `sendUserMessage` call in `setTimeout(0)` to defer it to the next macrotask. By that point, `finishRun()` has synchronously cleared `activeRun` and `isStreaming`, so `prompt()` succeeds.

This is the same pattern the Pi framework itself uses for auto-retry after `agent_end` (see `agent-session.ts` `_handleRetryableError`).

### Why not `deliverAs: "followUp"`?

The `followUp` queue is drained by the agent loop *before* `agent_end` is emitted. A message queued during `agent_end` arrives after the drain has already happened, so it sits in the queue indefinitely — requiring the user to manually send it via ALT+UP.

## Test plan

- [x] Ran autoresearch session long enough for the agent to hit context limits and trigger auto-resume
- [x] Verified the loop continues without manual intervention

Fixes davebcn87/pi-autoresearch#38