### PR TITLE
feat: move session files to ~/.pi/autoresearch/ outside project git tree

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -29,8 +29,8 @@ import { createServer, type Server, type ServerResponse } from "node:http";
 
 import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { randomBytes } from "node:crypto";
-import { tmpdir } from "node:os";
+import { randomBytes, createHash } from "node:crypto";
+import { tmpdir, homedir } from "node:os";
 
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
@@ -505,6 +505,25 @@ function validateWorkDir(ctxCwd: string): string | null {
     return `workingDir "${workDir}" (from autoresearch.config.json) does not exist.`;
   }
   return null;
+}
+
+/**
+ * Resolve the session directory for autoresearch files.
+ * All session files (jsonl, md, sh, checks.sh, ideas.md) live here,
+ * completely outside the project's git tree.
+ *
+ * Path: ~/.pi/autoresearch/<basename>-<8-char-hash>/
+ * The hash is derived from the full resolved working directory path,
+ * ensuring a stable 1:1 mapping.
+ */
+function resolveSessionDir(ctxCwd: string): string {
+  const workDir = resolveWorkDir(ctxCwd);
+  const hash = createHash("sha256").update(workDir).digest("hex").slice(0, 8);
+  const basename = path.basename(workDir).replace(/[^a-zA-Z0-9._-]/g, "-");
+  const slug = `${basename}-${hash}`;
+  const sessionDir = path.join(homedir(), ".pi", "autoresearch", slug);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  return sessionDir;
 }
 
 /** Baseline = first experiment in current segment */
@@ -1043,11 +1062,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     let state = runtime.state;
 
-    // Resolve effective working directory (config stays in ctx.cwd, files in workDir)
-    const workDir = resolveWorkDir(ctx.cwd);
+    // Resolve session directory (files live outside the project git tree)
+    const sessionDir = resolveSessionDir(ctx.cwd);
 
