### PR TITLE
Make autoresearch shortcuts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ pi install npm:pi-autoresearch
 | `Ctrl+Shift+T` | Toggle dashboard expand/collapse (inline widget ↔ full results table above the editor) |
 | `Ctrl+Shift+F` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
 
+To avoid conflicts with other pi extensions, override or disable these shortcuts in
+`<agent-dir>/extensions/pi-autoresearch.json`. `<agent-dir>` is the active pi profile
+config directory (usually `~/.pi/agent`, or `PI_CODING_AGENT_DIR` when set):
+
+```json
+{
+  "shortcuts": {
+    "toggleDashboard": "ctrl+shift+y",
+    "fullscreenDashboard": null
+  }
+}
+```
+
+Use `null` to skip registering a shortcut. Omitted shortcuts keep their defaults.
+
 ### UI
 
 - **Status widget** — always visible above the editor: `🔬 autoresearch 12 runs 8 kept │ ★ total_µs: 15,200 (-12.3%) │ conf: 2.1×`
@@ -142,8 +157,8 @@ The agent reads `autoresearch.jsonl`, groups kept experiments into logical chang
 ### 4. Monitor progress
 
 - **Widget** — always visible above the editor
-- **`Ctrl+Shift+T`** — expand/collapse the full results table inline
-- **`Ctrl+Shift+F`** — fullscreen scrollable dashboard overlay
+- **`Ctrl+Shift+T`** — expand/collapse the full results table inline (config key: `shortcuts.toggleDashboard`)
+- **`Ctrl+Shift+F`** — fullscreen scrollable dashboard overlay (config key: `shortcuts.fullscreenDashboard`)
 - **`/autoresearch export`** — open a live browser dashboard with chart and share card
 - **`Escape`** — interrupt anytime and ask for a summary
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -8,7 +8,7 @@
  * - `run_experiment` tool — runs any command, times it, captures output, detects pass/fail
  * - `log_experiment` tool — records results with session-persisted state
  * - Status widget showing experiment count + best metric
- * - Ctrl+Shift+T toggle to expand/collapse full dashboard inline above the editor
+ * - Configurable shortcuts to expand/collapse and fullscreen the dashboard
  * - Adds autoresearch guidance to the system prompt and points the agent at autoresearch.md
  * - Injects autoresearch.md into context on every turn via before_agent_start
  */
@@ -50,6 +50,7 @@ import {
   autoresearchSummaryPathsFor,
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
+import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
 
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
@@ -676,7 +677,7 @@ function renderDashboardLines(
   width: number,
   th: Theme,
   maxRows: number = 6,
-  headerHint?: string
+  headerHints: string[] = []
 ): string[] {
   const lines: string[] = [];
 
@@ -860,12 +861,8 @@ function renderDashboardLines(
     `${th.fg("muted", "description")}`;
 
   lines.push(
-    headerHint
-      ? appendRightAlignedAdaptiveHint(headerLine, width, th, [
-          headerHint,
-          "ctrl+shift+t collapse • full: ctrl+shift+f",
-          "ctrl+shift+t • ctrl+shift+f",
-        ])
+    headerHints.length > 0
+      ? appendRightAlignedAdaptiveHint(headerLine, width, th, headerHints)
       : truncateToWidth(headerLine, width, "…", true)
   );
   lines.push(
@@ -984,6 +981,26 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // Outlasts pi's internal retry (setTimeout 0) and compaction-continue
   // (setTimeout 100); see badlogic/pi-mono#2023, #2110.
   const SETTLED_WINDOW_MS = 800;
+  const shortcuts = resolveAutoresearchShortcuts();
+
+  const dashboardHintVariants = (toggleAction: "expand" | "collapse"): string[] => {
+    const toggle = shortcuts.toggleDashboard
+      ? `${shortcuts.toggleDashboard} ${toggleAction}`
+      : null;
+    const fullscreen = shortcuts.fullscreenDashboard
+      ? `${shortcuts.fullscreenDashboard} fullscreen`
+      : null;
+
+    if (toggle && fullscreen) {
+      return [
+        `${toggle} • ${fullscreen}`,
+        `${toggle} • full: ${shortcuts.fullscreenDashboard}`,
+        `${shortcuts.toggleDashboard} • ${shortcuts.fullscreenDashboard}`,
+      ];
+    }
+
+    return [toggle, fullscreen].filter((hint): hint is string => hint !== null);
+  };
 
   const runtimeStore = createRuntimeStore();
   const getSessionKey = (ctx: ExtensionContext) => ctx.sessionManager.getSessionId();
@@ -1320,7 +1337,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               safeWidth,
               theme,
               rows,
-              "ctrl+shift+t collapse • ctrl+shift+f fullscreen"
+              dashboardHintVariants("collapse")
             ),
           ];
         },
@@ -1411,12 +1428,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           if (state.name) optional.push(theme.fg("dim", ` │ ${state.name}`));
 
           const left = [...essential, ...optional].join("");
+          const hintVariants = dashboardHintVariants("expand");
           return [
-            appendRightAlignedAdaptiveHint(left, safeWidth, theme, [
-              "ctrl+shift+t expand • ctrl+shift+f fullscreen",
-              "ctrl+shift+t expand • full: ctrl+shift+f",
-              "ctrl+shift+t • ctrl+shift+f",
-            ]),
+            hintVariants.length > 0
+              ? appendRightAlignedAdaptiveHint(left, safeWidth, theme, hintVariants)
+              : truncateToWidth(left, safeWidth, "…", true),
           ];
         },
         invalidate(): void {},
