### PR TITLE
fix: update dashboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ pi install https://github.com/davebcn87/pi-autoresearch
 
 | Shortcut     | Description |
 |--------------|-------------|
-| `Ctrl+Alt+R` | Toggle dashboard expand/collapse (inline widget ↔ full results table above the editor) |
-| `Ctrl+Alt+X` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
+| `Ctrl+Shift+T` | Toggle dashboard expand/collapse (inline widget ↔ full results table above the editor) |
+| `Ctrl+Shift+F` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
 
 ### UI
 
 - **Status widget** — always visible above the editor: `🔬 autoresearch 12 runs 8 kept │ ★ total_µs: 15,200 (-12.3%) │ conf: 2.1×`
 - **Confidence score** — after 3+ runs, shows how the best improvement compares to the session noise floor. ≥2.0× (green) = likely real, 1.0–2.0× (yellow) = above noise but marginal, <1.0× (red) = within noise.
-- **Expanded dashboard** — `Ctrl+Alt+R` expands the widget into a full results table with columns for commit, metric, status, and description.
-- **Fullscreen overlay** — `Ctrl+Alt+X` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
+- **Expanded dashboard** — `Ctrl+Shift+T` expands the widget into a full results table with columns for commit, metric, status, and description.
+- **Fullscreen overlay** — `Ctrl+Shift+F` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
 
 ### Skills
 
@@ -139,8 +139,8 @@ The agent reads `autoresearch.jsonl`, groups kept experiments into logical chang
 ### 4. Monitor progress
 
 - **Widget** — always visible above the editor
-- **`Ctrl+Alt+R`** — expand/collapse the full results table inline
-- **`Ctrl+Alt+X`** — fullscreen scrollable dashboard overlay
+- **`Ctrl+Shift+T`** — expand/collapse the full results table inline
+- **`Ctrl+Shift+F`** — fullscreen scrollable dashboard overlay
 - **`/autoresearch export`** — open a live browser dashboard with chart and share card
 - **`Escape`** — interrupt anytime and ask for a summary
 

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ pi install https://github.com/davebcn87/pi-autoresearch
 
 ### Keyboard shortcuts
 
-| Shortcut | Description |
-|----------|-------------|
-| `Ctrl+X` | Toggle dashboard expand/collapse (inline widget ↔ full results table above the editor) |
-| `Ctrl+Shift+X` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
+| Shortcut     | Description |
+|--------------|-------------|
+| `Ctrl+Alt+R` | Toggle dashboard expand/collapse (inline widget ↔ full results table above the editor) |
+| `Ctrl+Alt+X` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
 
 ### UI
 
 - **Status widget** — always visible above the editor: `🔬 autoresearch 12 runs 8 kept │ ★ total_µs: 15,200 (-12.3%) │ conf: 2.1×`
 - **Confidence score** — after 3+ runs, shows how the best improvement compares to the session noise floor. ≥2.0× (green) = likely real, 1.0–2.0× (yellow) = above noise but marginal, <1.0× (red) = within noise.
-- **Expanded dashboard** — `Ctrl+X` expands the widget into a full results table with columns for commit, metric, status, and description.
-- **Fullscreen overlay** — `Ctrl+Shift+X` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
+- **Expanded dashboard** — `Ctrl+Alt+R` expands the widget into a full results table with columns for commit, metric, status, and description.
+- **Fullscreen overlay** — `Ctrl+Alt+X` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
 
 ### Skills
 
@@ -139,8 +139,8 @@ The agent reads `autoresearch.jsonl`, groups kept experiments into logical chang
 ### 4. Monitor progress
 
 - **Widget** — always visible above the editor
