### PR TITLE
fix(autoresearch): persist manual off state

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pi install npm:pi-autoresearch
 | Subcommand | Description |
 |------------|-------------|
 | `/autoresearch <text>` | Enter autoresearch mode. If `autoresearch.md` exists, resumes the loop with `<text>` as context. Otherwise, sets up a new session. |
-| `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `autoresearch.jsonl` intact. |
+| `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `autoresearch.jsonl` intact. The manual-off choice is persisted outside the repo under `~/.pi/autoresearch/state/`, so `/tree`, compaction, and session reloads do not reactivate it. |
 | `/autoresearch clear` | Delete `autoresearch.jsonl`, reset all state, and turn autoresearch mode off. Use this for a clean start. |
 | `/autoresearch export` | Open a live dashboard in your browser. Auto-updates as experiments run. |
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -30,8 +30,8 @@ import { createServer, type Server, type ServerResponse } from "node:http";
 
 import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { randomBytes } from "node:crypto";
-import { tmpdir } from "node:os";
+import { createHash, randomBytes } from "node:crypto";
+import { homedir, tmpdir } from "node:os";
 
 import {
   runHook,
@@ -480,6 +480,57 @@ function validateWorkDir(ctxCwd: string): string | null {
     return `workingDir "${workDir}" (from autoresearch.config.json) does not exist.`;
   }
   return null;
+}
+
+interface ManualOffState {
+  manualOff: boolean;
+  cwd: string;
+  workDir: string;
+  updatedAt: number;
+}
+
+function manualOffStatePath(ctxCwd: string, workDir: string): string {
+  const key = createHash("sha256")
+    .update(JSON.stringify({ cwd: path.resolve(ctxCwd), workDir: path.resolve(workDir) }))
+    .digest("hex")
+    .slice(0, 32);
+  return path.join(homedir(), ".pi", "autoresearch", "state", `${key}.json`);
+}
+
+function isManuallyOff(ctxCwd: string, workDir: string): boolean {
+  try {
+    const statePath = manualOffStatePath(ctxCwd, workDir);
+    if (!fs.existsSync(statePath)) return false;
+    const state = JSON.parse(fs.readFileSync(statePath, "utf-8")) as Partial<ManualOffState>;
+    return state.manualOff === true;
+  } catch {
+    return false;
+  }
+}
+
+function setManualOff(ctxCwd: string, workDir: string): void {
+  try {
+    const statePath = manualOffStatePath(ctxCwd, workDir);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    const state: ManualOffState = {
+      manualOff: true,
+      cwd: path.resolve(ctxCwd),
+      workDir: path.resolve(workDir),
+      updatedAt: Date.now(),
+    };
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+  } catch {
+    // Best effort only — the current runtime is still switched off.
+  }
+}
+
+function clearManualOff(ctxCwd: string, workDir: string): void {
+  try {
+    const statePath = manualOffStatePath(ctxCwd, workDir);
+    if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+  } catch {
+    // Best effort only — failure should not block explicit activation.
+  }
 }
 
 /** Baseline = first experiment in current segment */
@@ -1256,8 +1307,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     // Read max experiments from config file
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
-    // Auto-enter autoresearch mode only when a persisted experiment log exists
-    runtime.autoresearchMode = fs.existsSync(autoresearchJsonlPath(workDir));
+    // Auto-enter autoresearch mode only when a persisted experiment log exists,
+    // unless the user explicitly disabled it with `/autoresearch off`.
+    runtime.autoresearchMode = fs.existsSync(autoresearchJsonlPath(workDir)) &&
+      !isManuallyOff(ctx.cwd, workDir);
 
     updateWidget(ctx);
   };
@@ -1267,6 +1320,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     const runtime = getRuntime(ctx);
     const state = runtime.state;
+
+    if (!runtime.autoresearchMode && !runtime.runningExperiment) {
+      ctx.ui.setWidget("autoresearch", undefined);
+      return;
+    }
 
     if (state.results.length === 0) {
       if (!runtime.runningExperiment) {
@@ -1598,6 +1656,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       const wasInactive = !runtime.autoresearchMode;
       runtime.autoresearchMode = true;
+      clearManualOff(ctx.cwd, workDir);
       updateWidget(ctx);
 
       if (wasInactive) {
@@ -2938,6 +2997,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.lastRunDuration = null;
         runtime.runningExperiment = null;
         cancelPendingResume(runtime);
+        setManualOff(ctx.cwd, resolveWorkDir(ctx.cwd));
         stopDashboardServer();
         clearSessionUi(ctx);
         if (wasRunning) ctx.abort();
@@ -2963,6 +3023,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.runningExperiment = null;
         cancelPendingResume(runtime);
         runtime.state = createExperimentState();
+        clearManualOff(ctx.cwd, resolveWorkDir(ctx.cwd));
         stopDashboardServer();
         updateWidget(ctx);
 
@@ -2991,6 +3052,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       runtime.autoResumeTurns = 0;
 
       const workDir = resolveWorkDir(ctx.cwd);
+      clearManualOff(ctx.cwd, workDir);
       const rulesLoaded = hasAutoresearchRules(ctx);
       const kickoff = rulesLoaded
         ? `Autoresearch mode active. ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`


### PR DESCRIPTION
Hi David,

A nuissance I am encountering: When I try to interrupt autoresearch using /autoresearch off to do a bit of in-between manual work, intending to persist autoresearch state but leaving the mode for a while, the mode constantly reactivates on usage of /tree. This is because the activation check basically just checks for the existence of autoresearch.json. This is highly annoying.

My suggestion for fixing this behavior is implemented in this PR:

- Persist `/autoresearch off` in session-local state under `~/.pi/autoresearch/state/`
- Respect that manual-off marker during session reconstruction so `/tree`, compaction, and reloads do not reactivate autoresearch just because `autoresearch.jsonl` exists
- Clear the marker when autoresearch is explicitly started, initialized, or cleared

Curious to hear what you think about this.