### PR TITLE
Adding script hooks for before and after iterations to steer the research and do post-run executions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 .DS_Store
+
+# AI-generated image artefacts (should not be committed)
+gpt-image-*.png
+nano-banana-*.png

--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ pi install https://github.com/davebcn87/pi-autoresearch
 
 **`autoresearch-finalize`** turns a noisy autoresearch branch into clean, independent branches — one per logical change, each starting from the merge-base. Groups must not share files, so each branch can be reviewed and merged independently.
 
+**`autoresearch-hooks`** *(optional)* helps author `autoresearch.hooks/before.sh` and `autoresearch.hooks/after.sh` for a session. It ships with ten reference scripts in [`skills/autoresearch-hooks/examples/`](skills/autoresearch-hooks/examples/) (external search, learnings journal, native notifications, anti-thrash, idea rotation, and more) — the skill handles the contract, you pick the inspiration. The core autoresearch loop has no hook awareness.
+
 | File | Purpose |
 |------|---------|
 | `autoresearch.md` | Session document — objective, metrics, files in scope, what's been tried. A fresh agent can resume from this alone. |
 | `autoresearch.sh` | Benchmark script — pre-checks, runs the workload, outputs `METRIC name=number` lines. |
 | `autoresearch.checks.sh` | *(optional)* Backpressure checks — tests, types, lint. Runs after each passing benchmark. Failures block `keep`. |
+| `autoresearch.hooks/` | *(optional)* Executable scripts (`before.sh`, `after.sh`) that fire around iterations. Stdout is delivered to the agent as a steer message. |
 
 ---
 
@@ -241,6 +244,62 @@ pnpm typecheck
 - If checks fail, the experiment is logged as `checks_failed` (same behavior as a crash — no commit, revert changes).
 - The `checks_failed` status is shown separately in the dashboard so you can distinguish correctness failures from benchmark crashes.
 - Checks have a separate timeout (default 300s, configurable via `checks_timeout_seconds` in `run_experiment`).
+
+---
+
+## Hooks (optional)
+
+Drop executable scripts in `autoresearch.hooks/` to run code at iteration boundaries. Hooks are **transparent to the agent** — the agent calls tools and sees results; hooks run alongside without any agent-facing surface.
+
+- `autoresearch.hooks/before.sh` — fires before every iteration (at `/autoresearch` activation and at the end of every `log_experiment`, after `after.sh`). Use for prospective work: fetch research, prime context for the next attempt.
+- `autoresearch.hooks/after.sh` — fires at the end of every `log_experiment`. Use for retrospective work: annotate learnings, send notifications.
+
+**Contract:**
+
+- Must be executable (`chmod +x`). Preserved on revert like all `autoresearch.*` artefacts.
+- **Stdin** — a JSON object on a single line. Shape depends on the stage (see below). Extract fields with `jq`.
+- **Stdout** is delivered to the agent as a steer message (capped at 8 KB). Empty stdout = silent.
+- Non-zero exit or >30s timeout surfaces an error steer to the agent.
+- Each fire appends a `{"type":"hook",…}` entry to `autoresearch.jsonl` for observability.
+
+**`before.sh` stdin** (on fresh activation `last_run` is `null`):
+
+```json
+{
+  "event": "before",
+  "cwd": "/path/to/workdir",
+  "next_run": 6,
+  "last_run": {
+    "run": 5, "status": "discard", "metric": 42.1,
+    "description": "…",
+    "asi": { "hypothesis": "…", "next_focus": "…" }
+  },
+  "session": {
+    "metric_name": "total_ms", "metric_unit": "ms", "direction": "lower",
+    "baseline_metric": 40.7, "best_metric": 33.5,
+    "run_count": 5, "goal": "optimize sort speed"
+  }
+}
+```
+
+**`after.sh` stdin:**
+
+```json
+{
+  "event": "after",
+  "cwd": "/path/to/workdir",
+  "run_entry": {
+    "run": 6, "status": "discard", "metric": 38.9,
+    "description": "…",
+    "asi": { "hypothesis": "…", "learned": "…" }
+  },
+  "session": { "metric_name": "total_ms", "direction": "lower", "baseline_metric": 40.7, "best_metric": 33.5, "run_count": 6, "goal": "…" }
+}
+```
+
+**Agent signal.** The agent writes `description` and `asi.*` fields in its `log_experiment` calls for its own future-self reasoning. The hook opportunistically mines whichever fields the agent naturally uses — `asi.hypothesis`, `asi.next_focus`, `description`, etc. There is no dedicated "hook input" field; the agent is unaware the hook exists.
+
+**Examples.** Reference scripts for both stages live at [`skills/autoresearch-hooks/examples/`](skills/autoresearch-hooks/examples/) — external search, qmd document search, persistent learnings, native notifications, git tagging, anti-thrash, idea rotator, hypothesis reflection, context rotation, token budget. Copy one to your session's `autoresearch.hooks/` directory, adapt, `chmod +x`.
 
 ---
 

--- a/extensions/pi-autoresearch/hooks.ts
+++ b/extensions/pi-autoresearch/hooks.ts
@@ -2,6 +2,8 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { hasAutoresearchConfigHeader } from "./jsonl.ts";
+
 const TIMEOUT_MS = 30_000;
 const STDOUT_MAX_BYTES = 8 * 1024;
 const TRUNCATION_MARKER = "\n…[truncated: hook stdout exceeded 8KB]";
@@ -155,4 +157,29 @@ export function hookLogEntry(stage: HookStage, result: HookResult): Record<strin
     stdout_bytes: Buffer.byteLength(result.stdout, "utf8"),
     timed_out: result.timedOut,
   };