-- **`Ctrl+X`** — expand/collapse the full results table inline
-- **`Ctrl+Shift+X`** — fullscreen scrollable dashboard overlay
+- **`Ctrl+Alt+R`** — expand/collapse the full results table inline
+- **`Ctrl+Alt+X`** — fullscreen scrollable dashboard overlay
 - **`/autoresearch export`** — open a live browser dashboard with chart and share card
 - **`Escape`** — interrupt anytime and ask for a summary
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -8,7 +8,7 @@
  * - `run_experiment` tool — runs any command, times it, captures output, detects pass/fail
  * - `log_experiment` tool — records results with session-persisted state
  * - Status widget showing experiment count + best metric
- * - Ctrl+Alt+R toggle to expand/collapse full dashboard inline above the editor
+ * - Ctrl+Shift+T toggle to expand/collapse full dashboard inline above the editor
  * - Adds autoresearch guidance to the system prompt and points the agent at autoresearch.md
  * - Injects autoresearch.md into context on every turn via before_agent_start
  */
@@ -873,8 +873,8 @@ function renderDashboardLines(
     headerHint
       ? appendRightAlignedAdaptiveHint(headerLine, width, th, [
           headerHint,
-          "ctrl+alt+r collapse • full: ctrl+alt+x",
-          "ctrl+alt+r • ctrl+alt+x",
+          "ctrl+shift+t collapse • full: ctrl+shift+f",
+          "ctrl+shift+t • ctrl+shift+f",
         ])
       : truncateToWidth(headerLine, width, "…", true)
   );
@@ -1331,7 +1331,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               safeWidth,
               theme,
               rows,
-              "ctrl+alt+r collapse • ctrl+alt+x fullscreen"
+              "ctrl+shift+t collapse • ctrl+shift+f fullscreen"
             ),
           ];
         },
@@ -1424,9 +1424,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           const left = [...essential, ...optional].join("");
           return [
             appendRightAlignedAdaptiveHint(left, safeWidth, theme, [
-              "ctrl+alt+r expand • ctrl+alt+x fullscreen",
-              "ctrl+alt+r expand • full: ctrl+alt+x",
-              "ctrl+alt+r • ctrl+alt+x",
+              "ctrl+shift+t expand • ctrl+shift+f fullscreen",
+              "ctrl+shift+t expand • full: ctrl+shift+f",
+              "ctrl+shift+t • ctrl+shift+f",
             ]),
           ];
         },
@@ -2515,10 +2515,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Ctrl+Alt+R — toggle dashboard expand/collapse
+  // Ctrl+Shift+T — toggle dashboard expand/collapse
   // -----------------------------------------------------------------------
 