@@ -2525,43 +2541,46 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Ctrl+Shift+T — toggle dashboard expand/collapse
+  // Toggle dashboard expand/collapse shortcut
   // -----------------------------------------------------------------------
 
-  pi.registerShortcut("ctrl+shift+t", {
-    description: "Toggle autoresearch dashboard",
-    handler: async (ctx) => {
-      const runtime = getRuntime(ctx);
-      const state = runtime.state;
-      if (state.results.length === 0) {
-        if (!runtime.autoresearchMode && !fs.existsSync(autoresearchMdPath(resolveWorkDir(ctx.cwd)))) {
-          ctx.ui.notify("No experiments yet — run /autoresearch to get started", "info");
-        } else {
-          ctx.ui.notify("No experiments yet", "info");
+  if (shortcuts.toggleDashboard) {
+    pi.registerShortcut(shortcuts.toggleDashboard, {
+      description: "Toggle autoresearch dashboard",
+      handler: async (ctx) => {
+        const runtime = getRuntime(ctx);
+        const state = runtime.state;
+        if (state.results.length === 0) {
+          if (!runtime.autoresearchMode && !fs.existsSync(autoresearchMdPath(resolveWorkDir(ctx.cwd)))) {
+            ctx.ui.notify("No experiments yet — run /autoresearch to get started", "info");
+          } else {
+            ctx.ui.notify("No experiments yet", "info");
+          }
+          return;
         }
-        return;
-      }
-      runtime.dashboardExpanded = !runtime.dashboardExpanded;
-      updateWidget(ctx);
-    },
-  });
+        runtime.dashboardExpanded = !runtime.dashboardExpanded;
+        updateWidget(ctx);
+      },
+    });
+  }
 
   // -----------------------------------------------------------------------
-  // Ctrl+Shift+F — fullscreen scrollable dashboard overlay
+  // Fullscreen scrollable dashboard overlay shortcut
   // -----------------------------------------------------------------------
 
-  pi.registerShortcut("ctrl+shift+f", {
-    description: "Fullscreen autoresearch dashboard",
-    handler: async (ctx) => {
-      const runtime = getRuntime(ctx);
-      const state = runtime.state;
-      if (state.results.length === 0) {
-        ctx.ui.notify("No experiments yet", "info");
-        return;
-      }
+  if (shortcuts.fullscreenDashboard) {
+    pi.registerShortcut(shortcuts.fullscreenDashboard, {
+      description: "Fullscreen autoresearch dashboard",
+      handler: async (ctx) => {
+        const runtime = getRuntime(ctx);
+        const state = runtime.state;
+        if (state.results.length === 0) {
+          ctx.ui.notify("No experiments yet", "info");
+          return;
+        }
 
-      await ctx.ui.custom<void>(
-        (tui, theme, _kb, done) => {
+        await ctx.ui.custom<void>(
+          (tui, theme, _kb, done) => {
           let scrollOffset = 0;
           let lastViewportRows = 8;
           let lastTotalRows = 0;
@@ -2676,18 +2695,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               clearOverlay();
             },
           };
-        },
-        {
-          overlay: true,
-          overlayOptions: {
-            width: "95%",
-            maxHeight: "90%",
-            anchor: "center" as const,
           },
-        }
-      );
-    },
-  });
+          {
+            overlay: true,
+            overlayOptions: {
+              width: "95%",
+              maxHeight: "90%",
+              anchor: "center" as const,
+            },
+          }
+        );
+      },
+    });
+  }
 
   // -----------------------------------------------------------------------
   // Export: local live dashboard