+}
+
+function hasConfigHeader(jsonlPath: string): boolean {
+  if (!fs.existsSync(jsonlPath)) return false;
+  try {
+    return hasAutoresearchConfigHeader(fs.readFileSync(jsonlPath, "utf-8"));
+  } catch {
+    return false;
+  }
+}
+
+export function appendHookLogEntryIfConfigured(
+  jsonlPath: string,
+  stage: HookStage,
+  result: HookResult,
+): boolean {
+  if (!result.fired) return false;
+  if (!hasConfigHeader(jsonlPath)) return false;
+
+  try {
+    fs.appendFileSync(jsonlPath, JSON.stringify(hookLogEntry(stage, result)) + "\n");
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/extensions/pi-autoresearch/hooks.ts
+++ b/extensions/pi-autoresearch/hooks.ts
@@ -1,0 +1,158 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const TIMEOUT_MS = 30_000;
+const STDOUT_MAX_BYTES = 8 * 1024;
+const TRUNCATION_MARKER = "\n…[truncated: hook stdout exceeded 8KB]";
+const HOOKS_DIR = "autoresearch.hooks";
+
+const NEWLINE = 0x0a;
+const UTF8_CONT_MASK = 0xc0;
+const UTF8_CONT = 0x80; // continuation byte: 10xxxxxx
+const UTF8_LEAD = 0xc0; // multi-byte leader: 11xxxxxx
+
+/** Trim at the last newline, falling back to the last complete UTF-8 character. */
+function truncateAtBoundary(buf: Buffer): Buffer {
+  const newlineEnd = buf.lastIndexOf(NEWLINE);
+  if (newlineEnd >= 0) return buf.subarray(0, newlineEnd + 1);
+  let end = buf.length;
+  while (end > 0 && (buf[end - 1] & UTF8_CONT_MASK) === UTF8_CONT) end--;
+  if (end > 0 && (buf[end - 1] & UTF8_CONT_MASK) === UTF8_LEAD) end--;
+  return buf.subarray(0, end);
+}
+
+export type HookStage = "before" | "after";
+
+export interface SessionSnapshot {
+  metric_name: string;
+  metric_unit: string;
+  direction: "lower" | "higher";
+  baseline_metric: number | null;
+  best_metric: number | null;
+  run_count: number;
+  goal: string;
+}
+
+export interface BeforeHookPayload {
+  event: "before";
+  cwd: string;
+  next_run: number;
+  last_run: Record<string, unknown> | null;
+  session: SessionSnapshot;
+}
+
+export interface AfterHookPayload {
+  event: "after";
+  cwd: string;
+  run_entry: Record<string, unknown>;
+  session: SessionSnapshot;
+}
+
+export type HookPayload = BeforeHookPayload | AfterHookPayload;
+
+export interface HookResult {
+  fired: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  timedOut: boolean;
+  durationMs: number;
+}
+
+export function hookScriptPath(workDir: string, stage: HookStage): string {
+  return path.join(workDir, HOOKS_DIR, `${stage}.sh`);
+}
+
+function isExecutableFile(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+const notFired: HookResult = {
+  fired: false,
+  stdout: "",
+  stderr: "",
+  exitCode: null,
+  timedOut: false,
+  durationMs: 0,
+};
+
+export async function runHook(payload: HookPayload): Promise<HookResult> {
+  const script = hookScriptPath(payload.cwd, payload.event);
+  if (!isExecutableFile(script)) return notFired;
+
+  const t0 = Date.now();
+  return new Promise<HookResult>((resolve) => {
+    const child = spawn("bash", [script], { cwd: payload.cwd, timeout: TIMEOUT_MS });
+
+    let stdout = "";
+    let stdoutBytes = 0;
+    let stdoutFull = false;
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (stdoutFull) return;
+      const remaining = STDOUT_MAX_BYTES - stdoutBytes;
+      if (chunk.length <= remaining) {
+        stdout += chunk.toString("utf8");
+        stdoutBytes += chunk.length;
+        return;
+      }
+      const kept = truncateAtBoundary(chunk.subarray(0, remaining));
+      stdout += kept.toString("utf8") + TRUNCATION_MARKER;
+      stdoutFull = true;
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    const finish = (exitCode: number | null, extraErr = "") => {
+      const combinedStderr = extraErr ? (stderr ? `${stderr}\n${extraErr}` : extraErr) : stderr;
+      resolve({
+        fired: true,
+        stdout,
+        stderr: combinedStderr,
+        exitCode,
+        timedOut: child.killed,
+        durationMs: Date.now() - t0,
+      });
+    };
+
+    child.on("error", (err) => finish(null, err.message));
+    child.on("close", (code) => finish(code));
+
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+export function steerMessageFor(stage: HookStage, result: HookResult): string | null {
+  if (!result.fired) return null;
+  if (result.timedOut) return `[${stage} hook timed out after ${TIMEOUT_MS / 1000}s]`;
+  if (result.exitCode !== 0) {
+    const parts = [`[${stage} hook exited ${result.exitCode}]`];
+    const err = result.stderr.trim();
+    const out = result.stdout.trim();
+    if (err) parts.push(err);
+    if (out) parts.push(out);
+    return parts.join("\n");
+  }
+  return result.stdout.trim() || null;
+}
+
+export function hookLogEntry(stage: HookStage, result: HookResult): Record<string, unknown> {
+  return {
+    type: "hook",
+    stage,
+    exit_code: result.exitCode,
+    duration_ms: result.durationMs,
+    stdout_bytes: Buffer.byteLength(result.stdout, "utf8"),
+    timed_out: result.timedOut,
+  };
+}

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -35,12 +35,16 @@ import { tmpdir } from "node:os";
 import {
   runHook,
   steerMessageFor,
-  hookLogEntry,
-  type HookStage,
-  type HookResult,
+  appendHookLogEntryIfConfigured,
   type HookPayload,
   type SessionSnapshot,
-} from "./hooks.js";
+} from "./hooks.ts";
+import {
+  parseJsonlEntry,
+  isAutoresearchRunEntry,
+  extractAutoresearchSessionName,
+  reconstructJsonlState,
+} from "./jsonl.ts";
 
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
@@ -1146,20 +1150,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     return fs.readFileSync(jsonlPath, "utf-8").split("\n").filter(Boolean);
   };
 
-  const parseRunEntry = (line: string): Record<string, unknown> | null => {
-    try {
-      const entry = JSON.parse(line);
-      return typeof entry.run === "number" ? entry : null;
-    } catch {
-      return null;
-    }
-  };
-
   const readLastRun = (workDir: string): Record<string, unknown> | null => {
     const lines = readJsonlLines(workDir);
     for (let i = lines.length - 1; i >= 0; i--) {
-      const entry = parseRunEntry(lines[i]);
-      if (entry) return entry;
+      const entry = parseJsonlEntry(lines[i]);
+      if (isAutoresearchRunEntry(entry)) return entry;
     }
     return null;
   };
@@ -1174,17 +1169,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     goal: state.name ?? "",
   });
 
-  const appendHookLogEntry = (workDir: string, stage: HookStage, result: HookResult): void => {
-    if (!result.fired) return;
-    try {
-      const jsonlPath = autoresearchJsonlPath(workDir);
-      fs.appendFileSync(jsonlPath, JSON.stringify(hookLogEntry(stage, result)) + "\n");
-    } catch {}
-  };
-
   const fireHook = async (payload: HookPayload): Promise<string | null> => {
     const result = await runHook(payload);
-    appendHookLogEntry(payload.cwd, payload.event, result);
+    appendHookLogEntryIfConfigured(autoresearchJsonlPath(payload.cwd), payload.event, result);
     return steerMessageFor(payload.event, result);
   };
 
@@ -1252,63 +1239,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     let loadedFromJsonl = false;
     try {
       if (fs.existsSync(jsonlPath)) {
-        let segment = 0;
-        const lines = fs.readFileSync(jsonlPath, "utf-8").trim().split("\n").filter(Boolean);
-        for (const line of lines) {
-          try {
-            const entry = JSON.parse(line);
+        const reconstructed = reconstructJsonlState(fs.readFileSync(jsonlPath, "utf-8"));
+        state.name = reconstructed.name;
+        state.metricName = reconstructed.metricName;
+        state.metricUnit = reconstructed.metricUnit;
+        state.bestDirection = reconstructed.bestDirection;
+        state.currentSegment = reconstructed.currentSegment;
+        state.results = reconstructed.results.map((result) => ({
+          ...result,
+          metrics: { ...result.metrics },
+        }));
+        state.secondaryMetrics = reconstructed.secondaryMetrics.map((metric) => ({ ...metric }));
+        runtime.iterationTokenHistory = [...reconstructed.iterationTokenHistory];
 
-            // Config header line — each header starts a new segment
-            if (entry.type === "config") {
-              if (entry.name) state.name = entry.name;
-              if (entry.metricName) state.metricName = entry.metricName;
-              if (entry.metricUnit !== undefined) state.metricUnit = entry.metricUnit;
-              if (entry.bestDirection) state.bestDirection = entry.bestDirection;
-              // Increment segment (first config = 0, second = 1, etc.)
-              if (state.results.length > 0) {
-                segment++;
-                // Reset per-segment tracking (mirrors live reinit behavior)
-                state.secondaryMetrics = [];
-              }
-              state.currentSegment = segment;
-              continue;
-            }
-
-            // Experiment result line
-            const iterationTokens = entry.iterationTokens ?? null;
-            state.results.push({
-              commit: entry.commit ?? "",
-              metric: entry.metric ?? 0,
-              metrics: entry.metrics ?? {},
-              status: entry.status ?? "keep",
-              description: entry.description ?? "",
-              timestamp: entry.timestamp ?? 0,
-              segment,
-              confidence: entry.confidence ?? null,
-              iterationTokens,
-              asi: entry.asi ?? undefined,
-            });
-
-            if (typeof iterationTokens === "number" && iterationTokens > 0) {
-              runtime.iterationTokenHistory.push(iterationTokens);
-            }
-
-            // Register secondary metrics
-            for (const name of Object.keys(entry.metrics ?? {})) {
-              if (!state.secondaryMetrics.find((m) => m.name === name)) {
-                let unit = "";
-                if (name.endsWith("µs")) unit = "µs";
-                else if (name.endsWith("_ms")) unit = "ms";
-                else if (name.endsWith("_s") || name.endsWith("_sec")) unit = "s";
-                else if (name.endsWith("_kb")) unit = "kb";
-                else if (name.endsWith("_mb")) unit = "mb";
-                state.secondaryMetrics.push({ name, unit });
-              }
-            }
-          } catch {
-            // Skip malformed lines
-          }
-        }
         if (state.results.length > 0) {
           loadedFromJsonl = true;
           state.bestMetric = findBaselineMetric(state.results, state.currentSegment);
@@ -2825,17 +2768,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     return fs.readFileSync(autoresearchJsonlPath(workDir), "utf-8").trim();
   }
 
-  function extractSessionName(jsonlContent: string): string {
-    const firstLine = jsonlContent.split("\n").find((l) => l.trim());
-    if (!firstLine) return "Autoresearch";
-    try {
-      const config = JSON.parse(firstLine);
-      return config.name || "Autoresearch";
-    } catch {
-      return "Autoresearch";
-    }
-  }
-
   function escapeHtml(text: string): string {
     return text
       .replace(/&/g, "&amp;")
@@ -2888,7 +2820,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   function writeDashboardFile(workDir: string): string {
     const jsonlContent = readJsonlContent(workDir);
-    const sessionName = extractSessionName(jsonlContent);
+    const sessionName = extractAutoresearchSessionName(jsonlContent);
     const html = injectDataIntoTemplate(readTemplate(), sessionName)
       .replace(LOGO_PLACEHOLDER, logoDataUrl());
     const exportDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-dashboard-"));

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -32,6 +32,16 @@ import { createWriteStream } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 
+import {
+  runHook,
+  steerMessageFor,
+  hookLogEntry,
+  type HookStage,
+  type HookResult,
+  type HookPayload,
+  type SessionSnapshot,
+} from "./hooks.js";
+
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
 // ---------------------------------------------------------------------------
@@ -466,7 +476,7 @@ interface AutoresearchConfig {
 /** Read autoresearch.config.json from the given directory (always ctx.cwd) */
 function readConfig(cwd: string): AutoresearchConfig {
   try {
-    const configPath = path.join(cwd, "autoresearch.config.json");
+    const configPath = autoresearchConfigPath(cwd);
     if (!fs.existsSync(configPath)) return {};
     return JSON.parse(fs.readFileSync(configPath, "utf-8"));
   } catch {
@@ -518,6 +528,30 @@ function findBaselineMetric(results: ExperimentResult[], segment: number): numbe
   const cur = currentResults(results, segment);
   return cur.length > 0 ? cur[0].metric : null;
 }
+
+/** Best = optimal metric across kept experiments in current segment (min for lower, max for higher) */
+function findBestMetric(
+  results: ExperimentResult[],
+  segment: number,
+  direction: "lower" | "higher",
+): number | null {
+  const kept = currentResults(results, segment)
+    .filter((r) => r.status === "keep")
+    .map((r) => r.metric);
+  if (kept.length === 0) return null;
+  return direction === "lower" ? Math.min(...kept) : Math.max(...kept);
+}
+
+// -----------------------------------------------------------------------
+// Session file paths (single source of truth for autoresearch.* filenames)
+// -----------------------------------------------------------------------
+
+const autoresearchJsonlPath  = (dir: string) => path.join(dir, "autoresearch.jsonl");
+const autoresearchMdPath     = (dir: string) => path.join(dir, "autoresearch.md");
+const autoresearchIdeasPath  = (dir: string) => path.join(dir, "autoresearch.ideas.md");
+const autoresearchChecksPath = (dir: string) => path.join(dir, "autoresearch.checks.sh");
+const autoresearchScriptPath = (dir: string) => path.join(dir, "autoresearch.sh");
+const autoresearchConfigPath = (dir: string) => path.join(dir, "autoresearch.config.json");
 
 function findBaselineRunNumber(results: ExperimentResult[], segment: number): number | null {
   const index = results.findIndex((result) => result.segment === segment);
@@ -1082,7 +1116,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   const hasIdeasFile = (ctx: ExtensionContext): boolean =>
-    fs.existsSync(path.join(resolveWorkDir(ctx.cwd), "autoresearch.ideas.md"));
+    fs.existsSync(autoresearchIdeasPath(resolveWorkDir(ctx.cwd)));
 
   const composeResumeMessage = (ctx: ExtensionContext): string => {
     const parts = [
@@ -1104,7 +1138,55 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   const hasAutoresearchRules = (ctx: ExtensionContext): boolean =>
-    fs.existsSync(path.join(resolveWorkDir(ctx.cwd), "autoresearch.md"));
+    fs.existsSync(autoresearchMdPath(resolveWorkDir(ctx.cwd)));
+
+  const readJsonlLines = (workDir: string): string[] => {
+    const jsonlPath = autoresearchJsonlPath(workDir);
+    if (!fs.existsSync(jsonlPath)) return [];
+    return fs.readFileSync(jsonlPath, "utf-8").split("\n").filter(Boolean);
+  };
+
+  const parseRunEntry = (line: string): Record<string, unknown> | null => {
+    try {
+      const entry = JSON.parse(line);
+      return typeof entry.run === "number" ? entry : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const readLastRun = (workDir: string): Record<string, unknown> | null => {
+    const lines = readJsonlLines(workDir);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const entry = parseRunEntry(lines[i]);
+      if (entry) return entry;
+    }
+    return null;
+  };
+
+  const buildSessionSnapshot = (state: ExperimentState): SessionSnapshot => ({
+    metric_name: state.metricName,
+    metric_unit: state.metricUnit,
+    direction: state.bestDirection,
+    baseline_metric: state.bestMetric,
+    best_metric: findBestMetric(state.results, state.currentSegment, state.bestDirection),
+    run_count: state.results.length,
+    goal: state.name ?? "",
+  });
+
+  const appendHookLogEntry = (workDir: string, stage: HookStage, result: HookResult): void => {
+    if (!result.fired) return;
+    try {
+      const jsonlPath = autoresearchJsonlPath(workDir);
+      fs.appendFileSync(jsonlPath, JSON.stringify(hookLogEntry(stage, result)) + "\n");
+    } catch {}
+  };
+
+  const fireHook = async (payload: HookPayload): Promise<string | null> => {
+    const result = await runHook(payload);
+    appendHookLogEntry(payload.cwd, payload.event, result);
+    return steerMessageFor(payload.event, result);
+  };
 
   // Running experiment state (for spinner in fullscreen overlay)
   let overlayTui: { requestRender: () => void } | null = null;
@@ -1166,7 +1248,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     const workDir = resolveWorkDir(ctx.cwd);
 
     // Primary: read from autoresearch.jsonl (alongside autoresearch.md/sh)
-    const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+    const jsonlPath = autoresearchJsonlPath(workDir);
     let loadedFromJsonl = false;
     try {
       if (fs.existsSync(jsonlPath)) {
@@ -1268,7 +1350,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
     // Auto-enter autoresearch mode only when a persisted experiment log exists
-    runtime.autoresearchMode = fs.existsSync(path.join(workDir, "autoresearch.jsonl"));
+    runtime.autoresearchMode = fs.existsSync(autoresearchJsonlPath(workDir));
 
     updateWidget(ctx);
   };
@@ -1486,11 +1568,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     if (!runtime.autoresearchMode) return;
 
     const workDir = resolveWorkDir(ctx.cwd);
-    const mdPath = path.join(workDir, "autoresearch.md");
-    const ideasPath = path.join(workDir, "autoresearch.ideas.md");
+    const mdPath = autoresearchMdPath(workDir);
+    const ideasPath = autoresearchIdeasPath(workDir);
     const hasIdeas = fs.existsSync(ideasPath);
 
-    const checksPath = path.join(workDir, "autoresearch.checks.sh");
+    const checksPath = autoresearchChecksPath(workDir);
     const hasChecks = fs.existsSync(checksPath);
 
     let extra =
@@ -1575,7 +1657,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       // Write config header to jsonl (append for re-init, create for first)
       const workDir = resolveWorkDir(ctx.cwd);
       try {
-        const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+        const jsonlPath = autoresearchJsonlPath(workDir);
         const config = JSON.stringify({
           type: "config",
           name: state.name,
@@ -1599,9 +1681,21 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         };
       }
 
+      const wasInactive = !runtime.autoresearchMode;
       runtime.autoresearchMode = true;
       runtime.iterationStartTokens = ctx.getContextUsage()?.tokens ?? null;
       updateWidget(ctx);
+
+      if (wasInactive) {
+        const steer = await fireHook({
+          event: "before",
+          cwd: workDir,
+          next_run: state.results.length + 1,
+          last_run: readLastRun(workDir),
+          session: buildSessionSnapshot(state),
+        });
+        if (steer) pi.sendUserMessage(steer, { deliverAs: "steer" });
+      }
 
       const reinitNote = isReinit ? " (re-initialized — previous results archived, new baseline needed)" : "";
       const limitNote = state.maxExperiments !== null ? `\nMax iterations: ${state.maxExperiments} (from autoresearch.config.json)` : "";
@@ -1674,7 +1768,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const timeout = (params.timeout_seconds ?? 600) * 1000;
 
       // Guard: if autoresearch.sh exists, only allow running it
-      const autoresearchShPath = path.join(workDir, "autoresearch.sh");
+      const autoresearchShPath = autoresearchScriptPath(workDir);
       if (fs.existsSync(autoresearchShPath) && !isAutoresearchShCommand(params.command)) {
         return {
           content: [{
@@ -1887,7 +1981,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       let checksOutput = "";
       let checksDuration = 0;
 
-      const checksPath = path.join(workDir, "autoresearch.checks.sh");
+      const checksPath = autoresearchChecksPath(workDir);
       if (benchmarkPassed && fs.existsSync(checksPath)) {
         const checksTimeout = (params.checks_timeout_seconds ?? 300) * 1000;
         const ct0 = Date.now();
@@ -2381,46 +2475,60 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         }
       }
 
-      // Persist to autoresearch.jsonl (always, regardless of status)
+      const jsonlEntry: Record<string, unknown> = {
+        run: state.results.length,
+        ...experiment,
+      };
+      if (!mergedASI) delete jsonlEntry.asi;
+      const jsonlLine = JSON.stringify(jsonlEntry);
+
       try {
-        const jsonlPath = path.join(workDir, "autoresearch.jsonl");
-        const jsonlEntry: Record<string, unknown> = {
-          run: state.results.length,
-          ...experiment,
-        };
-        // Only write asi if present (keep lines compact when no ASI)
-        if (!mergedASI) delete jsonlEntry.asi;
-        fs.appendFileSync(jsonlPath, JSON.stringify(jsonlEntry) + "\n");
+        fs.appendFileSync(autoresearchJsonlPath(workDir), jsonlLine + "\n");
         broadcastDashboardUpdate(workDir);
       } catch (e) {
         text += `\n⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}`;
       }
 
-      // Auto-revert on discard/crash/checks_failed — revert all files except autoresearch session files
       if (params.status !== "keep") {
         try {
-          const protectedFiles = ["autoresearch.jsonl", "autoresearch.md", "autoresearch.ideas.md", "autoresearch.sh", "autoresearch.checks.sh"];
-          const stageCmd = protectedFiles.map((f) => `git add "${path.join(workDir, f)}" 2>/dev/null || true`).join("; ");
-          await pi.exec("bash", ["-c", `${stageCmd}; git checkout -- .; git clean -fd 2>/dev/null`], { cwd: workDir, timeout: 10000 });
+          const revertScript = `
+            git checkout -- . ':(exclude,glob)**/autoresearch.*' ':(exclude,glob)**/autoresearch.*/**'
+            git clean -fd -e 'autoresearch.*' -e '**/autoresearch.*/**' 2>/dev/null
+          `;
+          await pi.exec("bash", ["-c", revertScript], { cwd: workDir, timeout: 10000 });
           text += `\n📝 Git: reverted changes (${params.status}) — autoresearch files preserved`;
         } catch (e) {
           text += `\n⚠️ Git revert failed: ${e instanceof Error ? e.message : String(e)}`;
         }
       }
 
-      // Clear running experiment and checks state (log_experiment consumes the run)
+      const afterSteer = await fireHook({
+        event: "after",
+        cwd: workDir,
+        run_entry: jsonlEntry,
+        session: buildSessionSnapshot(state),
+      });
+      if (afterSteer) pi.sendUserMessage(afterSteer, { deliverAs: "steer" });
+
       const wallClockSeconds = runtime.lastRunDuration;
       runtime.runningExperiment = null;
       runtime.lastRunChecks = null;
       runtime.lastRunDuration = null;
 
-
-      // Check if max experiments limit reached
       const limitReached = state.maxExperiments !== null && segmentCount >= state.maxExperiments;
       if (limitReached) {
         text += `\n\n🛑 Maximum experiments reached (${state.maxExperiments}). STOP the experiment loop now.`;
         runtime.autoresearchMode = false;
         ctx.abort();
+      } else if (runtime.autoresearchMode) {
+        const beforeSteer = await fireHook({
+          event: "before",
+          cwd: workDir,
+          next_run: state.results.length + 1,
+          last_run: jsonlEntry,
+          session: buildSessionSnapshot(state),
+        });
+        if (beforeSteer) pi.sendUserMessage(beforeSteer, { deliverAs: "steer" });
       }
 
       updateWidget(ctx);
@@ -2524,7 +2632,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const runtime = getRuntime(ctx);
       const state = runtime.state;
       if (state.results.length === 0) {
-        if (!runtime.autoresearchMode && !fs.existsSync(path.join(resolveWorkDir(ctx.cwd), "autoresearch.md"))) {
+        if (!runtime.autoresearchMode && !fs.existsSync(autoresearchMdPath(resolveWorkDir(ctx.cwd)))) {
           ctx.ui.notify("No experiments yet — run /autoresearch to get started", "info");
         } else {
           ctx.ui.notify("No experiments yet", "info");
@@ -2714,7 +2822,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   }
 
   function readJsonlContent(workDir: string): string {
-    return fs.readFileSync(path.join(workDir, "autoresearch.jsonl"), "utf-8").trim();
+    return fs.readFileSync(autoresearchJsonlPath(workDir), "utf-8").trim();
   }
 
   function extractSessionName(jsonlContent: string): string {
@@ -2806,7 +2914,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   function resolveServedFile(workDir: string, requestPath: string): string | null {
     if (requestPath === "/") return dashboardServerHtmlPath;
-    if (requestPath === "/autoresearch.jsonl") return path.join(workDir, "autoresearch.jsonl");
+    if (requestPath === "/autoresearch.jsonl") return autoresearchJsonlPath(workDir);
     return null;
   }
 
@@ -2891,7 +2999,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   async function exportDashboard(ctx: ExtensionContext): Promise<void> {
     const workDir = resolveWorkDir(ctx.cwd);
-    const jsonlPath = path.join(workDir, "autoresearch.jsonl");
+    const jsonlPath = autoresearchJsonlPath(workDir);
 
     if (!fs.existsSync(jsonlPath)) {
       ctx.ui.notify("No autoresearch.jsonl found \u2014 run some experiments first", "error");
@@ -2957,7 +3065,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       if (command === "clear") {
-        const jsonlPath = path.join(resolveWorkDir(ctx.cwd), "autoresearch.jsonl");
+        const jsonlPath = autoresearchJsonlPath(resolveWorkDir(ctx.cwd));
         runtime.autoresearchMode = false;
         runtime.dashboardExpanded = false;
         runtime.lastAutoResumeTime = 0;
@@ -2994,13 +3102,29 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       runtime.autoresearchMode = true;
       runtime.autoResumeTurns = 0;
 
-      if (hasAutoresearchRules(ctx)) {
-        ctx.ui.notify("Autoresearch mode ON — rules loaded from autoresearch.md", "info");
-        sendWhenReady(ctx, `Autoresearch mode active. ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`);
-      } else {
-        ctx.ui.notify("Autoresearch mode ON — no autoresearch.md found, setting up", "info");
-        sendWhenReady(ctx, `Start autoresearch: ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`);
-      }
+      const workDir = resolveWorkDir(ctx.cwd);
+      const rulesLoaded = hasAutoresearchRules(ctx);
+      const kickoff = rulesLoaded
+        ? `Autoresearch mode active. ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`
+        : `Start autoresearch: ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`;
+
+      ctx.ui.notify(
+        rulesLoaded
+          ? "Autoresearch mode ON — rules loaded from autoresearch.md"
+          : "Autoresearch mode ON — no autoresearch.md found, setting up",
+        "info",
+      );
+
+      const state = runtime.state;
+      const activationSteer = await fireHook({
+        event: "before",
+        cwd: workDir,
+        next_run: state.results.length + 1,
+        last_run: readLastRun(workDir),
+        session: buildSessionSnapshot(state),
+      });
+
+      sendWhenReady(ctx, activationSteer ? `${activationSteer}\n\n${kickoff}` : kickoff);
     },
   });
 }

--- a/extensions/pi-autoresearch/jsonl.ts
+++ b/extensions/pi-autoresearch/jsonl.ts
@@ -1,0 +1,201 @@
+export type JsonlEntry = Record<string, unknown>;
+
+export interface AutoresearchConfigEntry extends JsonlEntry {
+  type: "config";
+  name?: string;
+  metricName?: string;
+  metricUnit?: string;
+  bestDirection?: "lower" | "higher";
+}
+
+export interface AutoresearchRunEntry extends JsonlEntry {
+  run: number;
+}
+
+export interface ReconstructedMetricDef {
+  name: string;
+  unit: string;
+}
+
+export interface ReconstructedRun {
+  commit: string;
+  metric: number;
+  metrics: Record<string, number>;
+  status: "keep" | "discard" | "crash" | "checks_failed";
+  description: string;
+  timestamp: number;
+  segment: number;
+  confidence: number | null;
+  iterationTokens: number | null;
+  asi?: Record<string, unknown>;
+}
+
+export interface ReconstructedJsonlState {
+  name: string | null;
+  metricName: string;
+  metricUnit: string;
+  bestDirection: "lower" | "higher";
+  currentSegment: number;
+  results: ReconstructedRun[];
+  secondaryMetrics: ReconstructedMetricDef[];
+  iterationTokenHistory: number[];
+}
+
+const DEFAULT_METRIC_NAME = "metric";
+const DEFAULT_METRIC_UNIT = "";
+const DEFAULT_DIRECTION = "lower" as const;
+
+function isObjectRecord(value: unknown): value is JsonlEntry {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyLines(text: string): string[] {
+  return text.split("\n").filter(Boolean);
+}
+
+function inferMetricUnit(name: string): string {
+  if (name.endsWith("µs")) return "µs";
+  if (name.endsWith("_ms")) return "ms";
+  if (name.endsWith("_s") || name.endsWith("_sec")) return "s";
+  if (name.endsWith("_kb")) return "kb";
+  if (name.endsWith("_mb")) return "mb";
+  return "";
+}
+
+function metricMapFrom(value: unknown): Record<string, number> {
+  if (!isObjectRecord(value)) return {};
+
+  const metrics: Record<string, number> = {};
+  for (const [name, metric] of Object.entries(value)) {
+    if (typeof metric === "number") metrics[name] = metric;
+  }
+  return metrics;
+}
+
+function statusFrom(value: unknown): ReconstructedRun["status"] {
+  if (value === "discard") return "discard";
+  if (value === "crash") return "crash";
+  if (value === "checks_failed") return "checks_failed";
+  return "keep";
+}
+
+function directionFrom(value: unknown): ReconstructedJsonlState["bestDirection"] {
+  return value === "higher" ? "higher" : DEFAULT_DIRECTION;
+}
+
+function asiFrom(value: unknown): Record<string, unknown> | undefined {
+  return isObjectRecord(value) ? value : undefined;
+}
+
+function reconstructedState(): ReconstructedJsonlState {
+  return {
+    name: null,
+    metricName: DEFAULT_METRIC_NAME,
+    metricUnit: DEFAULT_METRIC_UNIT,
+    bestDirection: DEFAULT_DIRECTION,
+    currentSegment: 0,
+    results: [],
+    secondaryMetrics: [],
+    iterationTokenHistory: [],
+  };
+}
+
+function updateConfig(state: ReconstructedJsonlState, entry: AutoresearchConfigEntry): void {
+  if (typeof entry.name === "string") state.name = entry.name;
+  if (typeof entry.metricName === "string") state.metricName = entry.metricName;
+  if (typeof entry.metricUnit === "string") state.metricUnit = entry.metricUnit;
+  state.bestDirection = directionFrom(entry.bestDirection);
+}
+
+function nextSegment(state: ReconstructedJsonlState, segment: number): number {
+  if (state.results.length === 0) return segment;
+  state.secondaryMetrics = [];
+  return segment + 1;
+}
+
+function runFrom(entry: AutoresearchRunEntry, segment: number): ReconstructedRun {
+  const iterationTokens = typeof entry.iterationTokens === "number" ? entry.iterationTokens : null;
+  return {
+    commit: typeof entry.commit === "string" ? entry.commit : "",
+    metric: typeof entry.metric === "number" ? entry.metric : 0,
+    metrics: metricMapFrom(entry.metrics),
+    status: statusFrom(entry.status),
+    description: typeof entry.description === "string" ? entry.description : "",
+    timestamp: typeof entry.timestamp === "number" ? entry.timestamp : 0,
+    segment,
+    confidence: typeof entry.confidence === "number" ? entry.confidence : null,
+    iterationTokens,
+    asi: asiFrom(entry.asi),
+  };
+}
+
+function recordIterationTokens(state: ReconstructedJsonlState, run: ReconstructedRun): void {
+  if (run.iterationTokens === null || run.iterationTokens <= 0) return;
+  state.iterationTokenHistory.push(run.iterationTokens);
+}
+
+function registerSecondaryMetrics(state: ReconstructedJsonlState, metrics: Record<string, number>): void {
+  for (const name of Object.keys(metrics)) {
+    if (state.secondaryMetrics.find((metric) => metric.name === name)) continue;
+    state.secondaryMetrics.push({ name, unit: inferMetricUnit(name) });
+  }
+}
+
+export function parseJsonlEntry(line: string): JsonlEntry | null {
+  try {
+    const parsed = JSON.parse(line);
+    return isObjectRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isAutoresearchConfigEntry(entry: unknown): entry is AutoresearchConfigEntry {
+  return isObjectRecord(entry) && entry.type === "config";
+}
+
+export function isAutoresearchRunEntry(entry: unknown): entry is AutoresearchRunEntry {
+  return isObjectRecord(entry) && typeof entry.run === "number";
+}
+
+function firstConfigEntry(jsonlContent: string): AutoresearchConfigEntry | null {
+  for (const line of nonEmptyLines(jsonlContent)) {
+    const entry = parseJsonlEntry(line);
+    if (isAutoresearchConfigEntry(entry)) return entry;
+  }
+  return null;
+}
+
+export function hasAutoresearchConfigHeader(jsonlContent: string): boolean {
+  return firstConfigEntry(jsonlContent) !== null;
+}
+
+export function extractAutoresearchSessionName(jsonlContent: string): string {
+  return firstConfigEntry(jsonlContent)?.name || "Autoresearch";
+}
+
+export function reconstructJsonlState(jsonlContent: string): ReconstructedJsonlState {
+  const state = reconstructedState();
+  let segment = 0;
+
+  for (const line of nonEmptyLines(jsonlContent)) {
+    const entry = parseJsonlEntry(line);
+    if (!entry) continue;
+
+    if (isAutoresearchConfigEntry(entry)) {
+      updateConfig(state, entry);
+      segment = nextSegment(state, segment);
+      state.currentSegment = segment;
+      continue;
+    }
+
+    if (!isAutoresearchRunEntry(entry)) continue;
+
+    const run = runFrom(entry, segment);
+    state.results.push(run);
+    recordIterationTokens(state, run);
+    registerSecondaryMetrics(state, run.metrics);
+  }
+
+  return state;
+}

--- a/skills/autoresearch-finalize/finalize.sh
+++ b/skills/autoresearch-finalize/finalize.sh
@@ -42,13 +42,11 @@ info() { echo -e "${GREEN}$1${NC}"; }
 cleanup_data() { if [ -d "${DATA_DIR:-}" ]; then rm -rf "$DATA_DIR"; fi; }
 fail() { cleanup_data; echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
 
-# Session artifacts are matched by basename so they're excluded regardless of
-# directory depth — autoresearch runs may happen in subdirectories (e.g.
-# libs/polaris/autoresearch.jsonl) and none should leak into PR branches.
 is_session_file() {
-  local base
-  base=$(basename "$1")
-  case "$base" in autoresearch.*) return 0;; *) return 1;; esac
+  case "/$1/" in
+    */autoresearch.*/*) return 0;;
+    *) return 1;;
+  esac
 }
 
 # ---------------------------------------------------------------------------

--- a/skills/autoresearch-hooks/SKILL.md
+++ b/skills/autoresearch-hooks/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: autoresearch-hooks
+description: Author pre/post-iteration hooks for an autoresearch session. Use when the user asks to add research fetching, Slack/webhook notifications, persistent learnings, auto-tagging, anti-thrash intervention, idea rotation, or any side effect around iterations.
+---
+
+# autoresearch-hooks
+
+Optional scripts that run at iteration boundaries in an autoresearch session. Two hooks, both transparent to the loop-running agent — their effect is a file on disk or a steer message.
+
+```
+autoresearch.hooks/
+  before.sh    # fires before each iteration (prospective)
+  after.sh     # fires after each log_experiment (retrospective)
+```
+
+Both files are optional. Files without the executable bit are silently ignored.
+
+---
+
+## Contract
+
+### Stdin — `before.sh`
+
+One JSON line. Parse with `jq`. Realistic example:
+
+```json
+{
+  "event": "before",
+  "cwd": "/path/to/workdir",
+  "next_run": 6,
+  "last_run": {
+    "run": 5,
+    "status": "discard",
+    "metric": 42.1,
+    "description": "Simplified to sorted(arr) — copy cost dominates",
+    "asi": {
+      "hypothesis": "Built-in sort avoids Python overhead",
+      "next_focus": "list copy avoidance"
+    }
+  },
+  "session": {
+    "metric_name": "total_ms",
+    "metric_unit": "ms",
+    "direction": "lower",
+    "baseline_metric": 40.7,
+    "best_metric": 33.5,
+    "run_count": 5,
+    "goal": "optimize sort speed"
+  }
+}
+```
+
+| Field                     | Notes                                                               |
+| ------------------------- | ------------------------------------------------------------------- |
+| `last_run`                | The most recent run entry. `null` on a fresh session.               |
+| `session.direction`       | `"lower"` or `"higher"` — which end of the scale wins.              |
+| `session.baseline_metric` | First run of the current segment. `null` until one run exists.      |
+| `session.best_metric`     | Optimal metric across **kept** runs only. `null` until one is kept. |
+| `session.goal`            | The session name set by `init_experiment`.                          |
+| `session.run_count`       | Total runs logged so far (any status).                              |
+
+### Stdin — `after.sh`
+
+```json
+{
+  "event": "after",
+  "cwd": "/path/to/workdir",
+  "run_entry": {
+    "run": 6,
+    "status": "discard",
+    "metric": 38.9,
+    "description": "Timsort hybrid slower on random",
+    "asi": {
+      "hypothesis": "Partial-sort heuristic on input distribution",
+      "learned": "Overhead dominates on random arrays"
+    }
+  },
+  "session": {
+    "metric_name": "total_ms",
+    "metric_unit": "ms",
+    "direction": "lower",
+    "baseline_metric": 40.7,
+    "best_metric": 33.5,
+    "run_count": 6,
+    "goal": "optimize sort speed"
+  }
+}
+```
+
+| Field       | Notes                                                         |
+| ----------- | ------------------------------------------------------------- |
+| `run_entry` | The run just logged. Always present.                          |
+| `session`   | Same shape as in `before.sh`, reflecting state after the run. |
+
+### Output
+
+- **Stdout** (up to 8 KB) — delivered to the agent as a steer message on the next turn. Empty = silent.
+- **Stderr + non-zero exit** — surfaced as an error steer.
+- **Timeout** — 30 s hard kill; flagged in the observability entry.
+
+### Preservation
+
+`autoresearch.hooks/**` survives the auto-revert, like all paths matching `autoresearch.*`.
+
+---
+
+## Examples
+
+Runnable reference scripts live in this skill's `examples/` directory — one file per pattern. Paths are resolved against the skill directory (parent of SKILL.md). Browse them for inspiration; they're not policy.
+
+- `examples/before/` — external search, qmd document search, anti-thrash, idea rotator, hypothesis reflection, context rotation, token budget
+- `examples/after/` — learnings journal, macOS notification on new best, auto-tag winning commits
+
+Each example is a complete, self-contained script with named constants, short helper functions, guard clauses, and intention-revealing names. Read the header comment for its purpose, copy to `autoresearch.hooks/<stage>.sh`, adapt.
+
+---
+
+## Steps to add a hook
+
+1. **Understand the session.** Read `autoresearch.md` for the objective and metric; glance at `autoresearch.sh` for the workload. Your hook should complement the loop, not duplicate it.
+
+2. **Clarify the user's intent.** What should happen, at which boundary? Research before / log after / notify on wins / intervene on thrash / etc.
+
+3. **Start from an example in `examples/`** that's closest to the intent (resolve against the skill directory). If nothing fits, write from scratch following the same style (named constants, short functions, guard clauses, JSON stdin parsed with `jq`). If the request combines retrospective + prospective concerns, use both `before.sh` and `after.sh` — don't overload one.
+
+4. **Copy, adapt, mark executable.**
+
+   ```bash
+   mkdir -p autoresearch.hooks
+   cp "<skill-dir>/examples/before/external-search.sh" autoresearch.hooks/before.sh
+   # ... adapt the script ...
+   chmod +x autoresearch.hooks/before.sh
+   ```
+
+5. **Sanity-test with a piped mock** before relying on it in the loop:
+
+   ```bash
+   jq -n '
+     {
+       event: "before",
+       cwd: ".",
+       next_run: 1,
+       last_run: null,
+       session: {
+         metric_name: "total_ms",
+         metric_unit: "ms",
+         direction: "lower",
+         baseline_metric: null,
+         best_metric: null,
+         run_count: 0,
+         goal: "test"
+       }
+     }
+   ' | ./autoresearch.hooks/before.sh
+   ```
+
+   For `after.sh`, swap `last_run: null` for a `run_entry` object (see the schema above).
+
+6. **Commit the hook** alongside other session files. It's preserved across reverts because the path matches `autoresearch.*`.
+
+---
+
+## Rules of thumb
+
+- **Read whatever fields the agent naturally writes** — `asi.hypothesis`, `asi.next_focus`, `asi.learned`, `description`. Don't invent a "hook input" field and instruct the agent to populate it; that breaks the transparency principle.
+
+- **Silent is the default.** Only print to stdout when you have something useful for the agent. Empty stdout means no steer.
+
+- **Guard with early exits.** `[ -z "$query" ] && exit 0` is cheaper and clearer than wrapping everything in `if`.
+
+- **One concern per script.** If you want research + learnings, put them in separate files (`before.sh` and `after.sh`). Don't bundle.
+
+- **No environment variables.** Everything is on stdin; extract `cwd` (and anything else) with `jq`. There is no `$AUTORESEARCH_WORK_DIR`.

--- a/skills/autoresearch-hooks/examples/README.md
+++ b/skills/autoresearch-hooks/examples/README.md
@@ -1,0 +1,46 @@
+# Hook examples
+
+Reference scripts for `autoresearch.hooks/before.sh` and `autoresearch.hooks/after.sh`. Each file is a complete, self-contained example — pick the one closest to what you want, copy it to your session's `autoresearch.hooks/` directory, adapt, and mark executable.
+
+These scripts ship with the `autoresearch-hooks` skill. When the skill is active, paths resolve against the skill directory, so the agent can copy them with:
+
+```bash
+cp "<skill-dir>/examples/before/external-search.sh" /path/to/session/autoresearch.hooks/before.sh
+chmod +x /path/to/session/autoresearch.hooks/before.sh
+```
+
+The files here are **not** marked executable on purpose — they're references, not installed hooks. A `chmod +x` step is required when you wire one up.
+
+For the hook contract (stdin schemas, stdout handling, timeouts, observability), see the main [README §Hooks](../../../README.md#hooks-optional).
+
+## `before/` — fires before each iteration
+
+| Script | Purpose |
+| --- | --- |
+| [`external-search.sh`](before/external-search.sh) | Mine agent notes for a query and fetch external material via your search tool of choice. |
+| [`qmd-search.sh`](before/qmd-search.sh) | Same shape, but targets a local [`qmd`](https://www.npmjs.com/package/qmd) BM25 / vector / rerank index over your project's markdown. |
+| [`anti-thrash.sh`](before/anti-thrash.sh) | After N consecutive discards, emit a steer suggesting a structural rethink. |
+| [`idea-rotator.sh`](before/idea-rotator.sh) | Surface the next unchecked bullet from `autoresearch.ideas.md` as a steer nudge. |
+| [`hypothesis-reflection.sh`](before/hypothesis-reflection.sh) | On a discard, ask a cheap model to critique the failed hypothesis and propose adjacent directions. |
+| [`context-rotation.sh`](before/context-rotation.sh) | Trim an oversized `autoresearch.md`, archiving the tail. |
+| [`token-budget.sh`](before/token-budget.sh) | Nudge the agent when cumulative iteration tokens approach a budget. |
+
+## `after/` — fires after each `log_experiment`
+
+| Script | Purpose |
+| --- | --- |
+| [`learnings-journal.sh`](after/learnings-journal.sh) | Append one human-readable line per run to `autoresearch.learnings.md`. |
+| [`macos-notify.sh`](after/macos-notify.sh) | Fire a native macOS banner only when the run is a new best. |
+| [`auto-tag-winners.sh`](after/auto-tag-winners.sh) | Tag every new best with a sortable git tag. |
+
+## Style conventions
+
+All examples follow the same structure:
+
+- **Named constants at the top** (`readonly`) — no magic literals
+- **Short helper functions** (3–8 lines) for named steps
+- **Guard clauses** at the top with early `exit 0`
+- **Query vs command separation** — queries return values/booleans, commands mutate
+- **Intention-revealing names** — `is_new_best`, `query_from_agent_notes`, `archive_tail`
+
+Adapt freely — these are starting points, not policy.

--- a/skills/autoresearch-hooks/examples/after/auto-tag-winners.sh
+++ b/skills/autoresearch-hooks/examples/after/auto-tag-winners.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Tag every new best with a sortable git tag so `git log --tags` becomes
+# a progression record. Pure side effect — no steer.
+
+set -euo pipefail
+
+readonly TAG_PREFIX="autoresearch/best-run"
+
+is_new_best() {
+  local status="$1" metric="$2" best="$3"
+  [ "$status" = "keep" ] && [ -n "$best" ] && [ "$metric" = "$best" ]
+}
+
+tag_name_for() {
+  local run="$1" metric="$2"
+  printf '%s-%s-%s' "$TAG_PREFIX" "$run" "$(printf '%g' "$metric")"
+}
+
+write_tag() {
+  git -C "$1" tag -f "$2" >/dev/null
+}
+
+input="$(cat)"
+status=$(jq -r '.run_entry.status' <<<"$input")
+metric=$(jq -r '.run_entry.metric' <<<"$input")
+best=$(jq -r '.session.best_metric // empty' <<<"$input")
+
+is_new_best "$status" "$metric" "$best" || exit 0
+
+workdir=$(jq -r '.cwd' <<<"$input")
+run=$(jq -r '.run_entry.run' <<<"$input")
+write_tag "$workdir" "$(tag_name_for "$run" "$metric")"

--- a/skills/autoresearch-hooks/examples/after/learnings-journal.sh
+++ b/skills/autoresearch-hooks/examples/after/learnings-journal.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Append one human-readable line per run to a file that survives revert
+# and accumulates across sessions. Pure side effect — no steer.
+
+set -euo pipefail
+
+readonly LEARNINGS_FILE="autoresearch.learnings.md"
+
+run_number()     { jq -r '.run_entry.run' <<<"$1"; }
+run_status()     { jq -r '.run_entry.status' <<<"$1"; }
+run_metric()     { jq -r '.run_entry.metric' <<<"$1"; }
+run_hypothesis() { jq -r '.run_entry.asi.hypothesis // "-"' <<<"$1"; }
+
+append_journal_line() {
+  local file="$1" run="$2" status="$3" metric="$4" hyp="$5"
+  printf 'run=%s status=%s metric=%s hyp=%s\n' "$run" "$status" "$metric" "$hyp" >> "$file"
+}
+
+input="$(cat)"
+file="$(jq -r '.cwd' <<<"$input")/$LEARNINGS_FILE"
+
+append_journal_line "$file" \
+  "$(run_number "$input")" \
+  "$(run_status "$input")" \
+  "$(run_metric "$input")" \
+  "$(run_hypothesis "$input")"

--- a/skills/autoresearch-hooks/examples/after/macos-notify.sh
+++ b/skills/autoresearch-hooks/examples/after/macos-notify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fires a native macOS banner (and optional steer) only on milestone runs.
+# Uses osascript, which is built into macOS. For other platforms swap to
+# terminal-notifier, notify-send (Linux), or a webhook curl.
+
+set -euo pipefail
+
+readonly TITLE="🏆 autoresearch: new best"
+
+is_new_best() {
+  local status="$1" metric="$2" best="$3"
+  [ "$status" = "keep" ] && [ -n "$best" ] && [ "$metric" = "$best" ]
+}
+
+send_mac_notification() {
+  osascript -e "display notification \"$1\" with title \"$TITLE\"" >/dev/null
+}
+
+input="$(cat)"
+status=$(jq -r '.run_entry.status' <<<"$input")
+metric=$(jq -r '.run_entry.metric' <<<"$input")
+best=$(jq -r '.session.best_metric // empty' <<<"$input")
+name=$(jq -r '.session.metric_name' <<<"$input")
+unit=$(jq -r '.session.metric_unit // ""' <<<"$input")
+
+is_new_best "$status" "$metric" "$best" || exit 0
+
+body="$name = $metric$unit"
+send_mac_notification "$body"
+echo "🏆 New best: $body"

--- a/skills/autoresearch-hooks/examples/before/anti-thrash.sh
+++ b/skills/autoresearch-hooks/examples/before/anti-thrash.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# After N consecutive discards, emit a steer suggesting a structural rethink.
+# Uses session state plus the jsonl tail to detect repeated failure patterns.
+
+set -euo pipefail
+
+readonly WINDOW_SIZE=5
+readonly STREAK_THRESHOLD=5
+
+recent_discard_count() {
+  jq -c 'select(.run != null and (.type // null) != "hook")' "$1" 2>/dev/null \
+    | tail -n "$WINDOW_SIZE" \
+    | jq -r 'select(.status == "discard") | .run' \
+    | wc -l | tr -d ' '
+}
+
+thrash_suggestions() {
+  echo "⚠️ $1 consecutive discards. Consider:"
+  echo "  - Re-reading autoresearch.md and the benchmark script"
+  echo "  - Trying something structurally different, not another variation"
+  echo "  - Measuring what the CPU is actually spending time on"
+}
+
+input="$(cat)"
+jsonl="$(jq -r '.cwd' <<<"$input")/autoresearch.jsonl"
+streak=$(recent_discard_count "$jsonl")
+
+[ "$streak" -lt "$STREAK_THRESHOLD" ] && exit 0
+thrash_suggestions "$streak"

--- a/skills/autoresearch-hooks/examples/before/context-rotation.sh
+++ b/skills/autoresearch-hooks/examples/before/context-rotation.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# When autoresearch.md exceeds a size threshold, keep the preamble and
+# archive the tail. Prevents session-document bloat from eating context.
+
+set -euo pipefail
+
+readonly MAX_BYTES=$((20 * 1024))
+readonly KEEP_LINES=80
+
+file_too_large() {
+  [ "$(wc -c < "$1")" -gt "$MAX_BYTES" ]
+}
+
+archive_tail() {
+  local file="$1" archive="${1%.md}.archive.md"
+  tail -n +$((KEEP_LINES + 1)) "$file" >> "$archive"
+  head -n "$KEEP_LINES" "$file" > "$file.tmp"
+  mv "$file.tmp" "$file"
+}
+
+input="$(cat)"
+md="$(jq -r '.cwd' <<<"$input")/autoresearch.md"
+[ -f "$md" ] && file_too_large "$md" || exit 0
+
+archive_tail "$md"
+echo "Rotated autoresearch.md (kept first $KEEP_LINES lines, archived rest)."

--- a/skills/autoresearch-hooks/examples/before/external-search.sh
+++ b/skills/autoresearch-hooks/examples/before/external-search.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Infers a query from the agent's natural notes and fetches external material.
+# Swap the search-cli call for any tool you have: an MCP client, a CLI over
+# a documentation index, a curl to a search API, a web-search wrapper.
+
+set -euo pipefail
+
+readonly RESEARCH_FILE="autoresearch.research.md"
+readonly RESULT_LIMIT=5
+
+query_from_agent_notes() {
+  jq -r '
+    .last_run.asi.next_focus //
+    .last_run.asi.hypothesis //
+    .last_run.description //
+    .session.goal //
+    empty
+  ' <<<"$1"
+}
+
+fetch_results() {
+  # Replace with your search tool of choice.
+  search-cli "$1" -n "$RESULT_LIMIT"
+}
+
+input="$(cat)"
+query=$(query_from_agent_notes "$input")
+[ -z "$query" ] && exit 0
+
+workdir="$(jq -r '.cwd' <<<"$input")"
+fetch_results "$query" > "$workdir/$RESEARCH_FILE"
+echo "Research saved → $RESEARCH_FILE (query: $query)"

--- a/skills/autoresearch-hooks/examples/before/hypothesis-reflection.sh
+++ b/skills/autoresearch-hooks/examples/before/hypothesis-reflection.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# On a discard, ask a cheap model to critique the failed hypothesis.
+# Swap llm-cli for any short-prompt CLI (claude-haiku, llama-cli, ollama,
+# a local endpoint via curl, etc.).
+
+set -euo pipefail
+
+readonly MODEL="claude-haiku-4-5"
+
+fired_on_discard() {
+  [ "$(jq -r '.last_run.status // empty' <<<"$1")" = "discard" ]
+}
+
+critique_prompt() {
+  local hyp="$1" reason="$2"
+  printf 'Hypothesis "%s" was discarded because: %s.\n' "$hyp" "$reason"
+  printf 'Name two adjacent directions that might work instead. One sentence each.'
+}
+
+ask_model() {
+  llm-cli --model "$MODEL" --prompt "$1"
+}
+
+input="$(cat)"
+fired_on_discard "$input" || exit 0
+
+hyp=$(jq -r '.last_run.asi.hypothesis // "unknown"' <<<"$input")
+reason=$(jq -r '.last_run.asi.rollback_reason // "unknown"' <<<"$input")
+ask_model "$(critique_prompt "$hyp" "$reason")"

--- a/skills/autoresearch-hooks/examples/before/idea-rotator.sh
+++ b/skills/autoresearch-hooks/examples/before/idea-rotator.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# If autoresearch.ideas.md exists, surface the top unchecked bullet
+# as a steer nudge. Format assumes markdown checkboxes: `- [ ] idea`.
+
+set -euo pipefail
+
+readonly IDEAS_FILE="autoresearch.ideas.md"
+readonly UNCHECKED_PATTERN='^- \[ \]'
+
+first_unchecked_idea() {
+  grep -m1 -E "$UNCHECKED_PATTERN" "$1" | sed 's/^- \[ \] //'
+}
+
+input="$(cat)"
+ideas="$(jq -r '.cwd' <<<"$input")/$IDEAS_FILE"
+[ -f "$ideas" ] || exit 0
+
+next=$(first_unchecked_idea "$ideas")
+[ -z "$next" ] && exit 0
+echo "Next idea from $IDEAS_FILE: $next"

--- a/skills/autoresearch-hooks/examples/before/qmd-search.sh
+++ b/skills/autoresearch-hooks/examples/before/qmd-search.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Same shape as external-search but targets a local qmd collection:
+# a BM25 / vector / rerank index over your project's markdown.
+# Useful for private or project-specific corpora (design docs, ADRs,
+# runbooks, past postmortems).
+#
+# One-time setup: qmd collection add <path> --name <name>
+# See https://www.npmjs.com/package/qmd
+
+set -euo pipefail
+
+readonly DOCS_FILE="autoresearch.docs.md"
+readonly RESULT_LIMIT=5
+
+query_from_agent_notes() {
+  jq -r '
+    .last_run.asi.next_focus //
+    .last_run.asi.hypothesis //
+    .last_run.description //
+    .session.goal //
+    empty
+  ' <<<"$1"
+}
+
+fetch_docs() {
+  # `qmd query` = combined search with query expansion + reranking.
+  # Alternatives: `qmd search` (pure BM25), `qmd vsearch` (vector similarity).
+  qmd query "$1" -n "$RESULT_LIMIT"
+}
+
+input="$(cat)"
+query=$(query_from_agent_notes "$input")
+[ -z "$query" ] && exit 0
+
+workdir="$(jq -r '.cwd' <<<"$input")"
+fetch_docs "$query" > "$workdir/$DOCS_FILE"
+echo "Docs saved → $DOCS_FILE (query: $query)"

--- a/skills/autoresearch-hooks/examples/before/token-budget.sh
+++ b/skills/autoresearch-hooks/examples/before/token-budget.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Nudge the agent when cumulative iteration tokens approach a budget.
+# Reads iterationTokens from every run entry in autoresearch.jsonl.
+
+set -euo pipefail
+
+readonly BUDGET=1000000
+readonly WARN_AT=800000
+
+total_iteration_tokens() {
+  jq -s '[.[] | select(.run != null) | .iterationTokens // 0] | add // 0' "$1" 2>/dev/null
+}
+
+exceeds_warn_threshold() {
+  [ "$1" -ge "$WARN_AT" ]
+}
+
+input="$(cat)"
+jsonl="$(jq -r '.cwd' <<<"$input")/autoresearch.jsonl"
+total=$(total_iteration_tokens "$jsonl")
+
+exceeds_warn_threshold "$total" || exit 0
+
+remaining=$((BUDGET - total))
+echo "⚠️ Token usage: $total / $BUDGET ($remaining remaining). Wrap up high-value ideas."

--- a/tests/jsonl-helpers.test.mjs
+++ b/tests/jsonl-helpers.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import test from "node:test";
+import { tmpdir } from "node:os";
+
+import { appendHookLogEntryIfConfigured } from "../extensions/pi-autoresearch/hooks.ts";
+import {
+  extractAutoresearchSessionName,
+  hasAutoresearchConfigHeader,
+  isAutoresearchConfigEntry,
+  isAutoresearchRunEntry,
+  parseJsonlEntry,
+  reconstructJsonlState,
+} from "../extensions/pi-autoresearch/jsonl.ts";
+
+test("hook entries are skipped when identifying run entries", () => {
+  const hookEntry = parseJsonlEntry('{"type":"hook","stage":"before","exit_code":0}');
+  const runEntry = parseJsonlEntry('{"run":1,"metric":42}');
+
+  assert.equal(isAutoresearchConfigEntry(hookEntry), false);
+  assert.equal(isAutoresearchRunEntry(hookEntry), false);
+  assert.equal(isAutoresearchRunEntry(runEntry), true);
+});
+
+test("hook-only jsonl does not count as having a config header", () => {
+  const jsonl = '{"type":"hook","stage":"before","exit_code":0}\n';
+
+  assert.equal(hasAutoresearchConfigHeader(jsonl), false);
+});
+
+test("session name comes from the first config entry, not the first line", () => {
+  const jsonl = [
+    '{"type":"hook","stage":"before","exit_code":0}',
+    '{"type":"config","name":"Hook-safe session","metricName":"total_ms","metricUnit":"ms","bestDirection":"lower"}',
+    '{"run":1,"commit":"abc1234","metric":10,"status":"keep","description":"baseline","timestamp":1,"metrics":{}}',
+  ].join("\n");
+
+  assert.equal(hasAutoresearchConfigHeader(jsonl), true);
+  assert.equal(extractAutoresearchSessionName(jsonl), "Hook-safe session");
+});
+
+test("reconstructJsonlState ignores hooks and preserves run segments", () => {
+  const jsonl = [
+    '{"type":"config","name":"Segmented session","metricName":"total_ms","metricUnit":"ms","bestDirection":"lower"}',
+    '{"type":"hook","stage":"before","exit_code":0}',
+    '{"run":1,"commit":"aaa1111","metric":10,"status":"keep","description":"baseline","timestamp":1,"metrics":{"compile_ms":4},"iterationTokens":21}',
+    '{"type":"hook","stage":"after","exit_code":0}',
+    '{"type":"config","name":"Segmented session","metricName":"total_ms","metricUnit":"ms","bestDirection":"lower"}',
+    '{"type":"hook","stage":"before","exit_code":0}',
+    '{"run":2,"commit":"bbb2222","metric":7,"status":"keep","description":"new baseline","timestamp":2,"metrics":{"render_ms":2},"iterationTokens":13}',
+  ].join("\n");
+
+  const state = reconstructJsonlState(jsonl);
+
+  assert.equal(state.results.length, 2);
+  assert.deepEqual(state.results.map((result) => result.metric), [10, 7]);
+  assert.deepEqual(state.results.map((result) => result.segment), [0, 1]);
+  assert.equal(state.currentSegment, 1);
+  assert.deepEqual(state.iterationTokenHistory, [21, 13]);
+  assert.deepEqual(state.secondaryMetrics.map((metric) => metric.name), ["render_ms"]);
+});
+
+test("hook observability does not create jsonl before config exists", () => {
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hooks-"));
+  const jsonlPath = path.join(tempDir, "autoresearch.jsonl");
+  const result = {
+    fired: true,
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+    timedOut: false,
+    durationMs: 5,
+  };
+
+  try {
+    assert.equal(appendHookLogEntryIfConfigured(jsonlPath, "before", result), false);
+    assert.equal(fs.existsSync(jsonlPath), false);
+
+    fs.writeFileSync(jsonlPath, '{"type":"hook","stage":"before","exit_code":0}\n');
+    assert.equal(appendHookLogEntryIfConfigured(jsonlPath, "after", result), false);
+    assert.equal(
+      fs.readFileSync(jsonlPath, "utf-8"),
+      '{"type":"hook","stage":"before","exit_code":0}\n',
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds two optional executable scripts that fire at iteration boundaries and stay **transparent to the loop-running agent**. Users configure hooks as infrastructure; the agent doesn't learn they exist. Stdout becomes a steer message; side effects happen on disk. We also ship a new `autoresearch-hooks` skill with a bunch of examples in `skills/autoresearch-hooks/examples/`; the skill itself helps author new ones.

<img width="1376" height="768" alt="nano-banana-20260424-165358-5d0c1e" src="https://github.com/user-attachments/assets/519bc28c-0fce-4eb6-91e4-2ebd75fb52a9" />


## Why 

Right now the only way to steer and get outputs is by manual intervention while executing. With hooks we can automate what happens before and after every iteration.

**Before**: It will serve to steer the execution: run some research, pull skills, change direction of hypothesis, etc.
**After**: Annotate learnings, notifications on new best...

## What ships

- **Extension** — new `hooks.ts` dispatcher (spawn, 30 s timeout, 8 KB stdout cap, JSON-stdin, observability), three fire sites in `index.ts` (`/autoresearch` activation, `init_experiment`, end of `log_experiment`), and a generalised preservation rule in `finalize.sh` that keeps any `autoresearch.*` path segment across reverts.
- **Skill** — new `autoresearch-hooks` with the contract and authoring steps, plus ten reference scripts at `skills/autoresearch-hooks/examples/` (seven `before/`, three `after/`).
- **Docs** — README gains a §Hooks section with stdin schemas and a pointer to the examples.

## Design principles

- **Agent-oblivious.** Hooks are infrastructure the user configures. The agent calls tools and sees results; hooks run alongside and communicate indirectly (files it naturally reads, or occasional user-message-shaped steers).
- **Structured input.** Each hook receives one JSON line on stdin with a stage-specific schema. No environment variables for hook state.
- **Unix plumbing.** Executable bit required. Stdout becomes a steer. Non-zero exit or timeout surfaces an error. No SDK, no lifecycle API.
- **Observability included.** Every fire appends a `{"type":"hook",…}` entry to `autoresearch.jsonl`.

## Contract

### Stdin — `before.sh`

One JSON line. Parse with `jq`. Realistic example:

```json
{
  "event": "before",
  "cwd": "/path/to/workdir",
  "next_run": 6,
  "last_run": {
    "run": 5,
    "status": "discard",
    "metric": 42.1,
    "description": "Simplified to sorted(arr) — copy cost dominates",
    "asi": {
      "hypothesis": "Built-in sort avoids Python overhead",
      "next_focus": "list copy avoidance"
    }
  },
  "session": {
    "metric_name": "total_ms",
    "metric_unit": "ms",
    "direction": "lower",
    "baseline_metric": 40.7,
    "best_metric": 33.5,
    "run_count": 5,
    "goal": "optimize sort speed"
  }
}
```

| Field                     | Notes                                                               |
| ------------------------- | ------------------------------------------------------------------- |
| `last_run`                | The most recent run entry. `null` on a fresh session.               |
| `session.direction`       | `"lower"` or `"higher"` — which end of the scale wins.              |
| `session.baseline_metric` | First run of the current segment. `null` until one run exists.      |
| `session.best_metric`     | Optimal metric across **kept** runs only. `null` until one is kept. |
| `session.goal`            | The session name set by `init_experiment`.                          |
| `session.run_count`       | Total runs logged so far (any status).                              |

### Stdin — `after.sh`

```json
{
  "event": "after",
  "cwd": "/path/to/workdir",
  "run_entry": {
    "run": 6,
    "status": "discard",
    "metric": 38.9,
    "description": "Timsort hybrid slower on random",
    "asi": {
      "hypothesis": "Partial-sort heuristic on input distribution",
      "learned": "Overhead dominates on random arrays"
    }
  },
  "session": {
    "metric_name": "total_ms",
    "metric_unit": "ms",
    "direction": "lower",
    "baseline_metric": 40.7,
    "best_metric": 33.5,
    "run_count": 6,
    "goal": "optimize sort speed"
  }
}
```

| Field       | Notes                                                         |
| ----------- | ------------------------------------------------------------- |
| `run_entry` | The run just logged. Always present.                          |
| `session`   | Same shape as in `before.sh`, reflecting state after the run. |

### Output

- **Stdout** (up to 8 KB) — delivered to the agent as a steer message on the next turn. Empty = silent.
- **Stderr + non-zero exit** — surfaced as an error steer.
- **Timeout** — 30 s hard kill; flagged in the observability entry.

## Agent signal

The agent writes `description` and `asi.*` fields (`hypothesis`, `next_focus`, `learned`, `rollback_reason`) in its `log_experiment` calls for its own future-self reasoning. Hooks opportunistically mine whichever fields the agent naturally uses. There is no dedicated "hook input" field; the `autoresearch-create` skill has zero mention of hooks. Adding a `autoresearch-hooks/` directory to a session is silently picked up on the next iteration boundary.

## Authoring a hook

Two surfaces, separate concerns:

| Surface | Audience | Purpose |
| --- | --- | --- |
| `skills/autoresearch-hooks/SKILL.md` | Agent handling a user request to "add a hook that X" | Contract + steps + rules of thumb |
| `skills/autoresearch-hooks/examples/` | Human (or agent) looking for inspiration | 10 runnable reference scripts, split by stage. Paths resolve against the skill directory, so `pi install` makes them reachable. |

Typical workflow:
1. Browse the skill's `examples/before/` or `examples/after/` for a pattern close to the intent.
2. Copy to `autoresearch.hooks/<stage>.sh`.
3. Adapt.
4. `chmod +x`.
5. Sanity-test with a piped mock JSON.

The examples themselves are **not** marked executable — they're references, not installed hooks. `chmod +x` is an explicit step.

## Observability

Every hook invocation appends a line to `autoresearch.jsonl`:

```json
{"type":"hook","stage":"before","exit_code":0,"duration_ms":3052,"stdout_bytes":109,"timed_out":false}
```

Useful for diagnosing slow hooks, cataloguing failures, or post-hoc analysis.