### PR TITLE
Add optional autoresearch hint model tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Optional `ask_autoresearch_hint` tool. When enabled in `autoresearch.config.json`, the loop can ask a configured larger pi model for bounded, side-effect-free strategy advice after stalled or failed experiment attempts.
+
 ## [1.4.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pi install npm:pi-autoresearch
 | `init_experiment` | One-time session config — name, metric, unit, direction |
 | `run_experiment` | Runs any command, times wall-clock duration, captures output |
 | `log_experiment` | Records result, auto-commits, updates widget and dashboard |
+| `ask_autoresearch_hint` | *(Optional)* Ask a configured larger model for concise strategy advice when the loop is stuck |
 
 ### `/autoresearch` command
 
@@ -209,7 +210,16 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "hints": {
+    "enabled": true,
+    "provider": "anthropic",
+    "model": "claude-opus-4-5",
+    "thinkingLevel": "high",
+    "maxRecentRuns": 8,
+    "maxCallsPerSession": 5,
+    "timeoutSeconds": 120
+  }
 }
 ```
 
@@ -217,6 +227,13 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 |-------|------|-------------|
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays in the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
+| `hints` | object | Optional expensive-model hint tool config. Missing or `enabled: false` means no hint model calls are made. When enabled, `provider` and `model` must match a configured pi model. |
+
+`ask_autoresearch_hint` is a side-channel advisory tool. It never edits files,
+changes the active pi model, commits, reverts, or writes `autoresearch.jsonl`.
+The agent is guided to use it only after repeated discards/crashes, stalled
+progress, or unclear next hypotheses, and every suggestion still has to be
+validated through `run_experiment` and `log_experiment`.
 
 ### Long-running loops and context
 

--- a/extensions/pi-autoresearch/hints.ts
+++ b/extensions/pi-autoresearch/hints.ts
@@ -1,0 +1,373 @@
+import { completeSimple, type AssistantMessage, type Model } from "@mariozechner/pi-ai";
+import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const DEFAULT_MAX_RECENT_RUNS = 8;
+const MIN_MAX_RECENT_RUNS = 1;
+const MAX_MAX_RECENT_RUNS = 20;
+
+const DEFAULT_MAX_CALLS_PER_SESSION = 5;
+const MIN_MAX_CALLS_PER_SESSION = 1;
+const MAX_MAX_CALLS_PER_SESSION = 20;
+
+const DEFAULT_TIMEOUT_SECONDS = 120;
+const MIN_TIMEOUT_SECONDS = 10;
+const MAX_TIMEOUT_SECONDS = 600;
+
+const DEFAULT_THINKING_LEVEL: HintThinkingLevel = "high";
+const HINT_FILE_MAX_CHARS = 3000;
+const EXTRA_CONTEXT_MAX_CHARS = 1500;
+const ASI_VALUE_MAX_CHARS = 180;
+
+type HintThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+export interface HintConfig {
+  enabled: boolean;
+  provider: string | null;
+  model: string | null;
+  thinkingLevel: HintThinkingLevel;
+  maxRecentRuns: number;
+  maxCallsPerSession: number;
+  timeoutSeconds: number;
+}
+
+export interface HintRun {
+  run?: number;
+  commit: string;
+  metric: number;
+  metrics: Record<string, number>;
+  status: "keep" | "discard" | "crash" | "checks_failed";
+  description: string;
+  segment: number;
+  confidence: number | null;
+  asi?: Record<string, unknown>;
+}
+
+export interface HintExperimentState {
+  name: string | null;
+  metricName: string;
+  metricUnit: string;
+  bestDirection: "lower" | "higher";
+  bestMetric: number | null;
+  currentSegment: number;
+  results: HintRun[];
+  confidence: number | null;
+}
+
+export interface HintPromptInput {
+  state: HintExperimentState;
+  workDir: string;
+  question: string;
+  extraContext?: string;
+  maxRecentRuns: number;
+  readFile?: (filePath: string) => string;
+}
+
+export interface HintRequestInput extends HintPromptInput {
+  model: Model;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  thinkingLevel: HintThinkingLevel;
+  timeoutSeconds: number;
+  signal?: AbortSignal;
+  complete?: typeof completeSimple;
+}
+
+export interface HintRequestResult {
+  text: string;
+  durationMs: number;
+  promptBytes: number;
+  stopReason: AssistantMessage["stopReason"];
+  usage: AssistantMessage["usage"] | null;
+}
+
+const HINT_SYSTEM_PROMPT = [
+  "You are a senior research advisor for pi-autoresearch.",
+  "Give concise strategy advice only. You cannot edit files, run commands, commit, or revert changes.",
+  "Return a likely diagnosis, 1-3 next experiments, and key failure modes.",
+  "The caller must validate every suggestion with run_experiment and log_experiment.",
+].join(" ");
+
+const HINT_THINKING_LEVELS = new Set<HintThinkingLevel>([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
+const ASI_HINT_KEYS = [
+  "hypothesis",
+  "next_action_hint",
+  "next_focus",
+  "rollback_reason",
+  "learned",
+  "bottleneck",
+  "failure_mode",
+  "error",
+];
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function trimString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function thinkingLevelFrom(value: unknown): HintThinkingLevel {
+  return typeof value === "string" && HINT_THINKING_LEVELS.has(value as HintThinkingLevel)
+    ? value as HintThinkingLevel
+    : DEFAULT_THINKING_LEVEL;
+}
+
+export function resolveHintConfig(config: { hints?: unknown } | null | undefined): HintConfig {
+  const raw = isObjectRecord(config?.hints) ? config.hints : null;
+  if (!raw || raw.enabled !== true) {
+    return {
+      enabled: false,
+      provider: null,
+      model: null,
+      thinkingLevel: DEFAULT_THINKING_LEVEL,
+      maxRecentRuns: DEFAULT_MAX_RECENT_RUNS,
+      maxCallsPerSession: DEFAULT_MAX_CALLS_PER_SESSION,
+      timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+    };
+  }
+
+  return {
+    enabled: true,
+    provider: trimString(raw.provider),
+    model: trimString(raw.model),
+    thinkingLevel: thinkingLevelFrom(raw.thinkingLevel),
+    maxRecentRuns: clampNumber(
+      raw.maxRecentRuns,
+      DEFAULT_MAX_RECENT_RUNS,
+      MIN_MAX_RECENT_RUNS,
+      MAX_MAX_RECENT_RUNS,
+    ),
+    maxCallsPerSession: clampNumber(
+      raw.maxCallsPerSession,
+      DEFAULT_MAX_CALLS_PER_SESSION,
+      MIN_MAX_CALLS_PER_SESSION,
+      MAX_MAX_CALLS_PER_SESSION,
+    ),
+    timeoutSeconds: clampNumber(
+      raw.timeoutSeconds,
+      DEFAULT_TIMEOUT_SECONDS,
+      MIN_TIMEOUT_SECONDS,
+      MAX_TIMEOUT_SECONDS,
+    ),
+  };
+}
+
+export function isHintConfigReady(config: HintConfig): config is HintConfig & { provider: string; model: string } {
+  return config.enabled && !!config.provider && !!config.model;
+}
+
+function readFileOrEmpty(filePath: string): string {
+  if (!fs.existsSync(filePath)) return "";
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars).trimEnd()}\n[truncated to ${maxChars} chars]`;
+}
+
+function formatMetric(value: number | null, unit: string): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${Number.isInteger(value) ? value : value.toFixed(3)}${unit}`;
+}
+
+function isBetter(value: number, current: number, direction: "lower" | "higher"): boolean {
+  return direction === "lower" ? value < current : value > current;
+}
+
+function findBestMetric(state: HintExperimentState): number | null {
+  let best: number | null = null;
+  for (const run of state.results) {
+    if (run.segment !== state.currentSegment) continue;
+    if (run.status !== "keep" || !Number.isFinite(run.metric) || run.metric <= 0) continue;
+    if (best === null || isBetter(run.metric, best, state.bestDirection)) best = run.metric;
+  }
+  return best;
+}
+
+function formatAsi(asi: Record<string, unknown> | undefined): string {
+  if (!asi) return "";
+  const parts: string[] = [];
+  for (const key of ASI_HINT_KEYS) {
+    const value = asi[key];
+    if (value === undefined) continue;
+    const text = typeof value === "string" ? value : JSON.stringify(value);
+    if (!text || text.trim() === "") continue;
+    parts.push(`${key}: ${truncateText(text.trim(), ASI_VALUE_MAX_CHARS).replace(/\n/g, " ")}`);
+  }
+  return parts.join(" | ");
+}
+
+function formatRun(run: HintRun, index: number, state: HintExperimentState): string {
+  const runNumber = run.run ?? index + 1;
+  const parts = [
+    `#${runNumber}`,
+    run.status,
+    `${state.metricName}=${formatMetric(run.metric, state.metricUnit)}`,
+    run.commit ? `commit=${run.commit}` : "",
+    run.description ? `desc=${run.description}` : "",
+    formatAsi(run.asi),
+  ].filter(Boolean);
+  return `- ${parts.join(" | ")}`;
+}
+
+function section(title: string, body: string): string {
+  const trimmed = body.trim();
+  return trimmed ? `## ${title}\n${trimmed}` : "";
+}
+
+export function buildHintPrompt(input: HintPromptInput): string {
+  const readFile = input.readFile ?? readFileOrEmpty;
+  const state = input.state;
+  const currentRuns = state.results.filter((run) => run.segment === state.currentSegment);
+  const recentRuns = currentRuns.slice(-input.maxRecentRuns);
+  const bestMetric = findBestMetric(state);
+
+  const sessionLines = [
+    `Goal: ${state.name ?? "-"}`,
+    `Metric: ${state.metricName}${state.metricUnit ? ` (${state.metricUnit})` : ""}; ${state.bestDirection} is better`,
+    `Runs in current segment: ${currentRuns.length}`,
+    `Baseline: ${formatMetric(state.bestMetric, state.metricUnit)}`,
+    `Best kept: ${formatMetric(bestMetric, state.metricUnit)}`,
+    state.confidence !== null ? `Confidence: ${state.confidence.toFixed(2)}x noise floor` : "",
+  ].filter(Boolean);
+
+  const recentRunsText = recentRuns.length > 0
+    ? recentRuns.map((run, i) => formatRun(run, state.results.indexOf(run), state)).join("\n")
+    : "No runs yet.";
+
+  const rules = truncateText(readFile(path.join(input.workDir, "autoresearch.md")).trim(), HINT_FILE_MAX_CHARS);
+  const ideas = truncateText(readFile(path.join(input.workDir, "autoresearch.ideas.md")).trim(), HINT_FILE_MAX_CHARS);
+  const extraContext = truncateText((input.extraContext ?? "").trim(), EXTRA_CONTEXT_MAX_CHARS);
+
+  return [
+    section("Session", sessionLines.join("\n")),
+    section(`Recent Runs (last ${recentRuns.length})`, recentRunsText),
+    section("Experiment Rules Excerpt", rules),
+    section("Ideas Backlog Excerpt", ideas),
+    section("Current Agent Question", input.question),
+    section("Extra Context From Current Agent", extraContext),
+    section(
+      "Response Contract",
+      [
+        "Give advice only; do not claim to have changed files or run tools.",
+        "Keep it short and actionable.",
+        "Recommend 1-3 next experiments and mention likely failure modes.",
+        "Favor changes that can be validated by the existing benchmark and checks.",
+      ].join("\n"),
+    ),
+  ].filter(Boolean).join("\n\n");
+}
+
+function textFromAssistantMessage(message: AssistantMessage): string {
+  return message.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+function createTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number) {
+  const controller = new AbortController();
+  let timedOut = false;
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  const onAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    didTimeout: () => timedOut,
+    dispose: () => {
+      clearTimeout(timeout);
+      if (signal) signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+export async function requestAutoresearchHint(input: HintRequestInput): Promise<HintRequestResult> {
+  const prompt = buildHintPrompt(input);
+  const timeout = createTimeoutSignal(input.signal, input.timeoutSeconds * 1000);
+  const t0 = Date.now();
+  const completionOptions: SimpleStreamOptions = {
+    apiKey: input.apiKey,
+    headers: input.headers,
+    signal: timeout.signal,
+    reasoning: input.thinkingLevel === "off" ? undefined : input.thinkingLevel,
+  };
+
+  try {
+    const response = await (input.complete ?? completeSimple)(
+      input.model,
+      {
+        systemPrompt: HINT_SYSTEM_PROMPT,
+        messages: [{
+          role: "user",
+          content: prompt,
+          timestamp: Date.now(),
+        }],
+      },
+      completionOptions,
+    );
+
+    if (timeout.didTimeout()) {
+      throw new Error(`Hint model timed out after ${input.timeoutSeconds}s`);
+    }
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "Hint model returned an error");
+    }
+    if (response.stopReason === "aborted") {
+      throw new Error(input.signal?.aborted ? "Hint model call was aborted" : "Hint model call was aborted or timed out");
+    }
+
+    const text = textFromAssistantMessage(response);
+    if (!text) throw new Error("Hint model returned no text");
+
+    return {
+      text,
+      durationMs: Date.now() - t0,
+      promptBytes: Buffer.byteLength(prompt, "utf-8"),
+      stopReason: response.stopReason,
+      usage: response.usage ?? null,
+    };
+  } catch (error) {
+    if (timeout.didTimeout()) {
+      throw new Error(`Hint model timed out after ${input.timeoutSeconds}s`);
+    }
+    if (input.signal?.aborted) {
+      throw new Error("Hint model call was aborted");
+    }
+    throw error;
+  } finally {
+    timeout.dispose();
+  }
+}

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -51,6 +51,11 @@ import {
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
 import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
+import {
+  isHintConfigReady,
+  requestAutoresearchHint,
+  resolveHintConfig,
+} from "./hints.ts";
 
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
@@ -142,6 +147,8 @@ interface AutoresearchRuntime {
   autoresearchMode: boolean;
   dashboardExpanded: boolean;
   experimentsThisSession: number;
+  hintsThisSession: number;
+  hintInFlight: boolean;
   autoResumeTurns: number;
   lastRunChecks: { pass: boolean; output: string; duration: number } | null;
   lastRunDuration: number | null;
@@ -171,6 +178,20 @@ const RunParams = Type.Object({
     Type.Number({
       description:
         "Kill autoresearch.checks.sh after this many seconds (default: 300). Only relevant when the checks file exists.",
+    })
+  ),
+});
+
+const HintParams = Type.Object({
+  question: Type.String({
+    minLength: 1,
+    description:
+      "Focused question for the configured larger hint model. Ask for strategy help, not code execution.",
+  }),
+  extra_context: Type.Optional(
+    Type.String({
+      description:
+        "Optional short context from the current agent. Do not include secrets, raw logs, or large file dumps.",
     })
   ),
 });
@@ -431,6 +452,7 @@ function currentResults(results: ExperimentResult[], segment: number): Experimen
 interface AutoresearchConfig {
   maxIterations?: number;
   workingDir?: string;
+  hints?: unknown;
 }
 
 /** Read autoresearch.config.json from the given directory (always ctx.cwd) */
@@ -635,6 +657,8 @@ function createSessionRuntime(): AutoresearchRuntime {
     autoresearchMode: false,
     dashboardExpanded: false,
     experimentsThisSession: 0,
+    hintsThisSession: 0,
+    hintInFlight: false,
     autoResumeTurns: 0,
     lastRunChecks: null,
     lastRunDuration: null,
@@ -1208,6 +1232,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     runtime.lastRunDuration = null;
     runtime.runningExperiment = null;
     runtime.experimentsThisSession = 0;
+    runtime.hintsThisSession = 0;
+    runtime.hintInFlight = false;
     runtime.autoResumeTurns = 0;
     runtime.state = createExperimentState();
 
@@ -1529,9 +1555,199 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       extra += `\n\n💡 Ideas backlog exists at ${ideasPath} — check it for promising experiment paths. Prune stale entries.`;
     }
 
+    const hintConfig = resolveHintConfig(readConfig(ctx.cwd));
+    if (isHintConfigReady(hintConfig)) {
+      extra +=
+        "\n\n## Autoresearch Hints (ACTIVE)" +
+        `\nask_autoresearch_hint is configured for ${hintConfig.provider}/${hintConfig.model}.` +
+        "\nUse ask_autoresearch_hint only after repeated discards/crashes, stalled progress, or unclear next hypotheses." +
+        "\nAsk one focused question. Treat the response as advisory, then validate any suggestion with run_experiment and log_experiment.";
+    }
+
     return {
       systemPrompt: event.systemPrompt + extra,
     };
+  });
+
+  // -----------------------------------------------------------------------
+  // ask_autoresearch_hint tool — optional side-channel strategy advice
+  // -----------------------------------------------------------------------
+
+  pi.registerTool({
+    name: "ask_autoresearch_hint",
+    label: "Ask Hint",
+    description:
+      "Ask the configured larger model for concise autoresearch strategy advice. Side-effect free and disabled unless autoresearch.config.json enables hints.",
+    parameters: HintParams,
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const runtime = getRuntime(ctx);
+      const question = params.question.trim();
+      if (!question) {
+        return {
+          content: [{ type: "text", text: "Hint unavailable: question must not be empty." }],
+          details: {},
+        };
+      }
+
+      const workDirError = validateWorkDir(ctx.cwd);
+      if (workDirError) {
+        return {
+          content: [{ type: "text", text: `Hint unavailable: ${workDirError}` }],
+          details: {},
+        };
+      }
+
+      const config = resolveHintConfig(readConfig(ctx.cwd));
+      if (!config.enabled) {
+        return {
+          content: [{
+            type: "text",
+            text: "Hint unavailable: hints are disabled. Set hints.enabled=true in autoresearch.config.json to allow expensive model calls.",
+          }],
+          details: { enabled: false },
+        };
+      }
+
+      if (!isHintConfigReady(config)) {
+        return {
+          content: [{
+            type: "text",
+            text: "Hint unavailable: hints.enabled is true, but hints.provider and hints.model must both be set in autoresearch.config.json.",
+          }],
+          details: { enabled: true, provider: config.provider, model: config.model },
+        };
+      }
+
+      if (runtime.hintInFlight) {
+        return {
+          content: [{ type: "text", text: "Hint unavailable: another hint request is already in flight." }],
+          details: { inFlight: true },
+        };
+      }
+
+      if (runtime.hintsThisSession >= config.maxCallsPerSession) {
+        return {
+          content: [{
+            type: "text",
+            text: `Hint unavailable: maxCallsPerSession reached (${config.maxCallsPerSession}). Continue with local experiments or raise the limit deliberately.`,
+          }],
+          details: {
+            hintsThisSession: runtime.hintsThisSession,
+            maxCallsPerSession: config.maxCallsPerSession,
+          },
+        };
+      }
+
+      const modelRegistry = ctx.modelRegistry;
+      if (!modelRegistry?.find || !modelRegistry?.getApiKeyAndHeaders) {
+        return {
+          content: [{
+            type: "text",
+            text: "Hint unavailable: this pi version does not expose modelRegistry.find/getApiKeyAndHeaders to extensions.",
+          }],
+          details: {},
+        };
+      }
+
+      const model = modelRegistry.find(config.provider, config.model);
+      if (!model) {
+        return {
+          content: [{
+            type: "text",
+            text: `Hint unavailable: model ${config.provider}/${config.model} was not found in pi's model registry.`,
+          }],
+          details: { provider: config.provider, model: config.model },
+        };
+      }
+
+      const workDir = resolveWorkDir(ctx.cwd);
+      runtime.hintInFlight = true;
+
+      try {
+        const auth = await modelRegistry.getApiKeyAndHeaders(model);
+        if (!auth.ok) {
+          return {
+            content: [{
+              type: "text",
+              text: `Hint unavailable: no usable auth for ${config.provider}/${config.model}: ${auth.error}`,
+            }],
+            details: { provider: config.provider, model: config.model },
+          };
+        }
+
+        runtime.hintsThisSession++;
+        const hint = await requestAutoresearchHint({
+          state: runtime.state,
+          workDir,
+          question,
+          extraContext: params.extra_context,
+          maxRecentRuns: config.maxRecentRuns,
+          model,
+          apiKey: auth.apiKey,
+          headers: auth.headers,
+          thinkingLevel: config.thinkingLevel,
+          timeoutSeconds: config.timeoutSeconds,
+          signal,
+        });
+
+        const callsRemaining = Math.max(0, config.maxCallsPerSession - runtime.hintsThisSession);
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Hint from ${config.provider}/${config.model}:\n\n${hint.text}` +
+              "\n\nValidate any suggestion with run_experiment and log_experiment before keeping changes.",
+          }],
+          details: {
+            provider: config.provider,
+            model: config.model,
+            durationMs: hint.durationMs,
+            promptBytes: hint.promptBytes,
+            stopReason: hint.stopReason,
+            usage: hint.usage,
+            hintsThisSession: runtime.hintsThisSession,
+            callsRemaining,
+          },
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text",
+            text: `Hint unavailable: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          details: {
+            provider: config.provider,
+            model: config.model,
+            hintsThisSession: runtime.hintsThisSession,
+          },
+        };
+      } finally {
+        runtime.hintInFlight = false;
+      }
+    },
+
+    renderCall(args, theme) {
+      let text = theme.fg("toolTitle", theme.bold("ask_autoresearch_hint "));
+      text += theme.fg("muted", args.question ?? "");
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const output = result.content[0]?.type === "text" ? result.content[0].text : "";
+      const details = result.details as { provider?: string; model?: string; durationMs?: number } | undefined;
+      if (details?.provider && details?.model && details?.durationMs !== undefined) {
+        return new Text(
+          theme.fg("accent", `hint ${details.provider}/${details.model} `) +
+            theme.fg("dim", `${(details.durationMs / 1000).toFixed(1)}s`) +
+            "\n" +
+            output,
+          0,
+          0,
+        );
+      }
+      return new Text(output, 0, 0);
+    },
   });
 
   // -----------------------------------------------------------------------