--- a/extensions/pi-autoresearch/shortcuts.ts
+++ b/extensions/pi-autoresearch/shortcuts.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+
+export const DEFAULT_TOGGLE_DASHBOARD_SHORTCUT = "ctrl+shift+t";
+export const DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT = "ctrl+shift+f";
+
+const CONFIG_FILE_NAME = "pi-autoresearch.json";
+
+export interface AutoresearchShortcuts {
+  toggleDashboard: string | null;
+  fullscreenDashboard: string | null;
+}
+
+interface AutoresearchShortcutConfig {
+  toggleDashboard?: unknown;
+  fullscreenDashboard?: unknown;
+}
+
+export function autoresearchShortcutsConfigPath(agentDir: string = getAgentDir()): string {
+  return join(agentDir, "extensions", CONFIG_FILE_NAME);
+}
+
+export function resolveAutoresearchShortcuts(
+  configPath: string = autoresearchShortcutsConfigPath()
+): AutoresearchShortcuts {
+  if (!existsSync(configPath)) {
+    return defaultAutoresearchShortcuts();
+  }
+
+  const config = readShortcutConfig(configPath);
+  if (!config) {
+    return defaultAutoresearchShortcuts();
+  }
+
+  return {
+    toggleDashboard: shortcutFromConfig(
+      config.toggleDashboard,
+      DEFAULT_TOGGLE_DASHBOARD_SHORTCUT
+    ),
+    fullscreenDashboard: shortcutFromConfig(
+      config.fullscreenDashboard,
+      DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT
+    ),
+  };
+}
+
+function readShortcutConfig(configPath: string): AutoresearchShortcutConfig | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch {
+    warnUsingDefaults("Could not read", configPath);
+    return null;
+  }
+
+  const shortcuts = isRecord(parsed) ? parsed.shortcuts : undefined;
+  if (shortcuts === undefined) {
+    return {};
+  }
+
+  if (!isRecord(shortcuts) || !hasValidShortcutValues(shortcuts)) {
+    warnUsingDefaults("Invalid", configPath);
+    return null;
+  }
+
+  return shortcuts;
+}
+
+function hasValidShortcutValues(shortcuts: Record<string, unknown>): boolean {
+  return (
+    isValidShortcutConfigValue(shortcuts.toggleDashboard) &&
+    isValidShortcutConfigValue(shortcuts.fullscreenDashboard)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidShortcutConfigValue(value: unknown): value is string | null | undefined {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === "string" && value !== "")
+  );
+}
+
+function shortcutFromConfig(configured: unknown, fallback: string): string | null {
+  if (configured === null) return null;
+  return typeof configured === "string" ? configured : fallback;
+}
+
+function defaultAutoresearchShortcuts(): AutoresearchShortcuts {
+  return {
+    toggleDashboard: DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
+    fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
+  };
+}
+
+function warnUsingDefaults(reason: "Could not read" | "Invalid", configPath: string): void {
+  console.warn(
+    `${reason} pi-autoresearch config at ${configPath}; using default shortcuts.`
+  );
+}

