### PR TITLE
Make autoresearch auto-resume limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `maxAutoResumeTurns` in `autoresearch.config.json` to tune the auto-resume safety valve. The default remains 20; `null` or `0` means intentional unlimited auto-resume.
+- `/autoresearch` can infer loop controls from natural language, e.g. “for 50 runs” or “continue indefinitely”, and writes the matching config automatically.
+
 ## [1.5.0] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pi install npm:pi-autoresearch
 ```
 /autoresearch optimize unit test runtime, monitor correctness
 /autoresearch model training, run 5 minutes of train.py and note the loss ratio as optimization target
+/autoresearch optimize bundle size for 50 runs
+/autoresearch continue indefinitely and never stop
 /autoresearch export
 /autoresearch off
 /autoresearch clear
@@ -209,7 +211,8 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "maxAutoResumeTurns": 50
 }
 ```
 
@@ -217,10 +220,11 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 |-------|------|-------------|
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays in the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
+| `maxAutoResumeTurns` | number \| null | Safety valve for automatic resume prompts after completed turns or compactions. Defaults to `20` to prevent accidental chat-only loops. Set to `null` or `0` for unlimited auto-resume. |
 
 ### Long-running loops and context
 
-The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `autoresearch.md`, the tail of `autoresearch.jsonl`, `autoresearch.ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works.
+The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `autoresearch.md`, the tail of `autoresearch.jsonl`, `autoresearch.ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works. For intentionally very long unattended sessions, raise or disable `maxAutoResumeTurns` so the safety valve does not stop the loop before your chosen run count.
 
 ---
 
