### PR TITLE
Default dashboard to expanded; fullscreen is the only toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- The dashboard widget is now always expanded — the full results table renders inline above the editor at all times. Removed the collapsed one-liner mode and the `Ctrl+Shift+T` expand/collapse toggle (and its `shortcuts.toggleDashboard` config key). Fullscreen (`Ctrl+Shift+F`) remains the only dashboard toggle.
+
 ## [1.5.0] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ pi install npm:pi-autoresearch
 
 | Shortcut     | Description |
 |--------------|-------------|
-| `Ctrl+Shift+T` | Toggle dashboard expand/collapse (inline widget ↔ full results table above the editor) |
 | `Ctrl+Shift+F` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
 
 To avoid conflicts with other pi extensions, override or disable these shortcuts in
@@ -73,8 +72,7 @@ config directory (usually `~/.pi/agent`, or `PI_CODING_AGENT_DIR` when set):
 ```json
 {
   "shortcuts": {
-    "toggleDashboard": "ctrl+shift+y",
-    "fullscreenDashboard": null
+    "fullscreenDashboard": "ctrl+shift+y"
   }
 }
 ```
@@ -83,9 +81,8 @@ Use `null` to skip registering a shortcut. Omitted shortcuts keep their defaults
 
 ### UI
 
-- **Status widget** — always visible above the editor: `🔬 autoresearch 12 runs 8 kept │ ★ total_µs: 15,200 (-12.3%) │ conf: 2.1×`
+- **Dashboard widget** — always visible above the editor: a full results table with columns for commit, metric, status, and description.
 - **Confidence score** — after 3+ runs, shows how the best improvement compares to the session noise floor. ≥2.0× (green) = likely real, 1.0–2.0× (yellow) = above noise but marginal, <1.0× (red) = within noise.
-- **Expanded dashboard** — `Ctrl+Shift+T` expands the widget into a full results table with columns for commit, metric, status, and description.
 - **Fullscreen overlay** — `Ctrl+Shift+F` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
 
 ### Skills
@@ -156,8 +153,7 @@ The agent reads `autoresearch.jsonl`, groups kept experiments into logical chang
 
 ### 4. Monitor progress
 
-- **Widget** — always visible above the editor
-- **`Ctrl+Shift+T`** — expand/collapse the full results table inline (config key: `shortcuts.toggleDashboard`)
+- **Widget** — full results table, always visible above the editor
 - **`Ctrl+Shift+F`** — fullscreen scrollable dashboard overlay (config key: `shortcuts.fullscreenDashboard`)
 - **`/autoresearch export`** — open a live browser dashboard with chart and share card
 - **`Escape`** — interrupt anytime and ask for a summary
