### PR TITLE
Deterministic compaction summary for autoresearch sessions

### DIFF
--- a/extensions/pi-autoresearch/compaction.ts
+++ b/extensions/pi-autoresearch/compaction.ts
@@ -1,0 +1,178 @@
+/**
+ * Deterministic compaction summary for autoresearch sessions.
+ *
+ * Replaces the default LLM-generated summary with a synthesized view of
+ * persisted state — experiment rules, ideas backlog, and recent runs.
+ * Everything that matters between iterations already lives on disk, so we
+ * skip the LLM call entirely and keep the summary lossless on what counts.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+  reconstructJsonlState,
+  type ReconstructedRun,
+} from "./jsonl.ts";
+
+const RECENT_RUN_LIMIT = 50;
+
+export interface AutoresearchSummaryPaths {
+  workDir: string;
+  jsonlPath: string;
+  mdPath: string;
+  ideasPath: string;
+}
+
+export function autoresearchSummaryPathsFor(workDir: string): AutoresearchSummaryPaths {
+  return {
+    workDir,
+    jsonlPath: path.join(workDir, "autoresearch.jsonl"),
+    mdPath: path.join(workDir, "autoresearch.md"),
+    ideasPath: path.join(workDir, "autoresearch.ideas.md"),
+  };
+}
+
+/**
+ * Build the full compaction summary text from persisted autoresearch state.
+ * Returns a markdown string that is itself the entire compaction summary.
+ */
+export function buildAutoresearchCompactionSummary(paths: AutoresearchSummaryPaths): string {
+  const sections = [
+    headerSection(),
+    rulesSection(paths.mdPath),
+    ideasSection(paths.ideasPath),
+    recentRunsSection(paths.jsonlPath),
+    nextStepSection(),
+  ];
+  return sections.filter(Boolean).join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+function headerSection(): string {
+  return [
+    "# Autoresearch Compaction Summary",
+    "",
+    "The conversation history was discarded; the persisted autoresearch state below is the source of truth.",
+    "Continue the experiment loop using only what is included here plus the live tools.",
+  ].join("\n");
+}
+
+function rulesSection(mdPath: string): string {
+  const content = readTrimmedFile(mdPath);
+  if (!content) return "";
+  return `## Experiment Rules (autoresearch.md)\n\n${content}`;
+}
+
+function ideasSection(ideasPath: string): string {
+  const content = readTrimmedFile(ideasPath);
+  if (!content) return "";
+  return `## Ideas Backlog (autoresearch.ideas.md)\n\n${content}`;
+}
+
+function recentRunsSection(jsonlPath: string): string {
+  const runs = recentRuns(jsonlPath);
+  if (runs.length === 0) {
+    return "## Recent Runs\n\nNo runs yet — start with the first hypothesis.";
+  }
+  const lines = runs.map((run) => formatRunLine(run, baselineFor(run, runs)));
+  return [
+    `## Recent Runs (last ${runs.length})`,
+    "",
+    "Format: `#run status metric (delta) | desc | hyp: ... | next: ... | rollback: ...`",
+    "",
+    ...lines,
+    "",
+    "If you need more details, read additional lines from autoresearch.jsonl.",
+  ].join("\n");
+}
+
+function nextStepSection(): string {
+  return [
+    "## Next Step",
+    "",
+    "Pick the most promising hypothesis (from the ideas backlog or the latest `next:` hints in recent runs)",
+    "and run the next experiment immediately. Do not stop until interrupted.",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Recent runs
+// ---------------------------------------------------------------------------
+
+function recentRuns(jsonlPath: string): ReconstructedRun[] {
+  const content = readFileOrEmpty(jsonlPath);
+  if (!content) return [];
+  const state = reconstructJsonlState(content);
+  return state.results.slice(-RECENT_RUN_LIMIT);
+}
+
+/** Baseline metric for a run = first run in the same segment within the visible window. */
+function baselineFor(run: ReconstructedRun, all: ReconstructedRun[]): number | null {
+  const sameSegment = all.find((other) => other.segment === run.segment);
+  return sameSegment?.metric ?? null;
+}
+
+function formatRunLine(run: ReconstructedRun, baseline: number | null): string {
+  const head = `#${run.run} ${padStatus(run.status)} ${formatMetric(run.metric)}${formatDelta(run.metric, baseline)}`;
+  const parts = [head, formatDescription(run), ...formatAsiFields(run.asi)];
+  return parts.filter(Boolean).join(" | ");
+}
+
+function padStatus(status: ReconstructedRun["status"]): string {
+  return status.padEnd(STATUS_WIDTH);
+}
+
+const STATUS_WIDTH = "checks_failed".length;
+
+function formatMetric(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(2);
+}
+
+function formatDelta(value: number, baseline: number | null): string {
+  if (baseline === null || baseline === 0 || value === baseline) return "";
+  const pct = ((value - baseline) / baseline) * 100;
+  const sign = pct > 0 ? "+" : "";
+  return ` (${sign}${pct.toFixed(1)}%)`;
+}
+
+function formatDescription(run: ReconstructedRun): string {
+  return run.description ? `desc: ${run.description}` : "";
+}
+
+function formatAsiFields(asi: ReconstructedRun["asi"]): string[] {
+  if (!asi) return [];
+  return [
+    formatAsiField(asi, "hypothesis", "hyp"),
+    formatAsiField(asi, "next_action_hint", "next"),
+    formatAsiField(asi, "rollback_reason", "rollback"),
+  ];
+}
+
+function formatAsiField(asi: Record<string, unknown>, key: string, label: string): string {
+  const value = asi[key];
+  if (typeof value !== "string" || value.trim() === "") return "";
+  return `${label}: ${value.trim()}`;
+}
+
+// ---------------------------------------------------------------------------
+// File IO
+// ---------------------------------------------------------------------------
+
+function readTrimmedFile(filePath: string): string {
+  return readFileOrEmpty(filePath).trim();
+}
+
+function readFileOrEmpty(filePath: string): string {
+  if (!fs.existsSync(filePath)) return "";
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}

--- a/extensions/pi-autoresearch/compaction.ts
+++ b/extensions/pi-autoresearch/compaction.ts
@@ -12,10 +12,14 @@ import * as path from "node:path";
 
 import {
   reconstructJsonlState,
+  type ReconstructedJsonlState,
   type ReconstructedRun,
 } from "./jsonl.ts";
 
 const RECENT_RUN_LIMIT = 50;
+
+type RunStatus = ReconstructedRun["status"];
+type StatusCounts = Record<RunStatus, number>;
 
 export interface AutoresearchSummaryPaths {
   workDir: string;
@@ -38,14 +42,20 @@ export function autoresearchSummaryPathsFor(workDir: string): AutoresearchSummar
  * Returns a markdown string that is itself the entire compaction summary.
  */
 export function buildAutoresearchCompactionSummary(paths: AutoresearchSummaryPaths): string {
+  const state = loadState(paths.jsonlPath);
   const sections = [
     headerSection(),
+    sessionSection(state),
     rulesSection(paths.mdPath),
     ideasSection(paths.ideasPath),
-    recentRunsSection(paths.jsonlPath),
+    recentRunsSection(state),
     nextStepSection(),
   ];
   return sections.filter(Boolean).join("\n\n");
+}
+
+function loadState(jsonlPath: string): ReconstructedJsonlState {
+  return reconstructJsonlState(readFileOrEmpty(jsonlPath));
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +71,72 @@ function headerSection(): string {
   ].join("\n");
 }
 
+function sessionSection(state: ReconstructedJsonlState): string {
+  const runs = currentSegmentRuns(state);
+  const lines = [
+    "## Session",
+    "",
+    `Goal: ${state.name ?? "—"}`,
+    `Metric: ${state.metricName} — ${state.bestDirection} is better`,
+    runCountLine(runs),
+    ...baselineAndBestLines(runs, state.bestDirection, state.metricUnit),
+  ];
+  return lines.join("\n");
+}
+
+function currentSegmentRuns(state: ReconstructedJsonlState): ReconstructedRun[] {
+  return state.results.filter((run) => run.segment === state.currentSegment);
+}
+
+function runCountLine(runs: ReconstructedRun[]): string {
+  if (runs.length === 0) return "Runs so far: 0";
+  const counts = countByStatus(runs);
+  const parts = [
+    `${counts.keep} keep`,
+    counts.discard ? `${counts.discard} discard` : "",
+    counts.crash ? `${counts.crash} crash` : "",
+    counts.checks_failed ? `${counts.checks_failed} checks_failed` : "",
+  ].filter(Boolean);
+  return `Runs so far: ${runs.length} (${parts.join(" · ")})`;
+}
+
+function countByStatus(runs: ReconstructedRun[]): StatusCounts {
+  const counts: StatusCounts = { keep: 0, discard: 0, crash: 0, checks_failed: 0 };
+  for (const run of runs) counts[run.status]++;
+  return counts;
+}
+
+function baselineAndBestLines(
+  runs: ReconstructedRun[],
+  direction: "lower" | "higher",
+  unit: string,
+): string[] {
+  const baseline = runs[0];
+  if (!baseline) return [];
+  const lines = [`Baseline (#${baseline.run}): ${formatMetricWithUnit(baseline.metric, unit)}`];
+  const best = bestRun(runs, direction);
+  if (best && best.run !== baseline.run) {
+    lines.push(
+      `Best     (#${best.run}): ${formatMetricWithUnit(best.metric, unit)}${formatDelta(best.metric, baseline.metric)}`,
+    );
+  }
+  return lines;
+}
+
+function formatMetricWithUnit(value: number, unit: string): string {
+  return `${formatMetric(value)}${unit}`;
+}
+
+function bestRun(runs: ReconstructedRun[], direction: "lower" | "higher"): ReconstructedRun | null {
+  const kept = runs.filter((run) => run.status === "keep" && Number.isFinite(run.metric));
+  if (kept.length === 0) return null;
+  return kept.reduce((best, run) => (isBetter(run.metric, best.metric, direction) ? run : best));
+}
+
+function isBetter(value: number, current: number, direction: "lower" | "higher"): boolean {
+  return direction === "lower" ? value < current : value > current;
+}
+
 function rulesSection(mdPath: string): string {
   const content = readTrimmedFile(mdPath);
   if (!content) return "";
@@ -73,12 +149,12 @@ function ideasSection(ideasPath: string): string {
   return `## Ideas Backlog (autoresearch.ideas.md)\n\n${content}`;
 }
 
-function recentRunsSection(jsonlPath: string): string {
-  const runs = recentRuns(jsonlPath);
+function recentRunsSection(state: ReconstructedJsonlState): string {
+  const runs = state.results.slice(-RECENT_RUN_LIMIT);
   if (runs.length === 0) {
     return "## Recent Runs\n\nNo runs yet — start with the first hypothesis.";
   }
-  const lines = runs.map((run) => formatRunLine(run, baselineFor(run, runs)));
+  const lines = runs.map((run) => formatRunLine(run, baselineFor(run, state.results)));
   return [
     `## Recent Runs (last ${runs.length})`,
     "",
@@ -103,14 +179,7 @@ function nextStepSection(): string {
 // Recent runs
 // ---------------------------------------------------------------------------
 
-function recentRuns(jsonlPath: string): ReconstructedRun[] {
-  const content = readFileOrEmpty(jsonlPath);
-  if (!content) return [];
-  const state = reconstructJsonlState(content);
-  return state.results.slice(-RECENT_RUN_LIMIT);
-}
-
-/** Baseline metric for a run = first run in the same segment within the visible window. */
+/** Baseline metric for a run = first run in the same segment across full reconstructed state. */
 function baselineFor(run: ReconstructedRun, all: ReconstructedRun[]): number | null {
   const sameSegment = all.find((other) => other.segment === run.segment);
   return sameSegment?.metric ?? null;

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -16,6 +16,7 @@
 import type {
   ExtensionAPI,
   ExtensionContext,
+  SessionBeforeCompactEvent,
   Theme,
 } from "@mariozechner/pi-coding-agent";
 import { truncateTail, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@mariozechner/pi-coding-agent";
@@ -45,6 +46,10 @@ import {
   extractAutoresearchSessionName,
   reconstructJsonlState,
 } from "./jsonl.ts";
+import {
+  autoresearchSummaryPathsFor,
+  buildAutoresearchCompactionSummary,
+} from "./compaction.ts";
 
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
@@ -1061,20 +1066,31 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     );
   };
 
-  const hasIdeasFile = (ctx: ExtensionContext): boolean =>
-    fs.existsSync(autoresearchIdeasPath(resolveWorkDir(ctx.cwd)));
+  const composeResumeMessage = (_ctx: ExtensionContext): string => {
+    // The compaction summary already contains the rules, ideas, and recent
+    // runs — so this resume message just kicks the loop forward.
+    return [
+      "Run the next iteration now.",
+      "Pick the most promising hypothesis from the ideas backlog or the latest `next:` hints in recent runs, then call run_experiment + log_experiment.",
+      "Do not re-read autoresearch.md or autoresearch.jsonl — the compaction summary already contains them.",
+      BENCHMARK_GUARDRAIL,
+    ].join(" ");
+  };
 
-  const composeResumeMessage = (ctx: ExtensionContext): string => {
-    const parts = [
-      "Autoresearch loop ended (likely context limit and auto-compaction).",
-      "Re-read the persisted autoresearch context before continuing: autoresearch.md (rules), the tail of autoresearch.jsonl (recent kept/discarded runs and ASI), and git log (commits map 1:1 to kept experiments).",
-    ];
-    if (hasIdeasFile(ctx)) {
-      parts.push("Then check autoresearch.ideas.md for promising paths to explore and prune stale/tried ideas.");
-    }
-    parts.push("Resume the experiment loop with the next most promising hypothesis.");
-    parts.push(BENCHMARK_GUARDRAIL);
-    return parts.join(" ");
+  const autoresearchCompactionFor = (
+    ctx: ExtensionContext,
+    event: SessionBeforeCompactEvent,
+  ) => {
+    if (!getRuntime(ctx).autoresearchMode) return undefined;
+    return {
+      compaction: {
+        summary: buildAutoresearchCompactionSummary(
+          autoresearchSummaryPathsFor(resolveWorkDir(ctx.cwd)),
+        ),
+        firstKeptEntryId: event.preparation.firstKeptEntryId,
+        tokensBefore: event.preparation.tokensBefore,
+      },
+    };
   };
 
   const sendWhenReady = (ctx: ExtensionContext, message: string): void => {
@@ -1435,8 +1451,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     schedulePendingResume(ctx, runtime, composeResumeMessage(ctx));
   };
 
-  pi.on("session_before_compact", async (_event, ctx) => {
+  pi.on("session_before_compact", async (event, ctx) => {
     pausePendingResume(getRuntime(ctx));
+    return autoresearchCompactionFor(ctx, event);
   });
 
   pi.on("session_compact", async (_event, ctx) => {

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1067,6 +1067,14 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   const composeResumeMessage = (_ctx: ExtensionContext): string => {
+    return [
+      "Run the next iteration now.",
+      "Use the persisted autoresearch state as needed, pick the most promising hypothesis, then call run_experiment + log_experiment.",
+      BENCHMARK_GUARDRAIL,
+    ].join(" ");
+  };
+
+  const composeCompactionResumeMessage = (_ctx: ExtensionContext): string => {
     // The compaction summary already contains the rules, ideas, and recent
     // runs — so this resume message just kicks the loop forward.
     return [
@@ -1437,6 +1445,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const ensurePendingResume = (
     ctx: ExtensionContext,
     gate: (runtime: AutoresearchRuntime) => boolean,
+    composeMessage: (ctx: ExtensionContext) => string = composeResumeMessage,
   ): void => {
     const runtime = getRuntime(ctx);
     if (hasPendingResume(runtime)) {
@@ -1448,7 +1457,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       notifyAutoResumeLimitReached(ctx);
       return;
     }
-    schedulePendingResume(ctx, runtime, composeResumeMessage(ctx));
+    schedulePendingResume(ctx, runtime, composeMessage(ctx));
   };
 
   pi.on("session_before_compact", async (event, ctx) => {
@@ -1457,7 +1466,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   pi.on("session_compact", async (_event, ctx) => {
-    ensurePendingResume(ctx, shouldAutoResumeAfterCompact);
+    ensurePendingResume(ctx, shouldAutoResumeAfterCompact, composeCompactionResumeMessage);
   });
 
   pi.on("agent_end", async (_event, ctx) => {

--- a/extensions/pi-autoresearch/jsonl.ts
+++ b/extensions/pi-autoresearch/jsonl.ts
@@ -18,6 +18,7 @@ export interface ReconstructedMetricDef {
 }
 
 export interface ReconstructedRun {
+  run: number;
   commit: string;
   metric: number;
   metrics: Record<string, number>;
@@ -112,6 +113,7 @@ function nextSegment(state: ReconstructedJsonlState, segment: number): number {
 
 function runFrom(entry: AutoresearchRunEntry, segment: number): ReconstructedRun {
   return {
+    run: typeof entry.run === "number" ? entry.run : 0,
     commit: typeof entry.commit === "string" ? entry.commit : "",
     metric: typeof entry.metric === "number" ? entry.metric : 0,
     metrics: metricMapFrom(entry.metrics),

--- a/tests/compaction.test.mjs
+++ b/tests/compaction.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import test from "node:test";
+import { tmpdir } from "node:os";
+
+import {
+  autoresearchSummaryPathsFor,
+  buildAutoresearchCompactionSummary,
+} from "../extensions/pi-autoresearch/compaction.ts";
+
+function withTempWorkDir(fn) {
+  const dir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-compact-"));
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeJsonlLines(workDir, lines) {
+  fs.writeFileSync(path.join(workDir, "autoresearch.jsonl"), lines.join("\n") + "\n");
+}
+
+test("summary contains all three persisted sources when present", () => {
+  withTempWorkDir((workDir) => {
+    fs.writeFileSync(path.join(workDir, "autoresearch.md"), "# Rules\nDo not cheat.");
+    fs.writeFileSync(path.join(workDir, "autoresearch.ideas.md"), "- Try memoization\n- Try parallelism");
+    writeJsonlLines(workDir, [
+      '{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',
+      '{"run":1,"commit":"aaa1111","metric":100,"status":"keep","description":"baseline","timestamp":1,"metrics":{},"asi":{"hypothesis":"start point"}}',
+      '{"run":2,"commit":"bbb2222","metric":80,"status":"keep","description":"cache foo","timestamp":2,"metrics":{},"asi":{"hypothesis":"memoize repeated keys","next_action_hint":"try LRU"}}',
+      '{"run":3,"commit":"ccc3333","metric":120,"status":"discard","description":"tried lru-cache","timestamp":3,"metrics":{},"asi":{"rollback_reason":"import overhead"}}',
+    ]);
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.match(summary, /# Autoresearch Compaction Summary/);
+    assert.match(summary, /## Experiment Rules \(autoresearch\.md\)/);
+    assert.match(summary, /Do not cheat\./);
+    assert.match(summary, /## Ideas Backlog \(autoresearch\.ideas\.md\)/);
+    assert.match(summary, /Try memoization/);
+    assert.match(summary, /## Recent Runs \(last 3\)/);
+    assert.match(summary, /#1 keep/);
+    assert.match(summary, /#2 keep\s+80 \(-20\.0%\)/);
+    assert.match(summary, /#3 discard\s+120 \(\+20\.0%\)/);
+    assert.match(summary, /hyp: memoize repeated keys/);
+    assert.match(summary, /next: try LRU/);
+    assert.match(summary, /rollback: import overhead/);
+    assert.match(summary, /## Next Step/);
+    assert.match(summary, /If you need more details, read additional lines from autoresearch\.jsonl\./);
+  });
+});
+
+test("summary degrades gracefully when no files exist", () => {
+  withTempWorkDir((workDir) => {
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.match(summary, /# Autoresearch Compaction Summary/);
+    assert.doesNotMatch(summary, /## Experiment Rules/);
+    assert.doesNotMatch(summary, /## Ideas Backlog/);
+    assert.match(summary, /No runs yet/);
+    assert.match(summary, /## Next Step/);
+  });
+});
+
+test("summary keeps only the last 50 runs", () => {
+  withTempWorkDir((workDir) => {
+    const lines = ['{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}'];
+    for (let i = 1; i <= 75; i++) {
+      lines.push(`{"run":${i},"commit":"c${i}","metric":${100 + i},"status":"keep","description":"r${i}","timestamp":${i},"metrics":{}}`);
+    }
+    writeJsonlLines(workDir, lines);
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.match(summary, /## Recent Runs \(last 50\)/);
+    assert.doesNotMatch(summary, /#25 keep/);
+    assert.match(summary, /#26 keep/);
+    assert.match(summary, /#75 keep/);
+  });
+});
+
+test("delta is computed against the first run of the same segment within window", () => {
+  withTempWorkDir((workDir) => {
+    writeJsonlLines(workDir, [
+      '{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',
+      '{"run":1,"commit":"a","metric":200,"status":"keep","description":"seg0 base","timestamp":1,"metrics":{}}',
+      '{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',
+      '{"run":2,"commit":"b","metric":100,"status":"keep","description":"seg1 base","timestamp":2,"metrics":{}}',
+      '{"run":3,"commit":"c","metric":80,"status":"keep","description":"seg1 better","timestamp":3,"metrics":{}}',
+    ]);
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    // seg1 base (#2) is the baseline for #3 — no delta on #2 itself
+    assert.match(summary, /#2 keep\s+100 \| desc: seg1 base/);
+    assert.match(summary, /#3 keep\s+80 \(-20\.0%\) \| desc: seg1 better/);
+    // seg0 base (#1) shows no delta (it is its own baseline)
+    assert.match(summary, /#1 keep\s+200 \| desc: seg0 base/);
+  });
+});

--- a/tests/compaction.test.mjs
+++ b/tests/compaction.test.mjs
@@ -22,12 +22,12 @@ function writeJsonlLines(workDir, lines) {
   fs.writeFileSync(path.join(workDir, "autoresearch.jsonl"), lines.join("\n") + "\n");
 }
 
-test("summary contains all three persisted sources when present", () => {
+test("summary contains all persisted sources when present", () => {
   withTempWorkDir((workDir) => {
     fs.writeFileSync(path.join(workDir, "autoresearch.md"), "# Rules\nDo not cheat.");
     fs.writeFileSync(path.join(workDir, "autoresearch.ideas.md"), "- Try memoization\n- Try parallelism");
     writeJsonlLines(workDir, [
-      '{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',
+      '{"type":"config","name":"Speed up parser","metricName":"total_us","metricUnit":"us","bestDirection":"lower"}',
       '{"run":1,"commit":"aaa1111","metric":100,"status":"keep","description":"baseline","timestamp":1,"metrics":{},"asi":{"hypothesis":"start point"}}',
       '{"run":2,"commit":"bbb2222","metric":80,"status":"keep","description":"cache foo","timestamp":2,"metrics":{},"asi":{"hypothesis":"memoize repeated keys","next_action_hint":"try LRU"}}',
       '{"run":3,"commit":"ccc3333","metric":120,"status":"discard","description":"tried lru-cache","timestamp":3,"metrics":{},"asi":{"rollback_reason":"import overhead"}}',
@@ -36,6 +36,12 @@ test("summary contains all three persisted sources when present", () => {
     const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
 
     assert.match(summary, /# Autoresearch Compaction Summary/);
+    assert.match(summary, /## Session/);
+    assert.match(summary, /Goal: Speed up parser/);
+    assert.match(summary, /Metric: total_us — lower is better/);
+    assert.match(summary, /Runs so far: 3 \(2 keep · 1 discard\)/);
+    assert.match(summary, /Baseline \(#1\): 100us/);
+    assert.match(summary, /Best\s+\(#2\): 80us \(-20\.0%\)/);
     assert.match(summary, /## Experiment Rules \(autoresearch\.md\)/);
     assert.match(summary, /Do not cheat\./);
     assert.match(summary, /## Ideas Backlog \(autoresearch\.ideas\.md\)/);
@@ -52,11 +58,49 @@ test("summary contains all three persisted sources when present", () => {
   });
 });
 
+test("session block omits baseline/best when no runs exist yet", () => {
+  withTempWorkDir((workDir) => {
+    writeJsonlLines(workDir, [
+      '{"type":"config","name":"Cold start","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',
+    ]);
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.match(summary, /Goal: Cold start/);
+    assert.match(summary, /Runs so far: 0/);
+    assert.doesNotMatch(summary, /Baseline/);
+    assert.doesNotMatch(summary, /Best\s+\(#/);
+  });
+});
+
+test("session block reflects current segment after re-init", () => {
+  withTempWorkDir((workDir) => {
+    writeJsonlLines(workDir, [
+      '{"type":"config","name":"Old goal","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',
+      '{"run":1,"commit":"a","metric":500,"status":"keep","description":"old baseline","timestamp":1,"metrics":{}}',
+      '{"type":"config","name":"New goal","metricName":"bytes","metricUnit":"kb","bestDirection":"higher"}',
+      '{"run":2,"commit":"b","metric":10,"status":"keep","description":"new baseline","timestamp":2,"metrics":{}}',
+      '{"run":3,"commit":"c","metric":15,"status":"keep","description":"better","timestamp":3,"metrics":{}}',
+    ]);
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.match(summary, /Goal: New goal/);
+    assert.match(summary, /Metric: bytes — higher is better/);
+    assert.match(summary, /Runs so far: 2 \(2 keep\)/);
+    assert.match(summary, /Baseline \(#2\): 10kb/);
+    assert.match(summary, /Best\s+\(#3\): 15kb \(\+50\.0%\)/);
+  });
+});
+
 test("summary degrades gracefully when no files exist", () => {
   withTempWorkDir((workDir) => {
     const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
 
     assert.match(summary, /# Autoresearch Compaction Summary/);
+    assert.match(summary, /## Session/);
+    assert.match(summary, /Goal: —/);
+    assert.match(summary, /Runs so far: 0/);
     assert.doesNotMatch(summary, /## Experiment Rules/);
     assert.doesNotMatch(summary, /## Ideas Backlog/);
     assert.match(summary, /No runs yet/);
@@ -81,7 +125,23 @@ test("summary keeps only the last 50 runs", () => {
   });
 });
 
-test("delta is computed against the first run of the same segment within window", () => {
+test("recent run deltas use the full segment baseline even when baseline is hidden", () => {
+  withTempWorkDir((workDir) => {
+    const lines = ['{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}'];
+    for (let i = 1; i <= 75; i++) {
+      lines.push(`{"run":${i},"commit":"c${i}","metric":${100 - i},"status":"keep","description":"r${i}","timestamp":${i},"metrics":{}}`);
+    }
+    writeJsonlLines(workDir, lines);
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.doesNotMatch(summary, /#1 keep/);
+    assert.match(summary, /#51 keep\s+49 \(-50\.5%\)/);
+    assert.match(summary, /#75 keep\s+25 \(-74\.7%\)/);
+  });
+});
+
+test("delta is computed against the first run of the same segment", () => {
   withTempWorkDir((workDir) => {
     writeJsonlLines(workDir, [
       '{"type":"config","name":"S","metricName":"ms","metricUnit":"ms","bestDirection":"lower"}',


### PR DESCRIPTION
## Summary

Replaces the default LLM-generated compaction summary with a deterministic, lossless view synthesized from persisted state — experiment rules, ideas backlog, and recent runs. Skips the LLM call entirely during compaction.

<img width="1486" height="984" alt="Screenshot 2026-04-29 at 12 33 19 PM" src="https://github.com/user-attachments/assets/0e8ca25b-cc63-4a84-8281-db34a98c3947" />

## Changes

### New: `compaction.ts`
- Builds the full compaction summary from disk state (autoresearch.jsonl, autoresearch.md, autoresearch.ideas.md)
- Sections: header, session stats (goal/metric/baseline/best), rules, ideas backlog, recent runs (last 50), next step prompt
- Hooks into `session_before_compact` to bypass the default LLM summarization

### `index.ts`
- Wires up the `session_before_compact` handler to return custom compaction when in autoresearch mode
- Splits auto-resume into two messages:
  - **Post-compaction**: tells the agent not to re-read files (summary has everything)
  - **Normal post-turn**: generic resume that doesn't assume compaction happened

### `jsonl.ts`
- Adds `run` number to `ReconstructedRun` for display in compaction summaries

### Tests
- 7 new test cases covering: full summary assembly, empty state, re-init segments, 50-run cap, baseline delta correctness (including when baseline is outside the visible window), and graceful degradation

## Design decisions

- **Recent-run deltas use the full segment baseline**, not the first visible run in the last-50 window. This keeps percentages accurate even for long sessions.
- **Recent Runs section includes all segments** (not just current) to preserve cross-segment context. The Session block clearly identifies the active goal/metric.
- **RECENT_RUN_LIMIT = 50** balances context size vs. history visibility.