### PR TITLE
add: configurable auto-resume limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "maxAutoResumeTurns": 100
 }
 ```
 
@@ -217,6 +218,7 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 |-------|------|-------------|
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays in the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
+| `maxAutoResumeTurns` | number | Maximum automatic resume prompts before the extension stops re-prompting. Defaults to 20. Increase this for long unattended runs that may cross many turns or compactions. |
 
 ### Long-running loops and context
 
@@ -336,6 +338,12 @@ Autoresearch loops run autonomously and can burn through tokens. Two ways to cap
    ```json
    {
      "maxIterations": 30
+   }
+   ```
+- **`maxAutoResumeTurns`** — cap automatic resume prompts. The default is 20:
+   ```json
+   {
+     "maxAutoResumeTurns": 100
    }
    ```
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -57,6 +57,7 @@ import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
 // ---------------------------------------------------------------------------
 const EXPERIMENT_MAX_LINES = 10;
 const EXPERIMENT_MAX_BYTES = 4 * 1024; // 4KB
+export const DEFAULT_MAX_AUTORESUME_TURNS = 20;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -430,6 +431,7 @@ function currentResults(results: ExperimentResult[], segment: number): Experimen
 
 interface AutoresearchConfig {
   maxIterations?: number;
+  maxAutoResumeTurns?: number;
   workingDir?: string;
 }
 
@@ -450,6 +452,14 @@ function readMaxExperiments(cwd: string): number | null {
   return (typeof config.maxIterations === "number" && config.maxIterations > 0)
     ? Math.floor(config.maxIterations)
     : null;
+}
+
+/** Read maxAutoResumeTurns from autoresearch.config.json, falling back to the safety default. */
+export function readMaxAutoResumeTurns(cwd: string): number {
+  const config = readConfig(cwd);
+  return (typeof config.maxAutoResumeTurns === "number" && config.maxAutoResumeTurns > 0)
+    ? Math.floor(config.maxAutoResumeTurns)
+    : DEFAULT_MAX_AUTORESUME_TURNS;
 }
 
 /**
@@ -974,7 +984,6 @@ function renderDashboardLines(
 // ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
-  const MAX_AUTORESUME_TURNS = 20;
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
 
@@ -1037,7 +1046,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!isAgentSettled(ctx)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    if (hasReachedAutoResumeLimit(ctx, runtime)) {
       cancelPendingResume(runtime);
       notifyAutoResumeLimitReached(ctx);
       return;
@@ -1073,12 +1082,15 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const shouldAutoResumeAfterCompact = (runtime: AutoresearchRuntime): boolean =>
     runtime.autoresearchMode;
 
-  const hasReachedAutoResumeLimit = (runtime: AutoresearchRuntime): boolean =>
-    runtime.autoResumeTurns >= MAX_AUTORESUME_TURNS;
+  const autoResumeLimit = (ctx: ExtensionContext): number =>
+    readMaxAutoResumeTurns(ctx.cwd);
+
+  const hasReachedAutoResumeLimit = (ctx: ExtensionContext, runtime: AutoresearchRuntime): boolean =>
+    runtime.autoResumeTurns >= autoResumeLimit(ctx);
 
   const notifyAutoResumeLimitReached = (ctx: ExtensionContext): void => {
     ctx.ui.notify(
-      `Autoresearch auto-resume limit reached (${MAX_AUTORESUME_TURNS} turns)`,
+      `Autoresearch auto-resume limit reached (${autoResumeLimit(ctx)} turns)`,
       "info",
     );
   };
@@ -1469,7 +1481,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!gate(runtime)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    if (hasReachedAutoResumeLimit(ctx, runtime)) {
       notifyAutoResumeLimitReached(ctx);
       return;
     }

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  DEFAULT_MAX_AUTORESUME_TURNS,
+  readMaxAutoResumeTurns,
+} from "../extensions/pi-autoresearch/index.ts";
+
+test("maxAutoResumeTurns defaults to the built-in safety limit", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    assert.equal(readMaxAutoResumeTurns(dir), DEFAULT_MAX_AUTORESUME_TURNS);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("maxAutoResumeTurns can be overridden from autoresearch.config.json", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    await writeFile(
+      join(dir, "autoresearch.config.json"),
+      JSON.stringify({ maxAutoResumeTurns: 3000 }),
+    );
+
+    assert.equal(readMaxAutoResumeTurns(dir), 3000);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("maxAutoResumeTurns ignores invalid values", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    await writeFile(
+      join(dir, "autoresearch.config.json"),
+      JSON.stringify({ maxAutoResumeTurns: 0 }),
+    );
+
+    assert.equal(readMaxAutoResumeTurns(dir), DEFAULT_MAX_AUTORESUME_TURNS);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Hi, this commit:

- add `maxAutoResumeTurns` to `autoresearch.config.json`
- keep the existing default auto-resume safety limit at 20
- document the new config option and add focused config tests

Thanks for your CR :)