-    // Primary: read from autoresearch.jsonl (alongside autoresearch.md/sh)
-    const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+    // Primary: read from autoresearch.jsonl in the session directory
+    const jsonlPath = path.join(sessionDir, "autoresearch.jsonl");
     let loadedFromJsonl = false;
     try {
       if (fs.existsSync(jsonlPath)) {
@@ -1149,7 +1168,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
     // Auto-enter autoresearch mode only when a persisted experiment log exists
-    runtime.autoresearchMode = fs.existsSync(path.join(workDir, "autoresearch.jsonl"));
+    runtime.autoresearchMode = fs.existsSync(path.join(sessionDir, "autoresearch.jsonl"));
 
     updateWidget(ctx);
   };
@@ -1358,8 +1377,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     // Auto-continue: send a message to resume the loop
     // The agent reads autoresearch.md on startup which has all context
-    const workDir = resolveWorkDir(ctx.cwd);
-    const ideasPath = path.join(workDir, "autoresearch.ideas.md");
+    const sessionDir = resolveSessionDir(ctx.cwd);
+    const ideasPath = path.join(sessionDir, "autoresearch.ideas.md");
     const hasIdeas = fs.existsSync(ideasPath);
 
     let resumeMsg = "Autoresearch loop ended (likely context limit). Resume the experiment loop — read autoresearch.md and git log for context.";
@@ -1378,20 +1397,23 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     const runtime = getRuntime(ctx);
     if (!runtime.autoresearchMode) return;
 
+    const sessionDir = resolveSessionDir(ctx.cwd);
     const workDir = resolveWorkDir(ctx.cwd);
-    const mdPath = path.join(workDir, "autoresearch.md");
-    const ideasPath = path.join(workDir, "autoresearch.ideas.md");
+    const mdPath = path.join(sessionDir, "autoresearch.md");
+    const ideasPath = path.join(sessionDir, "autoresearch.ideas.md");
     const hasIdeas = fs.existsSync(ideasPath);
 
-    const checksPath = path.join(workDir, "autoresearch.checks.sh");
+    const checksPath = path.join(sessionDir, "autoresearch.checks.sh");
     const hasChecks = fs.existsSync(checksPath);
 
     let extra =
       "\n\n## Autoresearch Mode (ACTIVE)" +
       "\nYou are in autoresearch mode. Optimize the primary metric through an autonomous experiment loop." +
       "\nUse init_experiment, run_experiment, and log_experiment tools. NEVER STOP until interrupted." +
+      `\nSession directory: ${sessionDir} — all autoresearch files live here (md, sh, jsonl, ideas).` +
+      `\nProject directory: ${workDir} — code under test lives here. Git operations happen here.` +
       `\nExperiment rules: ${mdPath} — read this file at the start of every session and after compaction.` +
-      "\nWrite promising but deferred optimizations as bullet points to autoresearch.ideas.md — don't let good ideas get lost." +
+      `\nWrite promising but deferred optimizations as bullet points to ${ideasPath} — don't let good ideas get lost.` +
       `\n${BENCHMARK_GUARDRAIL}` +
       "\nIf the user sends a follow-on message while an experiment is running, finish the current run_experiment + log_experiment cycle first, then address their message in the next iteration.";
 
@@ -1465,10 +1487,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       // Read max experiments from config file (config always in ctx.cwd)
       state.maxExperiments = readMaxExperiments(ctx.cwd);
 
-      // Write config header to jsonl (append for re-init, create for first)
+      // Write config header to jsonl in session directory (outside project git tree)
+      const sessionDir = resolveSessionDir(ctx.cwd);
       const workDir = resolveWorkDir(ctx.cwd);
       try {
-        const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+        const jsonlPath = path.join(sessionDir, "autoresearch.jsonl");
         const config = JSON.stringify({
           type: "config",
           name: state.name,
@@ -1481,7 +1504,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         } else {
           fs.writeFileSync(jsonlPath, config + "\n");
         }
-        broadcastDashboardUpdate(workDir);
+        broadcastDashboardUpdate(sessionDir);
       } catch (e) {
         return {
           content: [{
@@ -1502,7 +1525,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return {
         content: [{
           type: "text",
-          text: `✅ Experiment initialized: "${state.name}"${reinitNote}\nMetric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)${limitNote}${workDirNote}\nConfig written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
+          text: `✅ Experiment initialized: "${state.name}"${reinitNote}\nMetric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)${limitNote}${workDirNote}\nSession directory: ${sessionDir}\nConfig written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
         }],
         details: { state: cloneExperimentState(state) },
       };
@@ -1552,6 +1575,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         };
       }
       const workDir = resolveWorkDir(ctx.cwd);
+      const sessionDir = resolveSessionDir(ctx.cwd);
 
       // Block if max experiments limit already reached
       if (state.maxExperiments !== null) {
@@ -1566,28 +1590,33 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       const timeout = (params.timeout_seconds ?? 600) * 1000;
 
-      // Guard: if autoresearch.sh exists, only allow running it
-      const autoresearchShPath = path.join(workDir, "autoresearch.sh");
-      if (fs.existsSync(autoresearchShPath) && !isAutoresearchShCommand(params.command)) {
-        return {
-          content: [{
-            type: "text",
-            text: `❌ autoresearch.sh exists — you must run it instead of a custom command.\n\nFound: ${autoresearchShPath}\nYour command: ${params.command}\n\nUse: run_experiment({ command: "bash autoresearch.sh" }) or run_experiment({ command: "./autoresearch.sh" })`,
-          }],
-          details: {
-            command: params.command,
-            exitCode: null,
-            durationSeconds: 0,
-            passed: false,
-            crashed: true,
-            timedOut: false,
-            tailOutput: "",
-            checksPass: null,
-            checksTimedOut: false,
-            checksOutput: "",
-            checksDuration: 0,
-          } as RunDetails,
-        };
+      // Guard: if autoresearch.sh exists in session dir, only allow running it.
+      // Automatically rewrite the command to use the full session dir path.
+      const autoresearchShPath = path.join(sessionDir, "autoresearch.sh");
+      if (fs.existsSync(autoresearchShPath)) {
+        if (!isAutoresearchShCommand(params.command)) {
+          return {
+            content: [{
+              type: "text",
+              text: `❌ autoresearch.sh exists — you must run it instead of a custom command.\n\nFound: ${autoresearchShPath}\nYour command: ${params.command}\n\nUse: run_experiment({ command: "bash autoresearch.sh" }) or run_experiment({ command: "./autoresearch.sh" })`,
+            }],
+            details: {
+              command: params.command,
+              exitCode: null,
+              durationSeconds: 0,
+              passed: false,
+              crashed: true,
+              timedOut: false,
+              tailOutput: "",
+              checksPass: null,
+              checksTimedOut: false,
+              checksOutput: "",
+              checksDuration: 0,
+            } as RunDetails,
+          };
+        }
+        // Rewrite the command to use the full session dir path
+        params.command = `bash ${autoresearchShPath}`;
       }
 
       advanceIterationTracking(runtime, ctx);
@@ -1780,7 +1809,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       let checksOutput = "";
       let checksDuration = 0;
 
-      const checksPath = path.join(workDir, "autoresearch.checks.sh");
+      const checksPath = path.join(sessionDir, "autoresearch.checks.sh");
       if (benchmarkPassed && fs.existsSync(checksPath)) {
         const checksTimeout = (params.checks_timeout_seconds ?? 300) * 1000;
         const ct0 = Date.now();
@@ -2078,6 +2107,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         };
       }
       const workDir = resolveWorkDir(ctx.cwd);
+      const sessionDir = resolveSessionDir(ctx.cwd);
       const secondaryMetrics = params.metrics ?? {};
 
       // Gate: prevent "keep" when last run's checks failed
@@ -2274,9 +2304,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         }
       }
 
-      // Persist to autoresearch.jsonl (always, regardless of status)
+      // Persist to autoresearch.jsonl in session directory (outside project git tree)
       try {
-        const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+        const jsonlPath = path.join(sessionDir, "autoresearch.jsonl");
         const jsonlEntry: Record<string, unknown> = {
           run: state.results.length,
           ...experiment,
@@ -2284,18 +2314,17 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         // Only write asi if present (keep lines compact when no ASI)
         if (!mergedASI) delete jsonlEntry.asi;
         fs.appendFileSync(jsonlPath, JSON.stringify(jsonlEntry) + "\n");
-        broadcastDashboardUpdate(workDir);
+        broadcastDashboardUpdate(sessionDir);
       } catch (e) {
         text += `\n⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}`;
       }
 
-      // Auto-revert on discard/crash/checks_failed — revert all files except autoresearch session files
+      // Auto-revert on discard/crash/checks_failed — clean revert, no files to protect
+      // (all session files live in ~/.pi/autoresearch/, outside the project git tree)
       if (params.status !== "keep") {
         try {
-          const protectedFiles = ["autoresearch.jsonl", "autoresearch.md", "autoresearch.ideas.md", "autoresearch.sh", "autoresearch.checks.sh"];
-          const stageCmd = protectedFiles.map((f) => `git add "${path.join(workDir, f)}" 2>/dev/null || true`).join("; ");
-          await pi.exec("bash", ["-c", `${stageCmd}; git checkout -- .; git clean -fd 2>/dev/null`], { cwd: workDir, timeout: 10000 });
-          text += `\n📝 Git: reverted changes (${params.status}) — autoresearch files preserved`;
+          await pi.exec("bash", ["-c", "git checkout -- . && git clean -fd"], { cwd: workDir, timeout: 10000 });
+          text += `\n📝 Git: reverted changes (${params.status})`;
         } catch (e) {
           text += `\n⚠️ Git revert failed: ${e instanceof Error ? e.message : String(e)}`;
         }
@@ -2417,7 +2446,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const runtime = getRuntime(ctx);
       const state = runtime.state;
       if (state.results.length === 0) {
-        if (!runtime.autoresearchMode && !fs.existsSync(path.join(resolveWorkDir(ctx.cwd), "autoresearch.md"))) {
+        if (!runtime.autoresearchMode && !fs.existsSync(path.join(resolveSessionDir(ctx.cwd), "autoresearch.md"))) {
           ctx.ui.notify("No experiments yet — run /autoresearch to get started", "info");
         } else {
           ctx.ui.notify("No experiments yet", "info");
@@ -2606,8 +2635,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     return cachedLogoDataUrl;
   }
 
-  function readJsonlContent(workDir: string): string {
-    return fs.readFileSync(path.join(workDir, "autoresearch.jsonl"), "utf-8").trim();
+  function readJsonlContent(sessionDir: string): string {
+    return fs.readFileSync(path.join(sessionDir, "autoresearch.jsonl"), "utf-8").trim();
   }
 
   function extractSessionName(jsonlContent: string): string {
@@ -2697,9 +2726,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     return CONTENT_TYPES[ext] ?? "application/octet-stream";
   }
 
-  function resolveServedFile(workDir: string, requestPath: string): string | null {
+  function resolveServedFile(sessionDir: string, requestPath: string): string | null {
     if (requestPath === "/") return dashboardServerHtmlPath;
-    if (requestPath === "/autoresearch.jsonl") return path.join(workDir, "autoresearch.jsonl");
+    if (requestPath === "/autoresearch.jsonl") return path.join(sessionDir, "autoresearch.jsonl");
     return null;
   }
 
@@ -2783,8 +2812,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   }
 
   async function exportDashboard(ctx: ExtensionContext): Promise<void> {
-    const workDir = resolveWorkDir(ctx.cwd);
-    const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+    const sessionDir = resolveSessionDir(ctx.cwd);
+    const jsonlPath = path.join(sessionDir, "autoresearch.jsonl");
 
     if (!fs.existsSync(jsonlPath)) {
       ctx.ui.notify("No autoresearch.jsonl found \u2014 run some experiments first", "error");
@@ -2792,8 +2821,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     }
 
     try {
-      const dashboardHtmlPath = writeDashboardFile(workDir);
-      const port = await startStaticServer(workDir, dashboardHtmlPath);
+      const dashboardHtmlPath = writeDashboardFile(sessionDir);
+      const port = await startStaticServer(sessionDir, dashboardHtmlPath);
       const url = `http://127.0.0.1:${port}`;
       openInBrowser(url);
       ctx.ui.notify(`Dashboard at ${url} (live updates)`, "info");
@@ -2843,7 +2872,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       if (command === "clear") {
-        const jsonlPath = path.join(resolveWorkDir(ctx.cwd), "autoresearch.jsonl");
+        const sessionDir = resolveSessionDir(ctx.cwd);
+        const jsonlPath = path.join(sessionDir, "autoresearch.jsonl");
         runtime.autoresearchMode = false;
         runtime.dashboardExpanded = false;
         runtime.lastAutoResumeTime = 0;
@@ -2879,7 +2909,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       runtime.autoresearchMode = true;
       runtime.autoResumeTurns = 0;
 
-      const mdPath = path.join(resolveWorkDir(ctx.cwd), "autoresearch.md");
+      const mdPath = path.join(resolveSessionDir(ctx.cwd), "autoresearch.md");
       const hasRules = fs.existsSync(mdPath);
 
       if (hasRules) {

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -18,12 +18,15 @@ Autonomous experiment loop: try ideas, keep what works, discard what doesn't, ne
 1. Ask (or infer): **Goal**, **Command**, **Metric** (+ direction), **Files in scope**, **Constraints**.
 2. `git checkout -b autoresearch/<goal>-<date>`
 3. Read the source files. Understand the workload deeply before writing anything.
-4. Write `autoresearch.md` and `autoresearch.sh` (see below). Commit both.
-5. `init_experiment` → run baseline → `log_experiment` → start looping immediately.
+4. Call `init_experiment` first — it returns the **session directory** path where all autoresearch files live (outside the project git tree, under `~/.pi/autoresearch/`).
+5. Write `autoresearch.md` and `autoresearch.sh` to the **session directory** (not the project directory). These files never touch git.
+6. Run baseline → `log_experiment` → start looping immediately.
+
+**Important:** All autoresearch files (`autoresearch.md`, `autoresearch.sh`, `autoresearch.checks.sh`, `autoresearch.ideas.md`, `autoresearch.jsonl`) live in the session directory. The project directory is only for code under test. Git operations (commit, revert) are clean — no files to protect.
 
 ### `autoresearch.md`
 
-This is the heart of the session. A fresh agent with no context should be able to read this file and run the loop effectively. Invest time making it excellent.
+This is the heart of the session. A fresh agent with no context should be able to read this file and run the loop effectively. Invest time making it excellent. **Write this file to the session directory** (shown in `init_experiment` output).
 
 ```markdown
 # Autoresearch: <goal>
@@ -36,7 +39,10 @@ This is the heart of the session. A fresh agent with no context should be able t
 - **Secondary**: <name>, <name>, ... — independent tradeoff monitors
 
 ## How to Run
-`./autoresearch.sh` — outputs `METRIC name=number` lines.
+`run_experiment({ command: "bash autoresearch.sh" })` — the tool resolves the session dir path automatically.
+
+## Project Directory
+<Full path to the project under test — where code changes happen.>
 
 ## Files in Scope
 <Every file the agent may modify, with a brief note on what it does.>
@@ -56,7 +62,7 @@ Update `autoresearch.md` periodically — especially the "What's Been Tried" sec
 
 ### `autoresearch.sh`
 
-Bash script (`set -euo pipefail`) that: pre-checks fast (syntax errors in <1s), runs the benchmark, and outputs structured lines to stdout. Keep the script fast — every second is multiplied by hundreds of runs.
+Bash script (`set -euo pipefail`) that: pre-checks fast (syntax errors in <1s), runs the benchmark, and outputs structured lines to stdout. **Write this file to the session directory.** The tool runs it with `cwd` set to the project directory, so all relative paths in the script resolve against the project.
 
 **For fast, noisy benchmarks** (< 5s), run the workload multiple times inside the script and report the median. This produces stable data points and makes the confidence score reliable from the start. Slow workloads (ML training, large builds) don't need this — single runs are fine.
 
@@ -86,7 +92,7 @@ Use `log_experiment`'s `asi` parameter to annotate each run with **whatever woul
 JSON config file that lives in the pi session's working directory (`ctx.cwd`). Supported fields:
 
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
-- **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`autoresearch.jsonl`, `autoresearch.md`, `autoresearch.sh`, `autoresearch.checks.sh`, `autoresearch.ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays in `ctx.cwd`. Fails if the directory doesn't exist.
+- **`workingDir`** (string) — override the project directory for command execution and git operations. The session directory is derived from this path. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays in `ctx.cwd`. Fails if the directory doesn't exist.
 
 ```json
 {
@@ -97,7 +103,7 @@ JSON config file that lives in the pi session's working directory (`ctx.cwd`). S
 
 ### `autoresearch.checks.sh` (optional)
 
-Bash script (`set -euo pipefail`) for backpressure/correctness checks: tests, types, lint, etc. **Only create this file when the user's constraints require correctness validation** (e.g., "tests must pass", "types must check").
+Bash script (`set -euo pipefail`) for backpressure/correctness checks: tests, types, lint, etc. **Write to the session directory.** Only create this file when the user's constraints require correctness validation (e.g., "tests must pass", "types must check"). The tool runs it with `cwd` set to the project directory.
 
 When this file exists:
 - Runs automatically after every **passing** benchmark in `run_experiment`.
@@ -135,7 +141,7 @@ pnpm typecheck 2>&1 | grep -i error || true
 
 ## Ideas Backlog
 
-When you discover complex but promising optimizations that you won't pursue right now, **append them as bullets to `autoresearch.ideas.md`**. Don't let good ideas get lost.
+When you discover complex but promising optimizations that you won't pursue right now, **append them as bullets to `autoresearch.ideas.md` in the session directory**. Don't let good ideas get lost.
 
 On resume (context limit, crash), check `autoresearch.ideas.md` — prune stale/tried entries, experiment with the rest. When all paths are exhausted, delete the file and write a final summary.
 

--- a/skills/autoresearch-finalize/SKILL.md
+++ b/skills/autoresearch-finalize/SKILL.md
@@ -81,6 +81,8 @@ After the script finishes, report to the user:
 - Overall metric improvement (baseline → best)
 - Show the cleanup commands from the script's summary output
 
+Note: All autoresearch session files (jsonl, md, sh, ideas) live in `~/.pi/autoresearch/<session>/`, not in the project directory. They are never included in branches.
+
 ## Edge Cases
 
 - **Only 1 kept experiment**: One branch is fine — don't force splits.

--- a/skills/autoresearch-finalize/finalize.sh
+++ b/skills/autoresearch-finalize/finalize.sh
@@ -42,15 +42,6 @@ info() { echo -e "${GREEN}$1${NC}"; }
 cleanup_data() { if [ -d "${DATA_DIR:-}" ]; then rm -rf "$DATA_DIR"; fi; }
 fail() { cleanup_data; echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
 
-# Session artifacts are matched by basename so they're excluded regardless of
-# directory depth — autoresearch runs may happen in subdirectories (e.g.
-# libs/polaris/autoresearch.jsonl) and none should leak into PR branches.
-is_session_file() {
-  local base
-  base=$(basename "$1")
-  case "$base" in autoresearch.*) return 0;; *) return 1;; esac
-}
-
 # ---------------------------------------------------------------------------
 # Parse
 # ---------------------------------------------------------------------------
@@ -115,7 +106,7 @@ collect_group_files() {
   : > "$DATA_DIR/$group_index.files"
   while IFS= read -r -d '' changed_file; do
     [ -n "$changed_file" ] || continue
-    is_session_file "$changed_file" || echo "$changed_file" >> "$DATA_DIR/$group_index.files"
+    echo "$changed_file" >> "$DATA_DIR/$group_index.files"
   done < <(git diff --name-only -z "$prev_commit" "$last_commit")
 }
 
@@ -289,9 +280,7 @@ verify_union_matches_original() {
   git commit --allow-empty -m "verify: union of all groups" --quiet
 
   local non_session_diff=""
-  for changed_file in $(git diff --name-only HEAD "$FINAL_TREE" 2>/dev/null); do
-    is_session_file "$changed_file" || non_session_diff="$non_session_diff $changed_file"
-  done
+  non_session_diff=$(git diff --name-only HEAD "$FINAL_TREE" 2>/dev/null | tr '\n' ' ')
 
   git checkout "$ORIG_BRANCH" --quiet 2>/dev/null || true
   git branch -D "$verify_branch" 2>/dev/null || true
@@ -306,22 +295,11 @@ verify_union_matches_original() {
   return 0
 }
 
+# Session artifacts no longer live in the project directory (they're in ~/.pi/autoresearch/)
+# so this check is a no-op. Kept as a placeholder for future validations.
 verify_no_session_artifacts() {
-  local clean=true
-  for branch in "${CREATED_BRANCHES[@]}"; do
-    for changed_file in $(git diff-tree --no-commit-id --name-only -r "$(git rev-parse "$branch")" 2>/dev/null); do
-      if is_session_file "$changed_file"; then
-        echo -e "${RED}✗ Session artifact '$changed_file' in branch $branch!${NC}"
-        clean=false
-      fi
-    done
-  done
-
-  if [ "$clean" = true ]; then
-    echo -e "${GREEN}✓ No session artifacts in any branch.${NC}"
-    return 0
-  fi
-  return 1
+  echo -e "${GREEN}✓ Session files live outside project directory.${NC}"
+  return 0
 }
 
 verify_no_empty_commits() {
@@ -403,17 +381,11 @@ print_summary() {
   done
 
   echo ""
-  echo "Cleanup — after merging, delete the autoresearch branch and session files:"
+  echo "Cleanup — after merging, delete the autoresearch branch:"
   echo ""
   echo "  git branch -D $ORIG_BRANCH"
-  echo "  rm -f autoresearch.jsonl autoresearch.sh autoresearch.md autoresearch.ideas.md"
-
-  if [ -f "autoresearch.ideas.md" ]; then
-    echo ""
-    echo "Ideas backlog (from autoresearch.ideas.md):"
-    echo ""
-    sed 's/^/  /' autoresearch.ideas.md
-  fi
+  echo ""
+  echo "Session files live in ~/.pi/autoresearch/ and don't need cleanup."
 
   echo ""
   if [ "$STASHED" = true ]; then

--- a/tests/finalize_test.sh
+++ b/tests/finalize_test.sh
@@ -36,12 +36,8 @@ setup_repo() {
   # Autoresearch branch
   git checkout -b autoresearch/test-session --quiet
 
-  # Session files (should not end up in branches)
-  echo '{"type":"config","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}' > autoresearch.jsonl
-  echo "# Autoresearch session" > autoresearch.md
-  echo "#!/bin/bash" > autoresearch.sh
-  echo "- try X" > autoresearch.ideas.md
-  git add -A && git commit -m "add session files" --quiet
+  # Session files now live in ~/.pi/autoresearch/ (outside the project git tree)
+  # so they're never committed to the autoresearch branch.
 
   # Kept experiment 1: modify file_a
   echo "optimized_a" > file_a.txt
@@ -174,14 +170,8 @@ EOF
 
   bash "$FINALIZE" $REPO/groups.json >/dev/null 2>&1 || { fail_test "no session artifacts" "Script failed"; cleanup_repo "$REPO"; return; }
 
-  for f in autoresearch.jsonl autoresearch.sh autoresearch.md autoresearch.ideas.md; do
-    if git show "autoresearch/test/01-all":"$f" &>/dev/null 2>&1; then
-      fail_test "no session artifacts" "Session file $f found in branch"
-      cleanup_repo "$REPO"
-      return
-    fi
-  done
-
+  # Session files no longer exist in the project directory, so this check
+  # is trivially satisfied. The branch should only contain code changes.
   pass "no session artifacts"
   cleanup_repo "$REPO"
 }
@@ -347,7 +337,7 @@ EOF
   # Check output contains key sections
   echo "$OUTPUT" | grep -q "Optimize file A" || { fail_test "summary output" "Missing group title in output"; rm -f "$GROUPS_JSON"; cleanup_repo "$REPO"; return; }
   echo "$OUTPUT" | grep -q "Cleanup" || { fail_test "summary output" "Missing cleanup in output"; rm -f "$GROUPS_JSON"; cleanup_repo "$REPO"; return; }
-  echo "$OUTPUT" | grep -q "autoresearch.ideas.md" || { fail_test "summary output" "Missing ideas in output"; rm -f "$GROUPS_JSON"; cleanup_repo "$REPO"; return; }
+  # Ideas backlog now lives in ~/.pi/autoresearch/ session dir, not referenced in finalize summary
 
   # No summary file should be written to disk
   [ ! -f "autoresearch-finalize-summary.md" ] || { fail_test "summary output" "Summary file written to disk — should only print"; rm -f "$GROUPS_JSON"; cleanup_repo "$REPO"; return; }
@@ -674,14 +664,10 @@ test_nested_session_artifacts() {
 
   git checkout -b autoresearch/nested-test --quiet
 
-  # Session files in a subdirectory (like world's libraries/javascript/polaris/)
-  echo '{"type":"config"}' > libs/polaris/autoresearch.jsonl
-  echo "# session" > libs/polaris/autoresearch.md
-  echo "#!/bin/bash" > libs/polaris/autoresearch.sh
-  echo "- idea" > libs/polaris/autoresearch.ideas.md
-  echo "#!/bin/bash" > libs/polaris/autoresearch.checks.sh
+  # Session files now live in ~/.pi/autoresearch/ (outside the project git tree)
+  # Only code changes are committed to the autoresearch branch.
   echo "optimized" > libs/polaris/component.ts
-  git add -A && git commit -m "optimize + session files" --quiet
+  git add -A && git commit -m "optimize component" --quiet
 
   local BASE FINAL
   BASE=$(git merge-base HEAD main)
@@ -707,19 +693,8 @@ EOF
   local OUTPUT
   OUTPUT=$(bash "$FINALIZE" "$REPO/groups.json" 2>&1) || { fail_test "nested session artifacts" "Script failed: $OUTPUT"; cleanup_repo "$REPO"; return; }
 
-  # Branch should only have component.ts, not any autoresearch.* files
+  # Branch should have component.ts
   local BRANCH="autoresearch/test/01-optimize"
-  for f in $(git diff-tree --no-commit-id --name-only -r "$(git rev-parse "$BRANCH")"); do
-    local base
-    base=$(basename "$f")
-    case "$base" in
-      autoresearch.*)
-        fail_test "nested session artifacts" "Session artifact '$f' leaked into branch"
-        cleanup_repo "$REPO"
-        return
-        ;;
-    esac
-  done
 
   # Verify the actual code file is there
   local CONTENT


### PR DESCRIPTION
## Problem

All autoresearch session files (`autoresearch.jsonl`, `.md`, `.sh`, `.checks.sh`, `.ideas.md`) currently live in the project's working directory, forcing the agent to juggle files during git operations:

- **Git revert** needs to stage 5 protected files before checking out
- **Git commit** via `git add -A` picks up session files alongside code changes
- **Finalize** needs `is_session_file()` filtering on every diff
- The agent is constantly warned about file protection in the system prompt

## Solution

Move all session files to `~/.pi/autoresearch/<project-basename>-<8-char-hash>/`, completely outside the project's git tree.

The session directory is derived from the project path using a SHA256 hash, ensuring a stable 1:1 mapping. Scripts (`autoresearch.sh`, `checks.sh`) live in the session dir but execute with `cwd` set to the project directory, so relative paths in scripts still resolve correctly.

`run_experiment` auto-rewrites `bash autoresearch.sh` commands to use the full session dir path — transparent to the agent.

## What simplified

| Before | After |
|---|---|
| Git revert: stage 5 protected files, then checkout | Simple `git checkout` + `git clean` |
| Git commit: `git add -A` picks up session files | Only code changes |
| Finalize: `is_session_file()` filter on every diff | No filtering needed |
| System prompt: file juggling warnings | Clear session dir vs project dir paths |

## Changes

- **`index.ts`**: Added `resolveSessionDir()`, updated ~30 file path references, simplified git revert, init_experiment returns session dir path, system prompt includes both directories
- **`SKILL.md` (create)**: Updated setup flow — `init_experiment` first (returns session dir), then write files there
- **`SKILL.md` (finalize)**: Noted session files are external
- **`finalize.sh`**: Removed `is_session_file()` and all its call sites
- **`finalize_test.sh`**: Updated tests to not create session files in git (matches new behavior)

## Migration

This is a breaking change for existing sessions: the extension will no longer find session files in the project directory. Users with in-progress sessions should copy their `autoresearch.*` files to the new session directory (shown by `init_experiment` or in the system prompt).
