### PR TITLE
feat: add MiniMax provider support (MiniMax-M2.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ pnpm typecheck
 1. **Install pi** — follow the instructions at [pi.dev](https://pi.dev/)
 2. **An API key** for your preferred LLM provider (configured in pi)
 
+### Using MiniMax
+
+Set `MINIMAX_API_KEY` to use [MiniMax](https://www.minimaxi.com/) models. pi-autoresearch registers two MiniMax models automatically:
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex. |
+| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile. |
+
+```bash
+export MINIMAX_API_KEY=your-api-key-here
+```
+
+Then select a MiniMax model in pi's model picker. API endpoint: `https://api.minimax.io`.
+
 ## Controlling costs
 
 Autoresearch loops run autonomously and can burn through tokens. Two ways to cap spend:

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -979,6 +979,36 @@ function renderDashboardLines(
 // ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
+  // ---------------------------------------------------------------------------
+  // Register MiniMax provider (MiniMax-M2.7 and MiniMax-M2.7-highspeed)
+  // Set MINIMAX_API_KEY to enable. Uses MiniMax's Anthropic-compatible endpoint.
+  // ---------------------------------------------------------------------------
+  pi.registerProvider("minimax", {
+    baseUrl: "https://api.minimax.io/anthropic",
+    apiKey: "MINIMAX_API_KEY",
+    api: "anthropic-messages",
+    models: [
+      {
+        id: "MiniMax-M2.7",
+        name: "MiniMax M2.7",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+        contextWindow: 204800,
+        maxTokens: 131072,
+      },
+      {
+        id: "MiniMax-M2.7-highspeed",
+        name: "MiniMax M2.7 High Speed",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0.6, output: 2.4, cacheRead: 0.06, cacheWrite: 0.375 },
+        contextWindow: 204800,
+        maxTokens: 131072,
+      },
+    ],
+  });
+
   const MAX_AUTORESUME_TURNS = 20;
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";

--- a/tests/minimax_test.sh
+++ b/tests/minimax_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Integration test for MiniMax provider.
+# Verifies MINIMAX_API_KEY is set and that the MiniMax API is reachable
+# using the Anthropic-compatible endpoint registered by pi-autoresearch.
+#
+# Usage:
+#   MINIMAX_API_KEY=<key> bash tests/minimax_test.sh
+#
+# Exit codes: 0 = pass, 1 = fail, 77 = skip (no API key)
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); echo -e "${GREEN}✓ $1${NC}"; }
+skip() { echo -e "${YELLOW}⚠ $1${NC}"; }
+fail_test() { TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); echo -e "${RED}✗ $1${NC}"; echo "  $2"; }
+
+echo "=== MiniMax provider tests ==="
+echo ""
+
+# --- Unit test: verify provider configuration constants ---
+
+echo "--- Unit tests ---"
+
+# Verify expected models are defined in the extension source
+EXT_FILE="$(cd "$(dirname "$0")/.." && pwd)/extensions/pi-autoresearch/index.ts"
+
+if grep -q '"MiniMax-M2.7"' "$EXT_FILE" && grep -q '"MiniMax-M2.7-highspeed"' "$EXT_FILE"; then
+  pass "Extension registers MiniMax-M2.7 and MiniMax-M2.7-highspeed models"
+else
+  fail_test "Extension does not register MiniMax models" "Expected 'MiniMax-M2.7' and 'MiniMax-M2.7-highspeed' in $EXT_FILE"
+fi
+
+if grep -q 'api.minimax.io/anthropic' "$EXT_FILE"; then
+  pass "Extension uses MiniMax Anthropic-compatible endpoint"
+else
+  fail_test "Wrong or missing base URL" "Expected 'api.minimax.io/anthropic' in $EXT_FILE"
+fi
+
+if grep -q '"MINIMAX_API_KEY"' "$EXT_FILE"; then
+  pass "Extension reads MINIMAX_API_KEY for authentication"
+else
+  fail_test "MINIMAX_API_KEY not referenced" "Expected '\"MINIMAX_API_KEY\"' in $EXT_FILE"
+fi
+
+if grep -q '"anthropic-messages"' "$EXT_FILE"; then
+  pass "Extension configures anthropic-messages API type"
+else
+  fail_test "API type not set to anthropic-messages" "Expected '\"anthropic-messages\"' in $EXT_FILE"
+fi
+
+echo ""
+echo "--- Integration tests ---"
+
+if [ -z "${MINIMAX_API_KEY:-}" ]; then
+  skip "MINIMAX_API_KEY not set — skipping live API call"
+  echo ""
+  echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed (integration skipped)"
+  exit "${TESTS_FAILED}"
+fi
+
+# Integration test: call MiniMax Anthropic-compatible API
+ENDPOINT="https://api.minimax.io/anthropic/v1/messages"
+REQUEST_BODY='{"model":"MiniMax-M2.7","max_tokens":256,"messages":[{"role":"user","content":"Reply with the single word: pong"}]}'
+
+HTTP_STATUS=$(curl -s -o /tmp/minimax_response.json -w "%{http_code}" \
+  -X POST "$ENDPOINT" \
+  -H "x-api-key: ${MINIMAX_API_KEY}" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d "$REQUEST_BODY" 2>/dev/null)
+
+if [ "$HTTP_STATUS" = "200" ]; then
+  # Extract text from any content block with type=text (model may also emit thinking blocks)
+  CONTENT=$(python3 -c "
+import json, sys
+d = json.load(open('/tmp/minimax_response.json'))
+texts = [b['text'] for b in d.get('content', []) if b.get('type') == 'text']
+print(texts[0] if texts else '')
+" 2>/dev/null || echo "")
+  if [ -n "$CONTENT" ]; then
+    pass "MiniMax-M2.7 API call succeeded (HTTP 200, response: '$CONTENT')"
+  else
+    fail_test "MiniMax-M2.7 API returned 200 but no text block in response" "$(cat /tmp/minimax_response.json)"
+  fi
+else
+  fail_test "MiniMax-M2.7 API call failed" "HTTP $HTTP_STATUS: $(cat /tmp/minimax_response.json)"
+fi
+
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+exit "${TESTS_FAILED}"


### PR DESCRIPTION
## Summary

- Explicitly registers **MiniMax-M2.7** and **MiniMax-M2.7-highspeed** as pi providers via `pi.registerProvider()`, using MiniMax's Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`)
- Users set `MINIMAX_API_KEY` to enable the models in pi's model picker — no additional configuration required
- Adds `tests/minimax_test.sh` with 4 unit tests (validate provider config in source) and 1 live integration test (real API call to MiniMax)
- Updates README with a **Using MiniMax** section under Prerequisites

## API details

MiniMax exposes an [Anthropic-compatible endpoint](https://platform.minimax.io/docs/api-reference/text-anthropic-api):
- Base URL: `https://api.minimax.io/anthropic`
- Auth: `x-api-key` header with `MINIMAX_API_KEY`
- API type: `anthropic-messages`

Models registered:

| Model | Context | Max output |
|-------|---------|------------|
| `MiniMax-M2.7` | 204 800 tokens | 131 072 tokens |
| `MiniMax-M2.7-highspeed` | 204 800 tokens | 131 072 tokens |

## Test plan

- [x] Unit tests pass: provider config matches expected values (model IDs, endpoint, API type, env var)
- [x] Integration test passes: live `MiniMax-M2.7` API call returns a text response
- [x] `tests/finalize_test.sh` unaffected