@@ -2954,6 +3170,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.dashboardExpanded = false;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
+        runtime.hintsThisSession = 0;
+        runtime.hintInFlight = false;
         runtime.lastRunChecks = null;
         runtime.lastRunDuration = null;
         runtime.runningExperiment = null;
@@ -2979,6 +3197,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.dashboardExpanded = false;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
+        runtime.hintsThisSession = 0;
+        runtime.hintInFlight = false;
         runtime.lastRunChecks = null;
         runtime.runningExperiment = null;
         cancelPendingResume(runtime);

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -87,11 +87,28 @@ JSON config file that lives in the pi session's working directory (`ctx.cwd`). S
 
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
 - **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`autoresearch.jsonl`, `autoresearch.md`, `autoresearch.sh`, `autoresearch.checks.sh`, `autoresearch.ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays in `ctx.cwd`. Fails if the directory doesn't exist.
+- **`hints`** (object) — optional expensive-model hint tool config. Do not create this by default. Only add it when the user explicitly wants `ask_autoresearch_hint` to call a configured larger pi model for advisory strategy help.
 
 ```json
 {
   "workingDir": "/path/to/project",
   "maxIterations": 50
+}
+```
+
+When the user explicitly wants the hint tool, add:
+
+```json
+{
+  "hints": {
+    "enabled": true,
+    "provider": "anthropic",
+    "model": "claude-opus-4-5",
+    "thinkingLevel": "high",
+    "maxRecentRuns": 8,
+    "maxCallsPerSession": 5,
+    "timeoutSeconds": 120
+  }
 }
 ```
 

--- a/tests/hints.test.mjs
+++ b/tests/hints.test.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import test from "node:test";
+import { tmpdir } from "node:os";
+
+import {
+  buildHintPrompt,
+  isHintConfigReady,
+  requestAutoresearchHint,
+  resolveHintConfig,
+} from "../extensions/pi-autoresearch/hints.ts";
+import autoresearchExtension from "../extensions/pi-autoresearch/index.ts";
+
+function sampleState() {
+  return {
+    name: "Speed up parser",
+    metricName: "total_ms",
+    metricUnit: "ms",
+    bestDirection: "lower",
+    bestMetric: 100,
+    currentSegment: 0,
+    confidence: 1.5,
+    results: [
+      {
+        commit: "aaa1111",
+        metric: 100,
+        metrics: {},
+        status: "keep",
+        description: "baseline",
+        timestamp: 1,
+        segment: 0,
+        confidence: null,
+        asi: { hypothesis: "baseline" },
+      },
+      {
+        commit: "bbb2222",
+        metric: 130,
+        metrics: {},
+        status: "discard",
+        description: "inline everything",
+        timestamp: 2,
+        segment: 0,
+        confidence: 1.5,
+        asi: {
+          hypothesis: "inline hot parser path",
+          rollback_reason: "larger function hurt optimizer",
+          next_action_hint: "try cache shape metadata",
+        },
+      },
+    ],
+  };
+}
+
+test("hint config defaults to disabled", () => {
+  const config = resolveHintConfig({});
+
+  assert.equal(config.enabled, false);
+  assert.equal(config.provider, null);
+  assert.equal(config.model, null);
+  assert.equal(config.thinkingLevel, "high");
+  assert.equal(config.maxRecentRuns, 8);
+  assert.equal(config.maxCallsPerSession, 5);
+  assert.equal(config.timeoutSeconds, 120);
+  assert.equal(isHintConfigReady(config), false);
+});
+
+test("hint config accepts enabled provider/model and clamps numeric limits", () => {
+  const config = resolveHintConfig({
+    hints: {
+      enabled: true,
+      provider: " anthropic ",
+      model: " claude-opus ",
+      thinkingLevel: "xhigh",
+      maxRecentRuns: 100,
+      maxCallsPerSession: 0,
+      timeoutSeconds: 2,
+    },
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.provider, "anthropic");
+  assert.equal(config.model, "claude-opus");
+  assert.equal(config.thinkingLevel, "xhigh");
+  assert.equal(config.maxRecentRuns, 20);
+  assert.equal(config.maxCallsPerSession, 1);
+  assert.equal(config.timeoutSeconds, 10);
+  assert.equal(isHintConfigReady(config), true);
+});
+
+test("hint config falls back on invalid thinking level and incomplete model config", () => {
+  const config = resolveHintConfig({
+    hints: {
+      enabled: true,
+      provider: "",
+      model: "claude",
+      thinkingLevel: "surprise",
+    },
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.provider, null);
+  assert.equal(config.model, "claude");
+  assert.equal(config.thinkingLevel, "high");
+  assert.equal(isHintConfigReady(config), false);
+});
+
+test("hint prompt includes bounded session, recent runs, rules, ideas, and question", () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  try {
+    fs.writeFileSync(path.join(workDir, "autoresearch.md"), `# Rules\n${"A".repeat(4000)}`);
+    fs.writeFileSync(path.join(workDir, "autoresearch.ideas.md"), "- try memoization\n- try batching");
+
+    const prompt = buildHintPrompt({
+      state: sampleState(),
+      workDir,
+      question: "We have two discards; what should we try next?",
+      extraContext: "Focus on low-risk parser optimizations.",
+      maxRecentRuns: 1,
+    });
+
+    assert.match(prompt, /Goal: Speed up parser/);
+    assert.match(prompt, /Metric: total_ms \(ms\); lower is better/);
+    assert.doesNotMatch(prompt, /#1 \| keep/);
+    assert.match(prompt, /#2 \| discard \| total_ms=130ms/);
+    assert.match(prompt, /rollback_reason: larger function hurt optimizer/);
+    assert.match(prompt, /try memoization/);
+    assert.match(prompt, /We have two discards/);
+    assert.match(prompt, /Focus on low-risk parser optimizations/);
+    assert.match(prompt, /\[truncated to 3000 chars\]/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("requestAutoresearchHint uses injected completion and extracts text", async () => {
+  let captured = null;
+  const fakeComplete = async (model, context, options) => {
+    captured = { model, context, options };
+    return {
+      role: "assistant",
+      content: [{ type: "text", text: "Try one smaller cache experiment." }],
+      timestamp: Date.now(),
+      stopReason: "stop",
+      usage: {
+        input: 10,
+        output: 7,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 17,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    };
+  };
+
+  const result = await requestAutoresearchHint({
+    model: { id: "hint-model" },
+    apiKey: "key",
+    headers: { "x-test": "1" },
+    state: sampleState(),
+    workDir: tmpdir(),
+    question: "What next?",
+    maxRecentRuns: 2,
+    thinkingLevel: "off",
+    timeoutSeconds: 10,
+    complete: fakeComplete,
+  });
+
+  assert.equal(result.text, "Try one smaller cache experiment.");
+  assert.equal(result.stopReason, "stop");
+  assert.equal(result.usage.output, 7);
+  assert.equal(captured.options.apiKey, "key");
+  assert.equal(captured.options.headers["x-test"], "1");
+  assert.equal(captured.options.reasoning, undefined);
+  assert.match(captured.context.systemPrompt, /strategy advice only/);
+});
+
+function collectHintTool() {
+  let hintTool = null;
+  autoresearchExtension({
+    on() {},
+    registerCommand() {},
+    registerShortcut() {},
+    registerTool(tool) {
+      if (tool.name === "ask_autoresearch_hint") hintTool = tool;
+    },
+  });
+  return hintTool;
+}
+
+function fakeContext(workDir, modelRegistry) {
+  return {
+    cwd: workDir,
+    sessionManager: {
+      getSessionId() {
+        return "hint-test-session";
+      },
+    },
+    modelRegistry,
+  };
+}
+
+test("hint tool disabled config does not touch model registry", async () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  let findCalls = 0;
+  try {
+    const tool = collectHintTool();
+    const result = await tool.execute(
+      "call-1",
+      { question: "What next?" },
+      undefined,
+      undefined,
+      fakeContext(workDir, {
+        find() {
+          findCalls++;
+        },
+      }),
+    );
+
+    assert.equal(findCalls, 0);
+    assert.match(result.content[0].text, /hints are disabled/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("hint tool incomplete config does not touch model registry", async () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  let findCalls = 0;
+  try {
+    fs.writeFileSync(
+      path.join(workDir, "autoresearch.config.json"),
+      JSON.stringify({ hints: { enabled: true, model: "claude" } }),
+    );
+
+    const tool = collectHintTool();
+    const result = await tool.execute(
+      "call-1",
+      { question: "What next?" },
+      undefined,
+      undefined,
+      fakeContext(workDir, {
+        find() {
+          findCalls++;
+        },
+      }),
+    );
+
+    assert.equal(findCalls, 0);
+    assert.match(result.content[0].text, /provider and hints\.model/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("hint tool blocks concurrent calls while auth is resolving", async () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  try {
+    fs.writeFileSync(
+      path.join(workDir, "autoresearch.config.json"),
+      JSON.stringify({
+        hints: {
+          enabled: true,
+          provider: "anthropic",
+          model: "claude",
+        },
+      }),
+    );
+
+    let resolveAuth;
+    const authPromise = new Promise((resolve) => {
+      resolveAuth = resolve;
+    });
+
+    const tool = collectHintTool();
+    const ctx = fakeContext(workDir, {
+      find() {
+        return { id: "claude", provider: "anthropic", api: "anthropic-messages" };
+      },
+      getApiKeyAndHeaders() {
+        return authPromise;
+      },
+    });
+
+    const first = tool.execute("call-1", { question: "What next?" }, undefined, undefined, ctx);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const second = await tool.execute("call-2", { question: "What next?" }, undefined, undefined, ctx);
+    assert.match(second.content[0].text, /already in flight/);
+
+    resolveAuth({ ok: false, error: "missing key" });
+    const firstResult = await first;
+    assert.match(firstResult.content[0].text, /missing key/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `ask_autoresearch_hint` tool that lets an autoresearch loop ask a configured larger Pi model for concise strategy advice when progress stalls.

The tool is disabled by default and side-effect free: it does not edit files, switch the active model, commit, revert, or write `autoresearch.jsonl`.

## Behavior

Configured through `autoresearch.config.json`:

```json
{
  "hints": {
    "enabled": true,
    "provider": "opencode-go",
    "model": "glm-5",
    "thinkingLevel": "low",
    "maxRecentRuns": 3,
    "maxCallsPerSession": 2,
    "timeoutSeconds": 120
  }
}