@@ -232,7 +228,7 @@ After 3+ experiments in a session, pi-autoresearch computes a **confidence score
 
 - Uses [Median Absolute Deviation (MAD)](https://en.wikipedia.org/wiki/Median_absolute_deviation) of all metric values in the current segment as a robust noise estimator.
 - Confidence = `|best_improvement| / MAD`. A score of 2.0× means the best improvement is twice the noise floor.
-- Shown in the widget, expanded dashboard, and `log_experiment` output.
+- Shown in the widget, fullscreen dashboard, and `log_experiment` output.
 - Persisted to `autoresearch.jsonl` on each result for post-hoc analysis.
 - **Advisory only** — never auto-discards. The agent is guided to re-run experiments when confidence is low, but the final keep/discard decision stays with the agent.
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -8,7 +8,7 @@
  * - `run_experiment` tool — runs any command, times it, captures output, detects pass/fail
  * - `log_experiment` tool — records results with session-persisted state
  * - Status widget showing experiment count + best metric
- * - Configurable shortcuts to expand/collapse and fullscreen the dashboard
+ * - Configurable shortcut to open the fullscreen dashboard overlay
  * - Adds autoresearch guidance to the system prompt and points the agent at autoresearch.md
  * - Injects autoresearch.md into context on every turn via before_agent_start
  */
@@ -140,7 +140,6 @@ interface LogDetails {
 
 interface AutoresearchRuntime {
   autoresearchMode: boolean;
-  dashboardExpanded: boolean;
   experimentsThisSession: number;
   autoResumeTurns: number;
   lastRunChecks: { pass: boolean; output: string; duration: number } | null;
@@ -633,7 +632,6 @@ function createExperimentState(): ExperimentState {
 function createSessionRuntime(): AutoresearchRuntime {
   return {
     autoresearchMode: false,
-    dashboardExpanded: false,
     experimentsThisSession: 0,
     autoResumeTurns: 0,
     lastRunChecks: null,
@@ -983,23 +981,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const SETTLED_WINDOW_MS = 800;
   const shortcuts = resolveAutoresearchShortcuts();
 
-  const dashboardHintVariants = (toggleAction: "expand" | "collapse"): string[] => {
-    const toggle = shortcuts.toggleDashboard
-      ? `${shortcuts.toggleDashboard} ${toggleAction}`
-      : null;
-    const fullscreen = shortcuts.fullscreenDashboard
-      ? `${shortcuts.fullscreenDashboard} fullscreen`
-      : null;
-
-    if (toggle && fullscreen) {
-      return [
-        `${toggle} • ${fullscreen}`,
-        `${toggle} • full: ${shortcuts.fullscreenDashboard}`,
-        `${shortcuts.toggleDashboard} • ${shortcuts.fullscreenDashboard}`,
-      ];
-    }
-
-    return [toggle, fullscreen].filter((hint): hint is string => hint !== null);
+  const dashboardHintVariants = (): string[] => {
+    if (!shortcuts.fullscreenDashboard) return [];
+    return [
+      `${shortcuts.fullscreenDashboard} fullscreen`,
+      shortcuts.fullscreenDashboard,
+    ];
   };
 
   const runtimeStore = createRuntimeStore();
@@ -1328,9 +1315,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
 
-    if (runtime.dashboardExpanded) {
-      // Expanded: full dashboard table rendered as widget
-      ctx.ui.setWidget("autoresearch", (tui, theme) => ({
+    // Full dashboard table rendered as widget
+    ctx.ui.setWidget("autoresearch", (tui, theme) => ({
         render(width: number): string[] {
           const safeWidth = Math.max(1, width || getTuiSize(tui).width);
           const title = truncateDisplayText(
@@ -1354,107 +1340,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
               safeWidth,
               theme,
               rows,
-              dashboardHintVariants("collapse")
+              dashboardHintVariants()
             ),
           ];
         },
         invalidate(): void {},
       }));
-    } else {
-      // Collapsed: compact one-liner — compute everything inside render
-      ctx.ui.setWidget("autoresearch", (tui, theme) => ({
-        render(width: number): string[] {
-          const safeWidth = Math.max(1, width || getTuiSize(tui).width);
-          const cur = currentResults(state.results, state.currentSegment);
-          const kept = cur.filter((r) => r.status === "keep").length;
-          const crashed = cur.filter((r) => r.status === "crash").length;
-          const checksFailed = cur.filter((r) => r.status === "checks_failed").length;
-          const baseline = state.bestMetric;
-          const baselineSec = findBaselineSecondary(
-            state.results,
-            state.currentSegment,
-            state.secondaryMetrics
-          );
-
-          let bestPrimary: number | null = null;
-          let bestSec: Record<string, number> = {};
-          let bestRunNum = 0;
-          for (let i = state.results.length - 1; i >= 0; i--) {
-            const r = state.results[i];
-            if (r.segment !== state.currentSegment) continue;
-            if (r.status === "keep" && r.metric > 0) {
-              if (bestPrimary === null || isBetter(r.metric, bestPrimary, state.bestDirection)) {
-                bestPrimary = r.metric;
-                bestSec = r.metrics ?? {};
-                bestRunNum = i + 1;
-              }
-            }
-          }
-
-          const displayVal = bestPrimary ?? baseline;
-          const essential = [
-            theme.fg("accent", "🔬"),
-            theme.fg("muted", ` ${state.results.length} runs`),
-            theme.fg("success", ` ${kept} kept`),
-            theme.fg("dim", " │ "),
-            theme.fg(
-              "warning",
-              theme.bold(`★ ${state.metricName}: ${formatNum(displayVal, state.metricUnit)}`)
-            ),
-            bestRunNum > 0 ? theme.fg("dim", ` #${bestRunNum}`) : "",
-          ];
-
-          const optional: string[] = [];
-          if (crashed > 0) optional.push(theme.fg("error", ` ${crashed}💥`));
-          if (checksFailed > 0) optional.push(theme.fg("error", ` ${checksFailed}⚠`));
-
-          if (baseline !== null && bestPrimary !== null && baseline !== 0 && bestPrimary !== baseline) {
-            const pct = ((bestPrimary - baseline) / baseline) * 100;
-            const sign = pct > 0 ? "+" : "";
-            const deltaColor = isBetter(bestPrimary, baseline, state.bestDirection)
-              ? "success"
-              : "error";
-            optional.push(theme.fg(deltaColor, ` (${sign}${pct.toFixed(1)}%)`));
-          }
-
-          if (state.confidence !== null) {
-            const confStr = state.confidence.toFixed(1);
-            const confColor: Parameters<typeof theme.fg>[0] = state.confidence >= 2.0 ? "success" : state.confidence >= 1.0 ? "warning" : "error";
-            optional.push(theme.fg("dim", " │ "));
-            optional.push(theme.fg(confColor, `conf: ${confStr}×`));
-          }
-
-          if (state.secondaryMetrics.length > 0) {
-            for (const sm of state.secondaryMetrics) {
-              const val = bestSec[sm.name];
-              const bv = baselineSec[sm.name];
-              if (val === undefined) continue;
-              let secText = `${sm.name}: ${formatNum(val, sm.unit)}`;
-              if (bv !== undefined && bv !== 0 && val !== bv) {
-                const p = ((val - bv) / bv) * 100;
-                const s = p > 0 ? "+" : "";
-                const c = val <= bv ? "success" : "error";
-                secText += theme.fg(c, ` ${s}${p.toFixed(1)}%`);
-              }
-              optional.push(theme.fg("dim", "  "));
-              optional.push(theme.fg("muted", secText));
-              break;
-            }
-          }
-
-          if (state.name) optional.push(theme.fg("dim", ` │ ${state.name}`));
-
-          const left = [...essential, ...optional].join("");
-          const hintVariants = dashboardHintVariants("expand");
-          return [
-            hintVariants.length > 0
-              ? appendRightAlignedAdaptiveHint(left, safeWidth, theme, hintVariants)
-              : truncateToWidth(left, safeWidth, "…", true),
-          ];
-        },
-        invalidate(): void {},
-      }));
-    }
   };
 
   pi.on("session_start", async (_e, ctx) => reconstructState(ctx));
@@ -2558,30 +2449,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Toggle dashboard expand/collapse shortcut
-  // -----------------------------------------------------------------------
-
-  if (shortcuts.toggleDashboard) {
-    pi.registerShortcut(shortcuts.toggleDashboard, {
-      description: "Toggle autoresearch dashboard",
-      handler: async (ctx) => {
-        const runtime = getRuntime(ctx);
-        const state = runtime.state;
-        if (state.results.length === 0) {
-          if (!runtime.autoresearchMode && !fs.existsSync(autoresearchMdPath(resolveWorkDir(ctx.cwd)))) {
-            ctx.ui.notify("No experiments yet — run /autoresearch to get started", "info");
-          } else {
-            ctx.ui.notify("No experiments yet", "info");
-          }
-          return;
-        }
-        runtime.dashboardExpanded = !runtime.dashboardExpanded;
-        updateWidget(ctx);
-      },
-    });
-  }
-
-  // -----------------------------------------------------------------------
   // Fullscreen scrollable dashboard overlay shortcut
   // -----------------------------------------------------------------------
 
@@ -2968,7 +2835,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         const wasRunning = !ctx.isIdle();
 
         setAutoresearchMode(ctx, false);
-        runtime.dashboardExpanded = false;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
         runtime.lastRunChecks = null;
@@ -2993,7 +2859,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       if (command === "clear") {
         const jsonlPath = autoresearchJsonlPath(resolveWorkDir(ctx.cwd));
         setAutoresearchMode(ctx, false);
-        runtime.dashboardExpanded = false;
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
         runtime.lastRunChecks = null;

--- a/extensions/pi-autoresearch/shortcuts.ts
+++ b/extensions/pi-autoresearch/shortcuts.ts
@@ -2,18 +2,15 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 
-export const DEFAULT_TOGGLE_DASHBOARD_SHORTCUT = "ctrl+shift+t";
 export const DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT = "ctrl+shift+f";
 
 const CONFIG_FILE_NAME = "pi-autoresearch.json";
 
 export interface AutoresearchShortcuts {
-  toggleDashboard: string | null;
   fullscreenDashboard: string | null;
 }
 
 interface AutoresearchShortcutConfig {
-  toggleDashboard?: unknown;
   fullscreenDashboard?: unknown;
 }
 
@@ -34,10 +31,6 @@ export function resolveAutoresearchShortcuts(
   }
 
   return {
-    toggleDashboard: shortcutFromConfig(
-      config.toggleDashboard,
-      DEFAULT_TOGGLE_DASHBOARD_SHORTCUT
-    ),
     fullscreenDashboard: shortcutFromConfig(
       config.fullscreenDashboard,
       DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT
@@ -68,10 +61,7 @@ function readShortcutConfig(configPath: string): AutoresearchShortcutConfig | nu
 }
 
 function hasValidShortcutValues(shortcuts: Record<string, unknown>): boolean {
-  return (
-    isValidShortcutConfigValue(shortcuts.toggleDashboard) &&
-    isValidShortcutConfigValue(shortcuts.fullscreenDashboard)
-  );
+  return isValidShortcutConfigValue(shortcuts.fullscreenDashboard);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -93,7 +83,6 @@ function shortcutFromConfig(configured: unknown, fallback: string): string | nul
 
 function defaultAutoresearchShortcuts(): AutoresearchShortcuts {
   return {
-    toggleDashboard: DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
     fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
   };
 }

--- a/tests/shortcuts.test.mjs
+++ b/tests/shortcuts.test.mjs
@@ -7,7 +7,6 @@ import test from "node:test";
 import {
   autoresearchShortcutsConfigPath,
   DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
-  DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
   resolveAutoresearchShortcuts,
 } from "../extensions/pi-autoresearch/shortcuts.ts";
 import autoresearchExtension from "../extensions/pi-autoresearch/index.ts";
@@ -19,7 +18,6 @@ test("autoresearch shortcuts default to the documented bindings when config is a
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
     assert.equal(configPath, join(agentDir, "extensions", "pi-autoresearch.json"));
-    assert.equal(shortcuts.toggleDashboard, DEFAULT_TOGGLE_DASHBOARD_SHORTCUT);
     assert.equal(shortcuts.fullscreenDashboard, DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT);
   } finally {
     await rm(agentDir, { recursive: true, force: true });
@@ -35,7 +33,6 @@ test("autoresearch shortcuts can be overridden by the config file", async () => 
       configPath,
       JSON.stringify({
         shortcuts: {
-          toggleDashboard: "ctrl+shift+y",
           fullscreenDashboard: "ctrl+shift+u",
         },
       })
@@ -43,7 +40,6 @@ test("autoresearch shortcuts can be overridden by the config file", async () => 
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.equal(shortcuts.toggleDashboard, "ctrl+shift+y");
     assert.equal(shortcuts.fullscreenDashboard, "ctrl+shift+u");
   } finally {
     await rm(agentDir, { recursive: true, force: true });
@@ -59,7 +55,6 @@ test("autoresearch shortcuts can be disabled with null in the config file", asyn
       configPath,
       JSON.stringify({
         shortcuts: {
-          toggleDashboard: null,
           fullscreenDashboard: null,
         },
       })
@@ -67,7 +62,6 @@ test("autoresearch shortcuts can be disabled with null in the config file", asyn
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.equal(shortcuts.toggleDashboard, null);
     assert.equal(shortcuts.fullscreenDashboard, null);
   } finally {
     await rm(agentDir, { recursive: true, force: true });
@@ -82,15 +76,12 @@ test("partial shortcut config defaults omitted fields independently", async () =
     await writeFile(
       configPath,
       JSON.stringify({
-        shortcuts: {
-          toggleDashboard: "ctrl+shift+y",
-        },
+        shortcuts: {},
       })
     );
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.equal(shortcuts.toggleDashboard, "ctrl+shift+y");
     assert.equal(shortcuts.fullscreenDashboard, DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT);
   } finally {
     await rm(agentDir, { recursive: true, force: true });
@@ -110,7 +101,6 @@ test("malformed shortcut config warns and falls back to defaults", async () => {
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
     assert.deepEqual(shortcuts, {
-      toggleDashboard: DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
       fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
     });
     assert.equal(warnings.length, 1);
@@ -134,8 +124,7 @@ test("invalid known shortcut fields warn and fall back to defaults for the whole
       configPath,
       JSON.stringify({
         shortcuts: {
-          toggleDashboard: 123,
-          fullscreenDashboard: "ctrl+shift+u",
+          fullscreenDashboard: 123,
         },
       })
     );
@@ -143,7 +132,6 @@ test("invalid known shortcut fields warn and fall back to defaults for the whole
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
     assert.deepEqual(shortcuts, {
-      toggleDashboard: DEFAULT_TOGGLE_DASHBOARD_SHORTCUT,
       fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
     });
     assert.equal(warnings.length, 1);
@@ -187,8 +175,7 @@ test("extension registers shortcuts from the active profile config", async () =>
       configPath,
       JSON.stringify({
         shortcuts: {
-          toggleDashboard: "ctrl+shift+y",
-          fullscreenDashboard: null,
+          fullscreenDashboard: "ctrl+shift+u",
         },
       })
     );
@@ -196,7 +183,7 @@ test("extension registers shortcuts from the active profile config", async () =>
     withAgentDir(agentDir, () => {
       assert.deepEqual(
         collectRegisteredShortcuts().map((entry) => entry.shortcut),
-        ["ctrl+shift+y"]
+        ["ctrl+shift+u"]
       );
     });
   } finally {


### PR DESCRIPTION
## Summary

Removes the collapsed/non-expanded dashboard mode. The dashboard now **always renders the full expanded results table** inline above the editor, and **fullscreen (\`Ctrl+Shift+F\`) is the only remaining toggle**.

## Changes

**\`extensions/pi-autoresearch/index.ts\`**
- Removed \`dashboardExpanded\` from the runtime type and initializer.
- Simplified \`dashboardHintVariants()\` — dropped the \`"expand"/"collapse"\` argument; it now only surfaces the fullscreen hint.
- Replaced the \`if (dashboardExpanded) { … } else { … }\` widget branch with the always-expanded table renderer (deleted the collapsed one-liner block).
- Removed the \`toggleDashboard\` shortcut registration and the \`dashboardExpanded = false\` resets in \`/autoresearch off\` and \`clear\`.

**\`extensions/pi-autoresearch/shortcuts.ts\`**
- Dropped \`DEFAULT_TOGGLE_DASHBOARD_SHORTCUT\`, the \`toggleDashboard\` interface field, its config parsing, validation, and default — leaving only \`fullscreenDashboard\`.

**\`tests/shortcuts.test.mjs\`** — removed all \`toggleDashboard\` assertions; tests now cover only \`fullscreenDashboard\`.

**\`README.md\`** / **\`CHANGELOG.md\`** — updated docs to reflect the always-expanded widget and the single fullscreen toggle.

## Verification

- \`tsc --noEmit\` passes.
- All 20 tests pass.