-  pi.registerShortcut("ctrl+alt+r", {
+  pi.registerShortcut("ctrl+shift+t", {
     description: "Toggle autoresearch dashboard",
     handler: async (ctx) => {
       const runtime = getRuntime(ctx);
@@ -2537,10 +2537,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Ctrl+Alt+X — fullscreen scrollable dashboard overlay
+  // Ctrl+Shift+F — fullscreen scrollable dashboard overlay
   // -----------------------------------------------------------------------
 
-  pi.registerShortcut("ctrl+alt+x", {
+  pi.registerShortcut("ctrl+shift+f", {
     description: "Fullscreen autoresearch dashboard",
     handler: async (ctx) => {
       const runtime = getRuntime(ctx);

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -8,7 +8,7 @@
  * - `run_experiment` tool — runs any command, times it, captures output, detects pass/fail
  * - `log_experiment` tool — records results with session-persisted state
  * - Status widget showing experiment count + best metric
- * - Ctrl+X toggle to expand/collapse full dashboard inline above the editor
+ * - Ctrl+Alt+R toggle to expand/collapse full dashboard inline above the editor
  * - Adds autoresearch guidance to the system prompt and points the agent at autoresearch.md
  * - Injects autoresearch.md into context on every turn via before_agent_start
  */
@@ -873,8 +873,8 @@ function renderDashboardLines(
     headerHint
       ? appendRightAlignedAdaptiveHint(headerLine, width, th, [
           headerHint,
-          "ctrl+x collapse • full: c-s-x",
-          "ctrl+x • c-s-x",
+          "ctrl+alt+r collapse • full: ctrl+alt+x",
+          "ctrl+alt+r • ctrl+alt+x",
         ])
       : truncateToWidth(headerLine, width, "…", true)
   );
@@ -1331,7 +1331,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               safeWidth,
               theme,
               rows,
-              "ctrl+x collapse • ctrl+shift+x fullscreen"
+              "ctrl+alt+r collapse • ctrl+alt+x fullscreen"
             ),
           ];
         },
@@ -1424,9 +1424,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           const left = [...essential, ...optional].join("");
           return [
             appendRightAlignedAdaptiveHint(left, safeWidth, theme, [
-              "ctrl+x expand • ctrl+shift+x fullscreen",
-              "ctrl+x expand • full: c-s-x",
-              "ctrl+x • c-s-x",
+              "ctrl+alt+r expand • ctrl+alt+x fullscreen",
+              "ctrl+alt+r expand • full: ctrl+alt+x",
+              "ctrl+alt+r • ctrl+alt+x",
             ]),
           ];
         },
@@ -2515,10 +2515,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Ctrl+X — toggle dashboard expand/collapse
+  // Ctrl+Alt+R — toggle dashboard expand/collapse
   // -----------------------------------------------------------------------
 
-  pi.registerShortcut("ctrl+x", {
+  pi.registerShortcut("ctrl+alt+r", {
     description: "Toggle autoresearch dashboard",
     handler: async (ctx) => {
       const runtime = getRuntime(ctx);
@@ -2537,10 +2537,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Ctrl+Shift+X — fullscreen scrollable dashboard overlay
+  // Ctrl+Alt+X — fullscreen scrollable dashboard overlay
   // -----------------------------------------------------------------------
 
-  pi.registerShortcut("ctrl+shift+x", {
+  pi.registerShortcut("ctrl+alt+x", {
     description: "Fullscreen autoresearch dashboard",
     handler: async (ctx) => {
       const runtime = getRuntime(ctx);

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -11,7 +11,7 @@ Autonomous experiment loop: try ideas, keep what works, discard what doesn't, ne
 
 - **`init_experiment`** — configure session (name, metric, unit, direction). Call again to re-initialize with a new baseline when the optimization target changes.
 - **`run_experiment`** — runs command, times it, captures output.
-- **`log_experiment`** — records result. `keep` auto-commits. `discard`/`crash`/`checks_failed` auto-reverts code changes (autoresearch files preserved). Always include secondary `metrics` dict. Dashboard: ctrl+alt+r.
+- **`log_experiment`** — records result. `keep` auto-commits. `discard`/`crash`/`checks_failed` auto-reverts code changes (autoresearch files preserved). Always include secondary `metrics` dict. Dashboard: ctrl+shift+t.
 
 ## Setup
 

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -11,7 +11,7 @@ Autonomous experiment loop: try ideas, keep what works, discard what doesn't, ne
 
 - **`init_experiment`** — configure session (name, metric, unit, direction). Call again to re-initialize with a new baseline when the optimization target changes.
 - **`run_experiment`** — runs command, times it, captures output.
-- **`log_experiment`** — records result. `keep` auto-commits. `discard`/`crash`/`checks_failed` auto-reverts code changes (autoresearch files preserved). Always include secondary `metrics` dict. Dashboard: ctrl+x.
+- **`log_experiment`** — records result. `keep` auto-commits. `discard`/`crash`/`checks_failed` auto-reverts code changes (autoresearch files preserved). Always include secondary `metrics` dict. Dashboard: ctrl+alt+r.
 
 ## Setup
 


### PR DESCRIPTION
Using `ctrl+alt+r` for dashboard and `ctrl+alt+x` for fullscreen

prevent conflicts with pi@0.68 default shortcuts

fixes #53