--- a/tests/shortcuts.test.mjs
+++ b/tests/shortcuts.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  autoresearchShortcutsConfigPath,
+  DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
+  DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
+  resolveAutoresearchShortcuts,
+} from "../extensions/pi-autoresearch/shortcuts.ts";
+import autoresearchExtension from "../extensions/pi-autoresearch/index.ts";
+
+test("autoresearch shortcuts default to the documented bindings when config is absent", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    const shortcuts = resolveAutoresearchShortcuts(configPath);
+
+    assert.equal(configPath, join(agentDir, "extensions", "pi-autoresearch.json"));
+    assert.equal(shortcuts.toggleDashboard, DEFAULT_TOGGLE_DASHBOARD_SHORTCUT);
+    assert.equal(shortcuts.fullscreenDashboard, DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("autoresearch shortcuts can be overridden by the config file", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        shortcuts: {
+          toggleDashboard: "ctrl+shift+y",
+          fullscreenDashboard: "ctrl+shift+u",
+        },
+      })
+    );
+
+    const shortcuts = resolveAutoresearchShortcuts(configPath);
+
+    assert.equal(shortcuts.toggleDashboard, "ctrl+shift+y");
+    assert.equal(shortcuts.fullscreenDashboard, "ctrl+shift+u");
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("autoresearch shortcuts can be disabled with null in the config file", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        shortcuts: {
+          toggleDashboard: null,
+          fullscreenDashboard: null,
+        },
+      })
+    );
+
+    const shortcuts = resolveAutoresearchShortcuts(configPath);
+
+    assert.equal(shortcuts.toggleDashboard, null);
+    assert.equal(shortcuts.fullscreenDashboard, null);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("partial shortcut config defaults omitted fields independently", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        shortcuts: {
+          toggleDashboard: "ctrl+shift+y",
+        },
+      })
+    );
+
+    const shortcuts = resolveAutoresearchShortcuts(configPath);
+
+    assert.equal(shortcuts.toggleDashboard, "ctrl+shift+y");
+    assert.equal(shortcuts.fullscreenDashboard, DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("malformed shortcut config warns and falls back to defaults", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  const warnings = [];
+  const previousWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(configPath, "{ not json");
+
+    const shortcuts = resolveAutoresearchShortcuts(configPath);
+
+    assert.deepEqual(shortcuts, {
+      toggleDashboard: DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
+      fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /pi-autoresearch.*config/i);
+    assert.match(warnings[0], new RegExp(configPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  } finally {
+    console.warn = previousWarn;
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("invalid known shortcut fields warn and fall back to defaults for the whole file", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  const warnings = [];
+  const previousWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        shortcuts: {
+          toggleDashboard: 123,
+          fullscreenDashboard: "ctrl+shift+u",
+        },
+      })
+    );
+
+    const shortcuts = resolveAutoresearchShortcuts(configPath);
+
+    assert.deepEqual(shortcuts, {
+      toggleDashboard: DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
+      fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /invalid pi-autoresearch config/i);
+  } finally {
+    console.warn = previousWarn;
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+function withAgentDir(agentDir, fn) {
+  const previous = process.env.PI_CODING_AGENT_DIR;
+  try {
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    fn();
+  } finally {
+    if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previous;
+  }
+}
+
+function collectRegisteredShortcuts() {
+  const shortcuts = [];
+  autoresearchExtension({
+    on() {},
+    registerTool() {},
+    registerCommand() {},
+    registerShortcut(shortcut, options) {
+      shortcuts.push({ shortcut, description: options.description });
+    },
+  });
+  return shortcuts;
+}
+
+test("extension registers shortcuts from the active profile config", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        shortcuts: {
+          toggleDashboard: "ctrl+shift+y",
+          fullscreenDashboard: null,
+        },
+      })
+    );
+
+    withAgentDir(agentDir, () => {
+      assert.deepEqual(
+        collectRegisteredShortcuts().map((entry) => entry.shortcut),
+        ["ctrl+shift+y"]
+      );
+    });
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

pi-autoresearch currently registers `ctrl+shift+t` and `ctrl+shift+f` unconditionally for the inline and fullscreen dashboards. Those defaults are convenient, but they can collide with shortcuts from other pi extensions or local terminal/window-manager conventions. When a collision happens, users have no escape hatch: installing the package means accepting those bindings.

## What changed

- Adds a profile-aware config file at `<agent-dir>/extensions/pi-autoresearch.json`.
- Supports overriding dashboard bindings with:
  - `shortcuts.toggleDashboard`
  - `shortcuts.fullscreenDashboard`
- Supports disabling either binding with `null`.
- Keeps omitted shortcut fields on their backward-compatible defaults.
- Warns and falls back to defaults when the config file is malformed or known shortcut fields are invalid.
- Updates dashboard hint text to show the effective configured shortcuts, or omit hints for disabled bindings.
- Documents the config file in the README.

Example config:

```json
{
  "shortcuts": {
    "toggleDashboard": "ctrl+shift+y",
    "fullscreenDashboard": null
  }
}
```

## Validation

- `pnpm test`

Co-authored-by: AI <noreply@shopify.com>