@@ -338,6 +342,14 @@ Autoresearch loops run autonomously and can burn through tokens. Two ways to cap
      "maxIterations": 30
    }
    ```
+- **`maxAutoResumeTurns`** — cap or remove the auto-resume safety valve. The default is `20`; set `null` or `0` only when you intentionally want unattended runs to continue indefinitely:
+   ```json
+   {
+     "maxAutoResumeTurns": null
+   }
+   ```
+
+You can also set these verbally in `/autoresearch`: phrases like “run forever”, “continue indefinitely”, or “never stop” configure unlimited auto-resume; phrases like “for 50 runs” configure both `maxIterations` and enough auto-resume budget for that run count.
 
 ## License
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -59,6 +59,12 @@ const EXPERIMENT_MAX_LINES = 10;
 const EXPERIMENT_MAX_BYTES = 4 * 1024; // 4KB
 
 // ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_MAX_AUTORESUME_TURNS = 20;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -428,13 +434,20 @@ function currentResults(results: ExperimentResult[], segment: number): Experimen
   return results.filter((r) => r.segment === segment);
 }
 
-interface AutoresearchConfig {
-  maxIterations?: number;
+export interface AutoresearchConfig {
+  maxIterations?: number | null;
+  maxAutoResumeTurns?: number | null;
   workingDir?: string;
 }
 
+export interface InferredAutoresearchConfig {
+  maxIterations?: number;
+  clearMaxIterations?: boolean;
+  maxAutoResumeTurns?: number | null;
+}
+
 /** Read autoresearch.config.json from the given directory (always ctx.cwd) */
-function readConfig(cwd: string): AutoresearchConfig {
+export function readConfig(cwd: string): AutoresearchConfig {
   try {
     const configPath = autoresearchConfigPath(cwd);
     if (!fs.existsSync(configPath)) return {};
@@ -445,11 +458,96 @@ function readConfig(cwd: string): AutoresearchConfig {
 }
 
 /** Read maxExperiments from autoresearch.config.json (if it exists) */
-function readMaxExperiments(cwd: string): number | null {
+export function readMaxExperiments(cwd: string): number | null {
   const config = readConfig(cwd);
   return (typeof config.maxIterations === "number" && config.maxIterations > 0)
     ? Math.floor(config.maxIterations)
     : null;
+}
+
+/**
+ * Read the auto-resume safety valve from autoresearch.config.json.
+ * Undefined preserves the conservative default. null or 0 means unlimited.
+ */
+export function readMaxAutoResumeTurns(cwd: string): number | null {
+  const config = readConfig(cwd);
+  if (config.maxAutoResumeTurns === null || config.maxAutoResumeTurns === 0) return null;
+  return (typeof config.maxAutoResumeTurns === "number" && config.maxAutoResumeTurns > 0)
+    ? Math.floor(config.maxAutoResumeTurns)
+    : DEFAULT_MAX_AUTORESUME_TURNS;
+}
+
+function parsePositiveInteger(value: string): number | null {
+  const parsed = Number.parseInt(value.replace(/[,_]/g, ""), 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/** Infer loop controls from natural-language `/autoresearch ...` arguments. */
+export function inferAutoresearchConfigFromPrompt(prompt: string): InferredAutoresearchConfig | null {
+  const text = prompt
+    .toLowerCase()
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return null;
+
+  const inferred: InferredAutoresearchConfig = {};
+
+  const autoResumeMatch = text.match(
+    /\b(?:for|after|limit(?:ed)?(?: to)?|stop after|only)?\s*(\d[\d,_]*)\s*(?:auto[- ]?resumes?|auto[- ]?resume turns?|resume turns?)\b/,
+  );
+  if (autoResumeMatch) {
+    const count = parsePositiveInteger(autoResumeMatch[1]);
+    if (count !== null) inferred.maxAutoResumeTurns = count;
+  }
+
+  const runMatch = text.match(
+    /\b(?:for|after|limit(?:ed)?(?: to)?|stop after|only)\s+(\d[\d,_]*)\s+(?:runs?|iterations?|experiments?)\b/,
+  );
+  if (runMatch) {
+    const count = parsePositiveInteger(runMatch[1]);
+    if (count !== null) {
+      inferred.maxIterations = count;
+      if (inferred.maxAutoResumeTurns === undefined) inferred.maxAutoResumeTurns = count;
+    }
+  }
+
+  const wantsUnlimited =
+    /\b(?:run|continue|resume|loop)\s+(?:indefinitely|infinite(?:ly)?|forever|without stopping)\b/.test(text) ||
+    /\b(?:indefinitely|forever)\s+(?:run|continue|resume|loop)\b/.test(text) ||
+    /\bunlimited\s+auto[- ]?resume\b/.test(text) ||
+    /\b(?:no|without)\s+(?:auto[- ]?resume\s+)?limits?\b/.test(text) ||
+    /\bnever\s+stopp?ing?\b/.test(text) ||
+    /\bdon'?t\s+stop\b/.test(text);
+
+  if (wantsUnlimited) {
+    inferred.maxAutoResumeTurns = null;
+    if (inferred.maxIterations === undefined) inferred.clearMaxIterations = true;
+  }
+
+  return Object.keys(inferred).length > 0 ? inferred : null;
+}
+
+export function applyInferredAutoresearchConfig(cwd: string, inferred: InferredAutoresearchConfig): string[] {
+  const configPath = autoresearchConfigPath(cwd);
+  const config = readConfig(cwd);
+  const notes: string[] = [];
+
+  if (inferred.clearMaxIterations) {
+    delete config.maxIterations;
+    notes.push("maxIterations=unlimited");
+  }
+  if (inferred.maxIterations !== undefined) {
+    config.maxIterations = inferred.maxIterations;
+    notes.push(`maxIterations=${inferred.maxIterations}`);
+  }
+  if (inferred.maxAutoResumeTurns !== undefined) {
+    config.maxAutoResumeTurns = inferred.maxAutoResumeTurns;
+    notes.push(`maxAutoResumeTurns=${inferred.maxAutoResumeTurns === null ? "unlimited" : inferred.maxAutoResumeTurns}`);
+  }
+
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  return notes;
 }
 
 /**
@@ -974,7 +1072,6 @@ function renderDashboardLines(
 // ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
-  const MAX_AUTORESUME_TURNS = 20;
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
 
@@ -1054,7 +1151,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!isAgentSettled(ctx)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    if (hasReachedAutoResumeLimit(ctx, runtime)) {
       cancelPendingResume(runtime);
       notifyAutoResumeLimitReached(ctx);
       return;
@@ -1090,12 +1187,15 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const shouldAutoResumeAfterCompact = (runtime: AutoresearchRuntime): boolean =>
     runtime.autoresearchMode;
 
-  const hasReachedAutoResumeLimit = (runtime: AutoresearchRuntime): boolean =>
-    runtime.autoResumeTurns >= MAX_AUTORESUME_TURNS;
+  const hasReachedAutoResumeLimit = (ctx: ExtensionContext, runtime: AutoresearchRuntime): boolean => {
+    const limit = readMaxAutoResumeTurns(ctx.cwd);
+    return limit !== null && runtime.autoResumeTurns >= limit;
+  };
 
   const notifyAutoResumeLimitReached = (ctx: ExtensionContext): void => {
+    const limit = readMaxAutoResumeTurns(ctx.cwd);
     ctx.ui.notify(
-      `Autoresearch auto-resume limit reached (${MAX_AUTORESUME_TURNS} turns)`,
+      `Autoresearch auto-resume limit reached (${limit ?? "unlimited"} turns)`,
       "info",
     );
   };
@@ -1211,6 +1311,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "Examples:",
       "  /autoresearch optimize unit test runtime, monitor correctness",
       "  /autoresearch model training, run 5 minutes of train.py and note the loss ratio as optimization target",
+      "  /autoresearch optimize bundle size for 50 runs",
+      "  /autoresearch continue indefinitely and never stop",
       "  /autoresearch export",
     ].join("\n");
 
@@ -1486,7 +1588,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!gate(runtime)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    if (hasReachedAutoResumeLimit(ctx, runtime)) {
       notifyAutoResumeLimitReached(ctx);
       return;
     }
@@ -3019,8 +3121,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return;
       }
 
+      const inferredConfig = inferAutoresearchConfigFromPrompt(trimmedArgs);
+      let configNote = "";
+      if (inferredConfig) {
+        const notes = applyInferredAutoresearchConfig(ctx.cwd, inferredConfig);
+        runtime.state.maxExperiments = readMaxExperiments(ctx.cwd);
+        runtime.autoResumeTurns = 0;
+        configNote = notes.length > 0 ? ` Config: ${notes.join(", ")}.` : "";
+      }
+
       if (runtime.autoresearchMode) {
-        ctx.ui.notify("Autoresearch already active — use '/autoresearch off' to stop first", "info");
+        const resume = `Autoresearch mode already active.${configNote} ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`;
+        ctx.ui.notify(`Autoresearch mode already active.${configNote}`, "info");
+        sendWhenReady(ctx, resume);
         return;
       }
 
@@ -3030,13 +3143,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const workDir = resolveWorkDir(ctx.cwd);
       const rulesLoaded = hasAutoresearchRules(ctx);
       const kickoff = rulesLoaded
-        ? `Autoresearch mode active. ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`
-        : `Start autoresearch: ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`;
+        ? `Autoresearch mode active.${configNote} ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`
+        : `Start autoresearch:${configNote} ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`;
 
       ctx.ui.notify(
         rulesLoaded
-          ? "Autoresearch mode ON — rules loaded from autoresearch.md"
-          : "Autoresearch mode ON — no autoresearch.md found, setting up",
+          ? `Autoresearch mode ON — rules loaded from autoresearch.md${configNote}`
+          : `Autoresearch mode ON — no autoresearch.md found, setting up${configNote}`,
         "info",
       );
 

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -86,14 +86,18 @@ Use `log_experiment`'s `asi` parameter to annotate each run with **whatever woul
 JSON config file that lives in the pi session's working directory (`ctx.cwd`). Supported fields:
 
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
+- **`maxAutoResumeTurns`** (number or null) — maximum automatic resume prompts before the safety valve stops the loop. Defaults to 20. Set to `null` or `0` for intentional unlimited auto-resume.
 - **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`autoresearch.jsonl`, `autoresearch.md`, `autoresearch.sh`, `autoresearch.checks.sh`, `autoresearch.ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays in `ctx.cwd`. Fails if the directory doesn't exist.
 
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "maxAutoResumeTurns": 50
 }
 ```
+
+The `/autoresearch` command also understands common natural-language loop controls and writes this config automatically. Phrases like “for 50 runs” set `maxIterations` and the auto-resume budget; phrases like “run forever”, “continue indefinitely”, or “never stop” set unlimited auto-resume and remove the experiment cap.
 
 ### `autoresearch.checks.sh` (optional)
 

--- a/tests/autoresume-config.test.mjs
+++ b/tests/autoresume-config.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  applyInferredAutoresearchConfig,
+  DEFAULT_MAX_AUTORESUME_TURNS,
+  inferAutoresearchConfigFromPrompt,
+  readMaxAutoResumeTurns,
+  readMaxExperiments,
+} from "../extensions/pi-autoresearch/index.ts";
+
+test("auto-resume defaults to the conservative built-in safety valve", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    assert.equal(readMaxAutoResumeTurns(dir), DEFAULT_MAX_AUTORESUME_TURNS);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("auto-resume config supports finite and unlimited values", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    await writeFile(join(dir, "autoresearch.config.json"), JSON.stringify({ maxAutoResumeTurns: 75 }));
+    assert.equal(readMaxAutoResumeTurns(dir), 75);
+
+    await writeFile(join(dir, "autoresearch.config.json"), JSON.stringify({ maxAutoResumeTurns: null }));
+    assert.equal(readMaxAutoResumeTurns(dir), null);
+
+    await writeFile(join(dir, "autoresearch.config.json"), JSON.stringify({ maxAutoResumeTurns: 0 }));
+    assert.equal(readMaxAutoResumeTurns(dir), null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("natural-language run counts configure experiment and auto-resume budgets", () => {
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("optimize bundle size for 50 runs"), {
+    maxIterations: 50,
+    maxAutoResumeTurns: 50,
+  });
+
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("continue for 1,000 experiments"), {
+    maxIterations: 1000,
+    maxAutoResumeTurns: 1000,
+  });
+});
+
+test("natural-language resume counts configure only the auto-resume budget", () => {
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("continue for 80 auto-resume turns"), {
+    maxAutoResumeTurns: 80,
+  });
+});
+
+test("natural-language unlimited phrases remove caps and allow indefinite auto-resume", () => {
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("continue indefinitely and never stop"), {
+    clearMaxIterations: true,
+    maxAutoResumeTurns: null,
+  });
+
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("run forever for 25 runs"), {
+    maxIterations: 25,
+    maxAutoResumeTurns: null,
+  });
+});
+
+test("natural-language parser avoids unrelated durations and product words", () => {
+  assert.equal(
+    inferAutoresearchConfigFromPrompt("model training, run 5 minutes of train.py"),
+    null,
+  );
+  assert.equal(
+    inferAutoresearchConfigFromPrompt("optimize infinite scroll performance"),
+    null,
+  );
+});
+
+test("applying inferred config preserves unrelated fields", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    await writeFile(
+      join(dir, "autoresearch.config.json"),
+      JSON.stringify({ workingDir: "../project", maxIterations: 10 }),
+    );
+
+    const notes = applyInferredAutoresearchConfig(dir, {
+      clearMaxIterations: true,
+      maxAutoResumeTurns: null,
+    });
+
+    assert.deepEqual(notes, ["maxIterations=unlimited", "maxAutoResumeTurns=unlimited"]);
+    assert.equal(readMaxExperiments(dir), null);
+    assert.equal(readMaxAutoResumeTurns(dir), null);
+    assert.deepEqual(JSON.parse(await readFile(join(dir, "autoresearch.config.json"), "utf-8")), {
+      workingDir: "../project",
+      maxAutoResumeTurns: null,
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Make the auto-resume safety valve configurable while preserving the existing safe default.

- Adds `maxAutoResumeTurns` to `autoresearch.config.json`
  - omitted/invalid: current default of `20`
  - positive number: finite auto-resume budget
  - `null` or `0`: intentional unlimited auto-resume
- Lets `/autoresearch` infer common loop controls from the user's prompt and write config automatically:
  - “for 50 runs” → `maxIterations: 50` and `maxAutoResumeTurns: 50`
  - “continue indefinitely”, “run forever”, “never stop” → unlimited auto-resume and no `maxIterations` cap
  - “for 80 auto-resume turns” → only the auto-resume budget
- Allows `/autoresearch ...` while autoresearch mode is already active to update the config, reset the auto-resume counter, and resume without requiring `/autoresearch off` first.
- Documents the config in README and the autoresearch skill.

## Rationale

`MAX_AUTORESUME_TURNS = 20` is a useful guard against accidental chat-only self-prompt loops, so this PR keeps that behavior as the default. However, some users intentionally run long unattended sessions and need a supported way to raise or disable the guard without locally patching the extension after every update.

This keeps the safety valve explicit and opt-in: unlimited auto-resume requires either a config value (`null`/`0`) or clear natural-language intent in `/autoresearch` such as “continue indefinitely” or “never stop”.

## Testing

- `npm test`
