### PR TITLE
Gate experiment tools behind autoresearch mode

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1007,6 +1007,23 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const getRuntime = (ctx: ExtensionContext): AutoresearchRuntime =>
     runtimeStore.ensure(getSessionKey(ctx));
 
+  // Registering through this gates the tool, so a new one can't slip in ungated.
+  const gatedToolNames = new Set<string>();
+  const registerGatedTool = (tool: Parameters<typeof pi.registerTool>[0]): void => {
+    gatedToolNames.add(tool.name);
+    pi.registerTool(tool);
+  };
+
+  // The one place mode flips: gated tools follow the flag, never drifting from it.
+  const setAutoresearchMode = (ctx: ExtensionContext, enabled: boolean): void => {
+    getRuntime(ctx).autoresearchMode = enabled;
+    const activeTools = new Set(pi.getActiveTools()); // setActiveTools replaces the whole set
+    for (const tool of gatedToolNames) {
+      enabled ? activeTools.add(tool) : activeTools.delete(tool);
+    }
+    pi.setActiveTools([...activeTools]);
+  };
+
   const isAgentSettled = (ctx: ExtensionContext): boolean =>
     ctx.isIdle() && !ctx.hasPendingMessages();
 
@@ -1274,7 +1291,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
     // Auto-enter autoresearch mode only when a persisted experiment log exists
-    runtime.autoresearchMode = fs.existsSync(autoresearchJsonlPath(workDir));
+    setAutoresearchMode(ctx, fs.existsSync(autoresearchJsonlPath(workDir)));
 
     updateWidget(ctx);
   };
@@ -1538,7 +1555,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // init_experiment tool — one-time setup
   // -----------------------------------------------------------------------
 
-  pi.registerTool({
+  registerGatedTool({
     name: "init_experiment",
     label: "Init Experiment",
     description:
@@ -1613,7 +1630,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       const wasInactive = !runtime.autoresearchMode;
-      runtime.autoresearchMode = true;
+      setAutoresearchMode(ctx, true);
       updateWidget(ctx);
 
       if (wasInactive) {
@@ -1655,7 +1672,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // run_experiment tool
   // -----------------------------------------------------------------------
 
-  pi.registerTool({
+  registerGatedTool({
     name: "run_experiment",
     label: "Run Experiment",
     description:
@@ -2170,7 +2187,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // log_experiment tool
   // -----------------------------------------------------------------------
 
-  pi.registerTool({
+  registerGatedTool({
     name: "log_experiment",
     label: "Log Experiment",
     description:
@@ -2436,7 +2453,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const limitReached = state.maxExperiments !== null && segmentCount >= state.maxExperiments;
       if (limitReached) {
         text += `\n\n🛑 Maximum experiments reached (${state.maxExperiments}). STOP the experiment loop now.`;
-        runtime.autoresearchMode = false;
+        setAutoresearchMode(ctx, false);
         ctx.abort();
       } else if (runtime.autoresearchMode) {
         const beforeSteer = await fireHook({
@@ -2950,7 +2967,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       if (command === "off") {
         const wasRunning = !ctx.isIdle();
 
-        runtime.autoresearchMode = false;
+        setAutoresearchMode(ctx, false);
         runtime.dashboardExpanded = false;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
@@ -2975,7 +2992,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       if (command === "clear") {
         const jsonlPath = autoresearchJsonlPath(resolveWorkDir(ctx.cwd));
-        runtime.autoresearchMode = false;
+        setAutoresearchMode(ctx, false);
         runtime.dashboardExpanded = false;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
@@ -3007,7 +3024,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return;
       }
 
-      runtime.autoresearchMode = true;
+      setAutoresearchMode(ctx, true);
       runtime.autoResumeTurns = 0;
 
       const workDir = resolveWorkDir(ctx.cwd);


### PR DESCRIPTION
## What

The `init_experiment`, `run_experiment`, and `log_experiment` tools are now revealed to the agent **only while autoresearch mode is active**, instead of being registered and callable in every session.

## Why

Outside autoresearch mode these tools are irrelevant and let an agent self-start an experiment loop unprompted. Hiding them keeps normal coding sessions clean (no extra tool schema or system-prompt guidance) and makes autoresearch strictly user-initiated.

## How

- **`registerGatedTool`** wraps `pi.registerTool` and records each tool name in a `gatedToolNames` set. Gating is *derived from registration*, so a newly added tool can't slip in ungated — and there's no parallel name list to keep in sync.
- **`setAutoresearchMode(ctx, enabled)`** is the single place the mode flips. It updates the active tool set via `setActiveTools` (computed incrementally so other tools are untouched), so tool visibility can never drift from the flag. All six mode-change sites now funnel through it.

## Effect on the flow

`autoresearchMode` becomes `true` only via:
1. the `/autoresearch <text>` command (user action), or
2. resuming a session whose `autoresearch.jsonl` already exists (prior user opt-in).

Because `init_experiment` is itself gated, the agent can no longer call it to bootstrap a loop on its own — closing the previous self-start path.

## Testing

- `tsc --strict` clean
- 20/20 existing tests pass