### PR TITLE
Use .auto subfolder for autoresearch session files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ pi install npm:pi-autoresearch
 
 | Subcommand | Description |
 |------------|-------------|
-| `/autoresearch <text>` | Enter autoresearch mode. If `autoresearch.md` exists, resumes the loop with `<text>` as context. Otherwise, sets up a new session. |
-| `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `autoresearch.jsonl` intact. |
-| `/autoresearch clear` | Delete `autoresearch.jsonl`, reset all state, and turn autoresearch mode off. Use this for a clean start. |
+| `/autoresearch <text>` | Enter autoresearch mode. If `.auto/prompt.md` exists, resumes the loop with `<text>` as context. Otherwise, sets up a new session. |
+| `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `.auto/log.jsonl` intact. |
+| `/autoresearch clear` | Delete `.auto/log.jsonl`, reset all state, and turn autoresearch mode off. Use this for a clean start. |
 | `/autoresearch export` | Open a live dashboard in your browser. Auto-updates as experiments run. |
 
 **Examples:**
@@ -91,14 +91,17 @@ Use `null` to skip registering a shortcut. Omitted shortcuts keep their defaults
 
 **`autoresearch-finalize`** turns a noisy autoresearch branch into clean, independent branches — one per logical change, each starting from the merge-base. Groups must not share files, so each branch can be reviewed and merged independently.
 
-**`autoresearch-hooks`** *(optional)* helps author `autoresearch.hooks/before.sh` and `autoresearch.hooks/after.sh` for a session. It ships with ten reference scripts in [`skills/autoresearch-hooks/examples/`](skills/autoresearch-hooks/examples/) (external search, learnings journal, native notifications, anti-thrash, idea rotation, and more) — the skill handles the contract, you pick the inspiration. The core autoresearch loop has no hook awareness.
+**`autoresearch-hooks`** *(optional)* helps author `.auto/hooks/before.sh` and `.auto/hooks/after.sh` for a session. It ships with ten reference scripts in [`skills/autoresearch-hooks/examples/`](skills/autoresearch-hooks/examples/) (external search, learnings journal, native notifications, anti-thrash, idea rotation, and more) — the skill handles the contract, you pick the inspiration. The core autoresearch loop has no hook awareness.
+
+All session files live in a single `.auto/` subfolder at the working-directory root — one folder to preserve across reverts, gitignore, and clean up. (Legacy flat `autoresearch.*` files are still read for in-flight sessions.)
 
 | File | Purpose |
 |------|---------|
-| `autoresearch.md` | Session document — objective, metrics, files in scope, what's been tried. A fresh agent can resume from this alone. |
-| `autoresearch.sh` | Benchmark script — pre-checks, runs the workload, outputs `METRIC name=number` lines. |
-| `autoresearch.checks.sh` | *(optional)* Backpressure checks — tests, types, lint. Runs after each passing benchmark. Failures block `keep`. |
-| `autoresearch.hooks/` | *(optional)* Executable scripts (`before.sh`, `after.sh`) that fire around iterations. Stdout is delivered to the agent as a steer message. |
+| `.auto/prompt.md` | Session document — objective, metrics, files in scope, what's been tried. A fresh agent can resume from this alone. |
+| `.auto/measure.sh` | Benchmark script — pre-checks, runs the workload, outputs `METRIC name=number` lines. |
+| `.auto/log.jsonl` | Append-only log of every run (written by the tools). |
+| `.auto/checks.sh` | *(optional)* Backpressure checks — tests, types, lint. Runs after each passing benchmark. Failures block `keep`. |
+| `.auto/hooks/` | *(optional)* Executable scripts (`before.sh`, `after.sh`) that fire around iterations. Stdout is delivered to the agent as a steer message. |
 
 ---
 
@@ -130,16 +133,16 @@ Then `/reload` in pi.
 /skill:autoresearch-create
 ```
 
-The agent asks about your goal, command, metric, and files in scope — or infers them from context. It then creates a branch, writes `autoresearch.md` and `autoresearch.sh`, runs the baseline, and starts looping immediately.
+The agent asks about your goal, command, metric, and files in scope — or infers them from context. It then creates a branch, writes `.auto/prompt.md` and `.auto/measure.sh`, runs the baseline, and starts looping immediately.
 
 ### 2. The loop
 
 The agent runs autonomously: edit → commit → `run_experiment` → `log_experiment` → keep or revert → repeat. It never stops unless interrupted.
 
-Every result is appended to `autoresearch.jsonl` in your project — one line per run. This means:
+Every result is appended to `.auto/log.jsonl` in your project — one line per run. This means:
 
 - **Survives restarts** — the agent can resume a session by reading the file
-- **Survives context resets** — `autoresearch.md` captures what's been tried so a fresh agent has full context
+- **Survives context resets** — `.auto/prompt.md` captures what's been tried so a fresh agent has full context
 - **Human readable** — open it anytime to see the full history
 - **Branch-aware** — each branch has its own session
 
@@ -149,7 +152,7 @@ Every result is appended to `autoresearch.jsonl` in your project — one line pe
 /skill:autoresearch-finalize
 ```
 
-The agent reads `autoresearch.jsonl`, groups kept experiments into logical changesets, proposes the grouping for your approval, then creates independent branches from the merge-base. Each commit includes metric improvements in the message. Groups must not share files, so branches can be reviewed and merged independently.
+The agent reads `.auto/log.jsonl`, groups kept experiments into logical changesets, proposes the grouping for your approval, then creates independent branches from the merge-base. Each commit includes metric improvements in the message. Groups must not share files, so branches can be reviewed and merged independently.
 
 ### 4. Monitor progress
 
@@ -190,8 +193,8 @@ The **extension** is domain-agnostic infrastructure. The **skill** encodes domai
 Two files keep the session alive across restarts and context resets:
 
 ```
-autoresearch.jsonl   — append-only log of every run (metric, status, commit, description)
-autoresearch.md      — living document: objective, what's been tried, dead ends, key wins
+.auto/log.jsonl   — append-only log of every run (metric, status, commit, description)
+.auto/prompt.md   — living document: objective, what's been tried, dead ends, key wins
 ```
 
 A fresh agent with no memory can read these two files and continue exactly where the previous session left off.
@@ -200,7 +203,7 @@ A fresh agent with no memory can read these two files and continue exactly where
 
 ## Configuration (optional)
 
-Create `autoresearch.config.json` in your pi session directory to customize behavior:
+Create `.auto/config.json` in your pi session directory to customize behavior:
 
 ```json
 {
@@ -211,12 +214,12 @@ Create `autoresearch.config.json` in your pi session directory to customize beha
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays in the session cwd. Fails if the directory doesn't exist. |
+| `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays under the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
 
 ### Long-running loops and context
 
-The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `autoresearch.md`, the tail of `autoresearch.jsonl`, `autoresearch.ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works.
+The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `.auto/prompt.md`, the tail of `.auto/log.jsonl`, `.auto/ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works.
 
 ---
 
@@ -229,7 +232,7 @@ After 3+ experiments in a session, pi-autoresearch computes a **confidence score
 - Uses [Median Absolute Deviation (MAD)](https://en.wikipedia.org/wiki/Median_absolute_deviation) of all metric values in the current segment as a robust noise estimator.
 - Confidence = `|best_improvement| / MAD`. A score of 2.0× means the best improvement is twice the noise floor.
 - Shown in the widget, fullscreen dashboard, and `log_experiment` output.
-- Persisted to `autoresearch.jsonl` on each result for post-hoc analysis.
+- Persisted to `.auto/log.jsonl` on each result for post-hoc analysis.
 - **Advisory only** — never auto-discards. The agent is guided to re-run experiments when confidence is low, but the final keep/discard decision stays with the agent.
 
 | Confidence | Color | Meaning |
@@ -242,7 +245,7 @@ After 3+ experiments in a session, pi-autoresearch computes a **confidence score
 
 ## Backpressure checks (optional)
 
-Create `autoresearch.checks.sh` to run correctness checks (tests, types, lint) after every passing benchmark. This ensures optimizations don't break things.
+Create `.auto/checks.sh` to run correctness checks (tests, types, lint) after every passing benchmark. This ensures optimizations don't break things.
 
 ```bash
 #!/bin/bash
@@ -264,18 +267,18 @@ pnpm typecheck
 
 ## Hooks (optional)
 
-Drop executable scripts in `autoresearch.hooks/` to run code at iteration boundaries. Hooks are **transparent to the agent** — the agent calls tools and sees results; hooks run alongside without any agent-facing surface.
+Drop executable scripts in `.auto/hooks/` to run code at iteration boundaries. Hooks are **transparent to the agent** — the agent calls tools and sees results; hooks run alongside without any agent-facing surface.
 
-- `autoresearch.hooks/before.sh` — fires before every iteration (at `/autoresearch` activation and at the end of every `log_experiment`, after `after.sh`). Use for prospective work: fetch research, prime context for the next attempt.
-- `autoresearch.hooks/after.sh` — fires at the end of every `log_experiment`. Use for retrospective work: annotate learnings, send notifications.
+- `.auto/hooks/before.sh` — fires before every iteration (at `/autoresearch` activation and at the end of every `log_experiment`, after `after.sh`). Use for prospective work: fetch research, prime context for the next attempt.
+- `.auto/hooks/after.sh` — fires at the end of every `log_experiment`. Use for retrospective work: annotate learnings, send notifications.
 
 **Contract:**
 
-- Must be executable (`chmod +x`). Preserved on revert like all `autoresearch.*` artefacts.
+- Must be executable (`chmod +x`). Preserved on revert — the entire `.auto/` folder survives (as do legacy `autoresearch.*` artefacts).
 - **Stdin** — a JSON object on a single line. Shape depends on the stage (see below). Extract fields with `jq`.
 - **Stdout** is delivered to the agent as a steer message (capped at 8 KB). Empty stdout = silent.
 - Non-zero exit or >30s timeout surfaces an error steer to the agent.
-- Each fire appends a `{"type":"hook",…}` entry to `autoresearch.jsonl` for observability.
+- Each fire appends a `{"type":"hook",…}` entry to `.auto/log.jsonl` for observability.
 
 **`before.sh` stdin** (on fresh activation `last_run` is `null`):
 
@@ -314,7 +317,7 @@ Drop executable scripts in `autoresearch.hooks/` to run code at iteration bounda
 
 **Agent signal.** The agent writes `description` and `asi.*` fields in its `log_experiment` calls for its own future-self reasoning. The hook opportunistically mines whichever fields the agent naturally uses — `asi.hypothesis`, `asi.next_focus`, `description`, etc. There is no dedicated "hook input" field; the agent is unaware the hook exists.
 
-**Examples.** Reference scripts for both stages live at [`skills/autoresearch-hooks/examples/`](skills/autoresearch-hooks/examples/) — external search, qmd document search, persistent learnings, native notifications, git tagging, anti-thrash, idea rotator, hypothesis reflection, context rotation. Copy one to your session's `autoresearch.hooks/` directory, adapt, `chmod +x`.
+**Examples.** Reference scripts for both stages live at [`skills/autoresearch-hooks/examples/`](skills/autoresearch-hooks/examples/) — external search, qmd document search, persistent learnings, native notifications, git tagging, anti-thrash, idea rotator, hypothesis reflection, context rotation. Copy one to your session's `.auto/hooks/` directory, adapt, `chmod +x`.
 
 ---
 
@@ -328,7 +331,7 @@ Drop executable scripts in `autoresearch.hooks/` to run code at iteration bounda
 Autoresearch loops run autonomously and can burn through tokens. Two ways to cap spend:
 
 - **API key limits** — most providers let you set per-key or monthly budgets. Check your provider's dashboard.
-- **`maxIterations`** — cap experiments per session in `autoresearch.config.json`:
+- **`maxIterations`** — cap experiments per session in `.auto/config.json`:
    ```json
    {
      "maxIterations": 30

--- a/assets/template.html
+++ b/assets/template.html
@@ -366,12 +366,12 @@
         .then(resp => resp.ok ? resp.text() : null)
         .then(text => {
           if (!text) {
-            setMetaMessage('No autoresearch.jsonl found.', true);
+            setMetaMessage('No session log found.', true);
             return;
           }
           if (text !== lastDataText) loadFromText(text);
         })
-        .catch(() => setMetaMessage('Failed to load autoresearch.jsonl.', true));
+        .catch(() => setMetaMessage('Failed to load session log.', true));
     }
 
     function parseAutoresearchText(text) {

--- a/extensions/pi-autoresearch/compaction.ts
+++ b/extensions/pi-autoresearch/compaction.ts
@@ -15,6 +15,7 @@ import {
   type ReconstructedJsonlState,
   type ReconstructedRun,
 } from "./jsonl.ts";
+import { sessionFilePath } from "./paths.ts";
 
 const RECENT_RUN_LIMIT = 50;
 
@@ -31,9 +32,9 @@ export interface AutoresearchSummaryPaths {
 export function autoresearchSummaryPathsFor(workDir: string): AutoresearchSummaryPaths {
   return {
     workDir,
-    jsonlPath: path.join(workDir, "autoresearch.jsonl"),
-    mdPath: path.join(workDir, "autoresearch.md"),
-    ideasPath: path.join(workDir, "autoresearch.ideas.md"),
+    jsonlPath: sessionFilePath(workDir, "log"),
+    mdPath: sessionFilePath(workDir, "prompt"),
+    ideasPath: sessionFilePath(workDir, "ideas"),
   };
 }
 
@@ -46,9 +47,9 @@ export function buildAutoresearchCompactionSummary(paths: AutoresearchSummaryPat
   const sections = [
     headerSection(),
     sessionSection(state),
-    rulesSection(paths.mdPath),
-    ideasSection(paths.ideasPath),
-    recentRunsSection(state),
+    rulesSection(paths.workDir, paths.mdPath),
+    ideasSection(paths.workDir, paths.ideasPath),
+    recentRunsSection(state, paths.workDir, paths.jsonlPath),
     nextStepSection(),
   ];
   return sections.filter(Boolean).join("\n\n");
@@ -137,19 +138,25 @@ function isBetter(value: number, current: number, direction: "lower" | "higher")
   return direction === "lower" ? value < current : value > current;
 }
 
-function rulesSection(mdPath: string): string {
+function readablePath(workDir: string, filePath: string): string {
+  const relative = path.relative(workDir, filePath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return filePath;
+  return relative;
+}
+
+function rulesSection(workDir: string, mdPath: string): string {
   const content = readTrimmedFile(mdPath);
   if (!content) return "";
-  return `## Experiment Rules (autoresearch.md)\n\n${content}`;
+  return `## Experiment Rules (${readablePath(workDir, mdPath)})\n\n${content}`;
 }
 
-function ideasSection(ideasPath: string): string {
+function ideasSection(workDir: string, ideasPath: string): string {
   const content = readTrimmedFile(ideasPath);
   if (!content) return "";
-  return `## Ideas Backlog (autoresearch.ideas.md)\n\n${content}`;
+  return `## Ideas Backlog (${readablePath(workDir, ideasPath)})\n\n${content}`;
 }
 
-function recentRunsSection(state: ReconstructedJsonlState): string {
+function recentRunsSection(state: ReconstructedJsonlState, workDir: string, jsonlPath: string): string {
   const runs = state.results.slice(-RECENT_RUN_LIMIT);
   if (runs.length === 0) {
     return "## Recent Runs\n\nNo runs yet — start with the first hypothesis.";
@@ -162,7 +169,7 @@ function recentRunsSection(state: ReconstructedJsonlState): string {
     "",
     ...lines,
     "",
-    "If you need more details, read additional lines from autoresearch.jsonl.",
+    `If you need more details, read additional lines from ${readablePath(workDir, jsonlPath)}.`,
   ].join("\n");
 }
 

--- a/extensions/pi-autoresearch/hooks.ts
+++ b/extensions/pi-autoresearch/hooks.ts
@@ -1,13 +1,12 @@
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
-import * as path from "node:path";
 
 import { hasAutoresearchConfigHeader } from "./jsonl.ts";
+import { hookScriptPath } from "./paths.ts";
 
 const TIMEOUT_MS = 30_000;
 const STDOUT_MAX_BYTES = 8 * 1024;
 const TRUNCATION_MARKER = "\n…[truncated: hook stdout exceeded 8KB]";
-const HOOKS_DIR = "autoresearch.hooks";
 
 const NEWLINE = 0x0a;
 const UTF8_CONT_MASK = 0xc0;
@@ -60,10 +59,6 @@ export interface HookResult {
   exitCode: number | null;
   timedOut: boolean;
   durationMs: number;
-}
-
-export function hookScriptPath(workDir: string, stage: HookStage): string {
-  return path.join(workDir, HOOKS_DIR, `${stage}.sh`);
 }
 
 function isExecutableFile(filePath: string): boolean {

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -9,8 +9,8 @@
  * - `log_experiment` tool — records results with session-persisted state
  * - Status widget showing experiment count + best metric
  * - Configurable shortcut to open the fullscreen dashboard overlay
- * - Adds autoresearch guidance to the system prompt and points the agent at autoresearch.md
- * - Injects autoresearch.md into context on every turn via before_agent_start
+ * - Adds autoresearch guidance to the system prompt and points the agent at .auto/prompt.md
+ * - Injects .auto/prompt.md into context on every turn via before_agent_start
  */
 
 import type {
@@ -51,6 +51,7 @@ import {
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
 import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
+import { sessionFilePath, sessionFileCandidates, ensureParentDir, AUTO_DIR } from "./paths.ts";
 
 // ---------------------------------------------------------------------------
 // Experiment output limits (sent to LLM — keep small to save context)
@@ -169,7 +170,7 @@ const RunParams = Type.Object({
   checks_timeout_seconds: Type.Optional(
     Type.Number({
       description:
-        "Kill autoresearch.checks.sh after this many seconds (default: 300). Only relevant when the checks file exists.",
+        "Kill .auto/checks.sh after this many seconds (default: 300). Only relevant when the checks file exists.",
     })
   ),
 });
@@ -330,12 +331,12 @@ function killTree(pid: number): void {
 }
 
 /**
- * Check if a command's primary purpose is running autoresearch.sh.
+ * Check if a command's primary purpose is running the benchmark script.
  *
  * Strategy: strip common harmless prefixes (env vars, env/time/nice wrappers)
- * then check that the core command is autoresearch.sh invoked via a known
- * pattern. Rejects chaining tricks like "evil.py; autoresearch.sh" because
- * we require autoresearch.sh to be the *first* real command.
+ * then check that the core command is the benchmark script invoked via a known
+ * pattern. Rejects chaining tricks like "evil.py; measure.sh" because we require
+ * the benchmark script to be the *first* real command.
  */
 function isAutoresearchShCommand(command: string): boolean {
   let cmd = command.trim();
@@ -351,14 +352,11 @@ function isAutoresearchShCommand(command: string): boolean {
     cmd = cmd.replace(/^(?:env|time|nice|nohup)(?:\s+-\S+(?:\s+\d+)?)*\s+/, "");
   } while (cmd !== prev);
 
-  // Now the core command must be autoresearch.sh via a known invocation:
-  //   autoresearch.sh
-  //   ./autoresearch.sh
-  //   /path/to/autoresearch.sh
-  //   bash [-flags] autoresearch.sh
-  //   bash [-flags] ./autoresearch.sh
-  //   bash [-flags] /path/to/autoresearch.sh
-  return /^(?:(?:bash|sh|source)\s+(?:-\w+\s+)*)?(?:\.\/|\/[\w/.-]*\/)?autoresearch\.sh(?:\s|$)/.test(cmd);
+  // Now the core command must be the benchmark script via a known invocation.
+  // Current layout requires the `.auto/measure.sh` path; legacy `autoresearch.sh`
+  // is still accepted for in-flight sessions. An optional path prefix allows
+  //   ./.auto/measure.sh, /abs/path/.auto/measure.sh, bash [-flags] autoresearch.sh, etc.
+  return /^(?:(?:bash|sh|source)\s+(?:-\w+\s+)*)?(?:\/|\.{1,2}\/|[\w.-]+\/)*(?:autoresearch\.sh|\.auto\/measure\.sh)(?:\s|$)/.test(cmd);
 }
 
 function isBetter(
@@ -432,7 +430,7 @@ interface AutoresearchConfig {
   workingDir?: string;
 }
 
-/** Read autoresearch.config.json from the given directory (always ctx.cwd) */
+/** Read the config file (.auto/config.json, legacy autoresearch.config.json) from the given directory (always ctx.cwd) */
 function readConfig(cwd: string): AutoresearchConfig {
   try {
     const configPath = autoresearchConfigPath(cwd);
@@ -443,7 +441,7 @@ function readConfig(cwd: string): AutoresearchConfig {
   }
 }
 
-/** Read maxExperiments from autoresearch.config.json (if it exists) */
+/** Read maxExperiments from the config file (if it exists) */
 function readMaxExperiments(cwd: string): number | null {
   const config = readConfig(cwd);
   return (typeof config.maxIterations === "number" && config.maxIterations > 0)
@@ -453,7 +451,7 @@ function readMaxExperiments(cwd: string): number | null {
 
 /**
  * Resolve the effective working directory.
- * Reads workingDir from autoresearch.config.json in ctxCwd.
+ * Reads workingDir from the config file (.auto/config.json) in ctxCwd.
  * Returns ctxCwd if not set. Supports relative (resolved against ctxCwd) and absolute paths.
  */
 function resolveWorkDir(ctxCwd: string): string {
@@ -474,10 +472,10 @@ function validateWorkDir(ctxCwd: string): string | null {
   try {
     const stat = fs.statSync(workDir);
     if (!stat.isDirectory()) {
-      return `workingDir "${workDir}" (from autoresearch.config.json) is not a directory.`;
+      return `workingDir "${workDir}" (from .auto/config.json) is not a directory.`;
     }
   } catch {
-    return `workingDir "${workDir}" (from autoresearch.config.json) does not exist.`;
+    return `workingDir "${workDir}" (from .auto/config.json) does not exist.`;
   }
   return null;
 }
@@ -505,12 +503,12 @@ function findBestMetric(
 // Session file paths (single source of truth for autoresearch.* filenames)
 // -----------------------------------------------------------------------
 
-const autoresearchJsonlPath  = (dir: string) => path.join(dir, "autoresearch.jsonl");
-const autoresearchMdPath     = (dir: string) => path.join(dir, "autoresearch.md");
-const autoresearchIdeasPath  = (dir: string) => path.join(dir, "autoresearch.ideas.md");
-const autoresearchChecksPath = (dir: string) => path.join(dir, "autoresearch.checks.sh");
-const autoresearchScriptPath = (dir: string) => path.join(dir, "autoresearch.sh");
-const autoresearchConfigPath = (dir: string) => path.join(dir, "autoresearch.config.json");
+const autoresearchJsonlPath  = (dir: string) => sessionFilePath(dir, "log");
+const autoresearchMdPath     = (dir: string) => sessionFilePath(dir, "prompt");
+const autoresearchIdeasPath  = (dir: string) => sessionFilePath(dir, "ideas");
+const autoresearchChecksPath = (dir: string) => sessionFilePath(dir, "checks");
+const autoresearchScriptPath = (dir: string) => sessionFilePath(dir, "measure");
+const autoresearchConfigPath = (dir: string) => sessionFilePath(dir, "config");
 
 function findBaselineRunNumber(results: ExperimentResult[], segment: number): number | null {
   const index = results.findIndex((result) => result.segment === segment);
@@ -1101,7 +1099,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     return [
       "Run the next iteration now.",
       "Pick the most promising hypothesis from the ideas backlog or the latest `next:` hints in recent runs, then call run_experiment + log_experiment.",
-      "Do not re-read autoresearch.md or autoresearch.jsonl — the compaction summary already contains them.",
+      "Do not re-read .auto/prompt.md or .auto/log.jsonl — the compaction summary already contains them.",
       BENCHMARK_GUARDRAIL,
     ].join(" ");
   };
@@ -1191,8 +1189,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "",
       "<text> enters autoresearch mode and starts or resumes the loop.",
       "off leaves autoresearch mode.",
-      "clear deletes autoresearch.jsonl and turns autoresearch mode off.",
-      "export opens a local live dashboard for autoresearch.jsonl in your browser.",
+      "clear deletes the session log (.auto/log.jsonl) and turns autoresearch mode off.",
+      "export opens a local live dashboard for the session log in your browser.",
 
       "",
       "Examples:",
@@ -1220,7 +1218,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     // Resolve effective working directory (config stays in ctx.cwd, files in workDir)
     const workDir = resolveWorkDir(ctx.cwd);
 
-    // Primary: read from autoresearch.jsonl (alongside autoresearch.md/sh)
+    // Primary: read from .auto/log.jsonl (alongside .auto/prompt.md and .auto/measure.sh)
     const jsonlPath = autoresearchJsonlPath(workDir);
     let loadedFromJsonl = false;
     try {
@@ -1419,7 +1417,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "\nYou are in autoresearch mode. Optimize the primary metric through an autonomous experiment loop." +
       "\nUse init_experiment, run_experiment, and log_experiment tools. NEVER STOP until interrupted." +
       `\nExperiment rules: ${mdPath} — read this file at the start of every session and after compaction.` +
-      "\nWrite promising but deferred optimizations as bullet points to autoresearch.ideas.md — don't let good ideas get lost." +
+      "\nWrite promising but deferred optimizations as bullet points to .auto/ideas.md — don't let good ideas get lost." +
       `\n${BENCHMARK_GUARDRAIL}` +
       "\nIf the user sends a follow-on message while an experiment is running, finish the current run_experiment + log_experiment cycle first, then address their message in the next iteration.";
 
@@ -1450,12 +1448,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     name: "init_experiment",
     label: "Init Experiment",
     description:
-      "Initialize the experiment session. Call once before the first run_experiment to set the name, primary metric, unit, and direction. Writes the config header to autoresearch.jsonl.",
+      "Initialize the experiment session. Call once before the first run_experiment to set the name, primary metric, unit, and direction. Writes the config header to .auto/log.jsonl.",
     promptSnippet:
       "Initialize experiment session (name, metric, unit, direction). Call once before first run.",
     promptGuidelines: [
       "Call init_experiment exactly once at the start of an autoresearch session, before the first run_experiment.",
-      "If autoresearch.jsonl already exists with a config, do NOT call init_experiment again.",
+      "If the session log (.auto/log.jsonl) already exists with a config, do NOT call init_experiment again.",
       "If the optimization target changes (different benchmark, metric, or workload), call init_experiment again to insert a new config header and reset the baseline.",
     ],
     parameters: InitParams,
@@ -1497,6 +1495,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const workDir = resolveWorkDir(ctx.cwd);
       try {
         const jsonlPath = autoresearchJsonlPath(workDir);
+        ensureParentDir(jsonlPath);
         const config = JSON.stringify({
           type: "config",
           name: state.name,
@@ -1514,7 +1513,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return {
           content: [{
             type: "text",
-            text: `⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}`,
+            text: `⚠️ Failed to write .auto/log.jsonl: ${e instanceof Error ? e.message : String(e)}`,
           }],
           details: {},
         };
@@ -1536,12 +1535,12 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       const reinitNote = isReinit ? " (re-initialized — previous results archived, new baseline needed)" : "";
-      const limitNote = state.maxExperiments !== null ? `\nMax iterations: ${state.maxExperiments} (from autoresearch.config.json)` : "";
+      const limitNote = state.maxExperiments !== null ? `\nMax iterations: ${state.maxExperiments} (from .auto/config.json)` : "";
       const workDirNote = workDir !== ctx.cwd ? `\nWorking directory: ${workDir}` : "";
       return {
         content: [{
           type: "text",
-          text: `✅ Experiment initialized: "${state.name}"${reinitNote}\nMetric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)${limitNote}${workDirNote}\nConfig written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
+          text: `✅ Experiment initialized: "${state.name}"${reinitNote}\nMetric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)${limitNote}${workDirNote}\nConfig written to .auto/log.jsonl. Now run the baseline with run_experiment.`,
         }],
         details: { state: cloneExperimentState(state) },
       };
@@ -1605,13 +1604,14 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       const timeout = (params.timeout_seconds ?? 600) * 1000;
 
-      // Guard: if autoresearch.sh exists, only allow running it
+      // Guard: if the benchmark script exists, only allow running it
       const autoresearchShPath = autoresearchScriptPath(workDir);
+      const benchmarkScriptRel = path.relative(workDir, autoresearchShPath) || path.basename(autoresearchShPath);
       if (fs.existsSync(autoresearchShPath) && !isAutoresearchShCommand(params.command)) {
         return {
           content: [{
             type: "text",
-            text: `❌ autoresearch.sh exists — you must run it instead of a custom command.\n\nFound: ${autoresearchShPath}\nYour command: ${params.command}\n\nUse: run_experiment({ command: "bash autoresearch.sh" }) or run_experiment({ command: "./autoresearch.sh" })`,
+            text: `❌ ${benchmarkScriptRel} exists — you must run it instead of a custom command.\n\nFound: ${autoresearchShPath}\nYour command: ${params.command}\n\nUse: run_experiment({ command: "bash ${benchmarkScriptRel}" }) or run_experiment({ command: "./${benchmarkScriptRel}" })`,
           }],
           details: {
             command: params.command,
@@ -1889,11 +1889,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         text += `💥 FAILED (exit code ${exitCode}) in ${durationSeconds.toFixed(1)}s\n`;
       } else if (checksTimedOut) {
         text += `✅ Benchmark PASSED in ${durationSeconds.toFixed(1)}s\n`;
-        text += `⏰ CHECKS TIMEOUT (autoresearch.checks.sh) after ${checksDuration.toFixed(1)}s\n`;
+        text += `⏰ CHECKS TIMEOUT (.auto/checks.sh) after ${checksDuration.toFixed(1)}s\n`;
         text += `Log this as 'checks_failed' — the benchmark metric is valid but checks timed out.\n`;
       } else if (checksPass === false) {
         text += `✅ Benchmark PASSED in ${durationSeconds.toFixed(1)}s\n`;
-        text += `💥 CHECKS FAILED (autoresearch.checks.sh) in ${checksDuration.toFixed(1)}s\n`;
+        text += `💥 CHECKS FAILED (.auto/checks.sh) in ${checksDuration.toFixed(1)}s\n`;
         text += `Log this as 'checks_failed' — the benchmark metric is valid but correctness checks did not pass.\n`;
       } else {
         text += `✅ PASSED in ${durationSeconds.toFixed(1)}s\n`;
@@ -2090,7 +2090,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "log_experiment automatically runs git add -A && git commit on 'keep', and auto-reverts code changes on 'discard'/'crash'/'checks_failed' (autoresearch files are preserved). Do NOT commit or revert manually.",
       "Use status 'keep' if the PRIMARY metric improved. 'discard' if worse or unchanged. 'crash' if it failed. Secondary metrics are for monitoring — they almost never affect keep/discard. Only discard a primary improvement if a secondary metric degraded catastrophically, and explain why in the description.",
       "log_experiment reports a confidence score after 3+ runs (best improvement as a multiple of the noise floor). ≥2.0× = likely real, <1.0× = within noise. If confidence is below 1.0×, consider re-running the same experiment to confirm before keeping. The score is advisory — it never auto-discards.",
-      "If you discover complex but promising optimizations you won't pursue immediately, append them as bullet points to autoresearch.ideas.md. Don't let good ideas get lost.",
+      "If you discover complex but promising optimizations you won't pursue immediately, append them as bullet points to .auto/ideas.md. Don't let good ideas get lost.",
       "Always include the asi parameter. At minimum: {\"hypothesis\": \"what you tried\"}. On discard/crash, also include rollback_reason and next_action_hint. Add any other key/value pairs that capture what you learned — dead ends, surprising findings, error details, bottlenecks. This is the only structured memory that survives reverts.",
     ],
     parameters: LogParams,
@@ -2115,7 +2115,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return {
           content: [{
             type: "text",
-            text: `❌ Cannot keep — autoresearch.checks.sh failed.\n\n${runtime.lastRunChecks.output.slice(-500)}\n\nLog as 'checks_failed' instead. The benchmark metric is valid but correctness checks did not pass.`,
+            text: `❌ Cannot keep — .auto/checks.sh failed.\n\n${runtime.lastRunChecks.output.slice(-500)}\n\nLog as 'checks_failed' instead. The benchmark metric is valid but correctness checks did not pass.`,
           }],
           details: {},
         };
@@ -2309,17 +2309,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const jsonlLine = JSON.stringify(jsonlEntry);
 
       try {
-        fs.appendFileSync(autoresearchJsonlPath(workDir), jsonlLine + "\n");
+        const jsonlPath = autoresearchJsonlPath(workDir);
+        ensureParentDir(jsonlPath);
+        fs.appendFileSync(jsonlPath, jsonlLine + "\n");
         broadcastDashboardUpdate(workDir);
       } catch (e) {
-        text += `\n⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}`;
+        text += `\n⚠️ Failed to write .auto/log.jsonl: ${e instanceof Error ? e.message : String(e)}`;
       }
 
       if (params.status !== "keep") {
         try {
           const revertScript = `
-            git checkout -- . ':(exclude,glob)**/autoresearch.*' ':(exclude,glob)**/autoresearch.*/**'
-            git clean -fd -e 'autoresearch.*' -e '**/autoresearch.*/**' 2>/dev/null
+            git checkout -- . ':(exclude,glob)**/${AUTO_DIR}' ':(exclude,glob)**/${AUTO_DIR}/**' ':(exclude,glob)**/autoresearch.*' ':(exclude,glob)**/autoresearch.*/**'
+            git clean -fd -e '${AUTO_DIR}' -e '**/${AUTO_DIR}/**' -e 'autoresearch.*' -e '**/autoresearch.*/**' 2>/dev/null
           `;
           await pi.exec("bash", ["-c", revertScript], { cwd: workDir, timeout: 10000 });
           text += `\n📝 Git: reverted changes (${params.status}) — autoresearch files preserved`;
@@ -2797,7 +2799,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     const jsonlPath = autoresearchJsonlPath(workDir);
 
     if (!fs.existsSync(jsonlPath)) {
-      ctx.ui.notify("No autoresearch.jsonl found \u2014 run some experiments first", "error");
+      ctx.ui.notify(`No ${path.basename(jsonlPath)} found \u2014 run some experiments first`, "error");
       return;
     }
 
@@ -2857,29 +2859,38 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       if (command === "clear") {
-        const jsonlPath = autoresearchJsonlPath(resolveWorkDir(ctx.cwd));
+        const workDir = resolveWorkDir(ctx.cwd);
+        const jsonlPaths = sessionFileCandidates(workDir, "log");
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
         runtime.lastRunChecks = null;
+        runtime.lastRunDuration = null;
         runtime.runningExperiment = null;
         cancelPendingResume(runtime);
         runtime.state = createExperimentState();
         stopDashboardServer();
         updateWidget(ctx);
 
-        if (fs.existsSync(jsonlPath)) {
+        const deletedPaths: string[] = [];
+        for (const jsonlPath of Object.values(jsonlPaths)) {
+          if (!fs.existsSync(jsonlPath)) continue;
           try {
             fs.unlinkSync(jsonlPath);
-            ctx.ui.notify("Deleted autoresearch.jsonl and turned autoresearch mode OFF", "info");
+            deletedPaths.push(path.relative(workDir, jsonlPath) || path.basename(jsonlPath));
           } catch (error) {
             ctx.ui.notify(
-              `Failed to delete autoresearch.jsonl: ${error instanceof Error ? error.message : String(error)}`,
+              `Failed to delete ${path.relative(workDir, jsonlPath) || path.basename(jsonlPath)}: ${error instanceof Error ? error.message : String(error)}`,
               "error"
             );
+            return;
           }
+        }
+
+        if (deletedPaths.length > 0) {
+          ctx.ui.notify(`Deleted ${deletedPaths.join(", ")} and turned autoresearch mode OFF`, "info");
         } else {
-          ctx.ui.notify("No autoresearch.jsonl found. Autoresearch mode OFF", "info");
+          ctx.ui.notify("No session log found. Autoresearch mode OFF", "info");
         }
         return;
       }
@@ -2894,14 +2905,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       const workDir = resolveWorkDir(ctx.cwd);
       const rulesLoaded = hasAutoresearchRules(ctx);
+      // No .auto/prompt.md yet — load the create skill so the agent follows the
+      // setup guidelines. `/skill:<name>` is expanded to the full SKILL.md by
+      // pi's input pipeline (requires `enableSkillCommands`), and trailing args
+      // are appended as the session goal. Must be sent as its own message that
+      // STARTS with `/skill:` so expansion triggers — don't prepend hook output.
       const kickoff = rulesLoaded
         ? `Autoresearch mode active. ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`
-        : `Start autoresearch: ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`;
+        : `/skill:autoresearch-create ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`.replace(/\s+/g, " ").trim();
 
       ctx.ui.notify(
         rulesLoaded
-          ? "Autoresearch mode ON — rules loaded from autoresearch.md"
-          : "Autoresearch mode ON — no autoresearch.md found, setting up",
+          ? "Autoresearch mode ON — rules loaded from .auto/prompt.md"
+          : "Autoresearch mode ON — no .auto/prompt.md found, loading autoresearch-create skill",
         "info",
       );
 
@@ -2914,7 +2930,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         session: buildSessionSnapshot(state),
       });
 
-      sendWhenReady(ctx, activationSteer ? `${activationSteer}\n\n${kickoff}` : kickoff);
+      // Prepend hook output only when prompt.md exists; otherwise the message
+      // must stay `/skill:...`-prefixed for command expansion.
+      const message = activationSteer && rulesLoaded ? `${activationSteer}\n\n${kickoff}` : kickoff;
+      sendWhenReady(ctx, message);
     },
   });
 }

--- a/extensions/pi-autoresearch/paths.ts
+++ b/extensions/pi-autoresearch/paths.ts
@@ -1,0 +1,88 @@
+/**
+ * Session file path resolution.
+ *
+ * All autoresearch session files live under a single `.auto/` subfolder
+ * (one folder to preserve across reverts, gitignore, and clean up). New
+ * sessions always write the `.auto/` layout. For backwards compatibility we
+ * still read the legacy flat `autoresearch.*` files when only those exist.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export const AUTO_DIR = ".auto";
+
+export type SessionFileKind = "log" | "prompt" | "ideas" | "checks" | "measure" | "config";
+export type HookStage = "before" | "after";
+
+const CURRENT_HOOKS_DIR = "hooks";
+const LEGACY_HOOKS_DIR = "autoresearch.hooks";
+
+const SESSION_FILE_NAMES: Record<SessionFileKind, { current: string; legacy: string }> = {
+  log:    { current: "log.jsonl",   legacy: "autoresearch.jsonl" },
+  prompt: { current: "prompt.md",  legacy: "autoresearch.md" },
+  ideas:  { current: "ideas.md",    legacy: "autoresearch.ideas.md" },
+  checks: { current: "checks.sh",   legacy: "autoresearch.checks.sh" },
+  measure:{ current: "measure.sh",  legacy: "autoresearch.sh" },
+  config: { current: "config.json", legacy: "autoresearch.config.json" },
+};
+
+export interface SessionFileCandidates {
+  current: string;
+  legacy: string;
+}
+
+function currentSessionPath(dir: string, kind: SessionFileKind): string {
+  return path.join(dir, AUTO_DIR, SESSION_FILE_NAMES[kind].current);
+}
+
+function legacySessionPath(dir: string, kind: SessionFileKind): string {
+  return path.join(dir, SESSION_FILE_NAMES[kind].legacy);
+}
+
+function currentHookPath(workDir: string, stage: HookStage): string {
+  return path.join(workDir, AUTO_DIR, CURRENT_HOOKS_DIR, `${stage}.sh`);
+}
+
+function legacyHookPath(workDir: string, stage: HookStage): string {
+  return path.join(workDir, LEGACY_HOOKS_DIR, `${stage}.sh`);
+}
+
+function currentLayoutExists(dir: string): boolean {
+  for (const kind of Object.keys(SESSION_FILE_NAMES) as SessionFileKind[]) {
+    if (fs.existsSync(currentSessionPath(dir, kind))) return true;
+  }
+  return fs.existsSync(path.join(dir, AUTO_DIR, CURRENT_HOOKS_DIR));
+}
+
+/** Return both physical paths for destructive or migration operations. */
+export function sessionFileCandidates(dir: string, kind: SessionFileKind): SessionFileCandidates {
+  return {
+    current: currentSessionPath(dir, kind),
+    legacy: legacySessionPath(dir, kind),
+  };
+}
+
+/**
+ * Effective path for a session file. If any current `.auto/` session artifact
+ * exists, stay in the current layout for every file and ignore stale legacy
+ * peers. Fall back to a legacy flat file only when no current layout exists.
+ */
+export function sessionFilePath(dir: string, kind: SessionFileKind): string {
+  const candidates = sessionFileCandidates(dir, kind);
+  if (currentLayoutExists(dir)) return candidates.current;
+  return fs.existsSync(candidates.legacy) ? candidates.legacy : candidates.current;
+}
+
+/** Effective path for a hook script, with the same layout choice as session files. */
+export function hookScriptPath(workDir: string, stage: HookStage): string {
+  const current = currentHookPath(workDir, stage);
+  const legacy = legacyHookPath(workDir, stage);
+  if (currentLayoutExists(workDir)) return current;
+  return fs.existsSync(legacy) ? legacy : current;
+}
+
+/** Ensure the parent directory for a session file exists before writing. */
+export function ensureParentDir(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -13,15 +13,31 @@ Autonomous experiment loop: try ideas, keep what works, discard what doesn't, ne
 - **`run_experiment`** — runs command, times it, captures output.
 - **`log_experiment`** — records result. `keep` auto-commits. `discard`/`crash`/`checks_failed` auto-reverts code changes (autoresearch files preserved). Always include secondary `metrics` dict. Dashboard: ctrl+shift+t.
 
+## Session files
+
+All session files live in a single `.auto/` subfolder at the working directory root. This keeps everything in one place — easy to preserve across reverts, gitignore, and clean up.
+
+| File | Purpose |
+|------|---------|
+| `.auto/prompt.md` | Experiment prompt / playbook (heart of the session) |
+| `.auto/measure.sh` | Benchmark script — emits `METRIC name=value` lines |
+| `.auto/log.jsonl` | Append-only result log (written by the tools) |
+| `.auto/ideas.md` | Ideas backlog (optional) |
+| `.auto/checks.sh` | Correctness checks (optional) |
+| `.auto/config.json` | Session config (optional) |
+| `.auto/hooks/{before,after}.sh` | Lifecycle hooks (optional) |
+
+> Always create files in the `.auto/` layout. Legacy flat `autoresearch.*` files are still read for in-flight sessions, but new sessions should use `.auto/`.
+
 ## Setup
 
 1. Ask (or infer): **Goal**, **Command**, **Metric** (+ direction), **Files in scope**, **Constraints**.
 2. `git checkout -b autoresearch/<goal>-<date>`
 3. Read the source files. Understand the workload deeply before writing anything.
-4. Write `autoresearch.md` and `autoresearch.sh` (see below). Commit both.
+4. `mkdir -p .auto`, then write `.auto/prompt.md` and `.auto/measure.sh` (see below). Commit both.
 5. `init_experiment` → run baseline → `log_experiment` → start looping immediately.
 
-### `autoresearch.md`
+### `.auto/prompt.md`
 
 This is the heart of the session. A fresh agent with no context should be able to read this file and run the loop effectively. Invest time making it excellent.
 
@@ -36,7 +52,7 @@ This is the heart of the session. A fresh agent with no context should be able t
 - **Secondary**: <name>, <name>, ... — independent tradeoff monitors
 
 ## How to Run
-`./autoresearch.sh` — outputs `METRIC name=number` lines.
+`./.auto/measure.sh` — outputs `METRIC name=number` lines.
 
 ## Files in Scope
 <Every file the agent may modify, with a brief note on what it does.>
@@ -52,9 +68,9 @@ This is the heart of the session. A fresh agent with no context should be able t
 and architectural insights so the agent doesn't repeat failed approaches.>
 ```
 
-Update `autoresearch.md` periodically — especially the "What's Been Tried" section — so resuming agents have full context.
+Update `.auto/prompt.md` periodically — especially the "What's Been Tried" section — so resuming agents have full context.
 
-### `autoresearch.sh`
+### `.auto/measure.sh`
 
 Bash script (`set -euo pipefail`) that: pre-checks fast (syntax errors in <1s), runs the benchmark, and outputs structured lines to stdout. Keep the script fast — every second is multiplied by hundreds of runs.
 
@@ -79,14 +95,14 @@ The script runs the same code every iteration — but you can **update it during
 
 Use `log_experiment`'s `asi` parameter to annotate each run with **whatever would help the next iteration make a better decision.** Free-form key/value pairs — you decide what's worth recording. Don't repeat the description or raw output; capture what you'd lose after a context reset.
 
-**Annotate failures and crashes heavily.** Discarded and crashed runs are reverted — the code changes are gone. The only record that survives is the description and ASI in `autoresearch.jsonl`. If you don't capture what you tried and why it failed, future iterations will waste time re-discovering the same dead ends.
+**Annotate failures and crashes heavily.** Discarded and crashed runs are reverted — the code changes are gone. The only record that survives is the description and ASI in `.auto/log.jsonl`. If you don't capture what you tried and why it failed, future iterations will waste time re-discovering the same dead ends.
 
-### `autoresearch.config.json` (optional)
+### `.auto/config.json` (optional)
 
-JSON config file that lives in the pi session's working directory (`ctx.cwd`). Supported fields:
+JSON config file that lives in `.auto/` under the pi session's working directory (`ctx.cwd`). Supported fields:
 
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
-- **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`autoresearch.jsonl`, `autoresearch.md`, `autoresearch.sh`, `autoresearch.checks.sh`, `autoresearch.ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays in `ctx.cwd`. Fails if the directory doesn't exist.
+- **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`.auto/log.jsonl`, `.auto/prompt.md`, `.auto/measure.sh`, `.auto/checks.sh`, `.auto/ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays under `ctx.cwd`. Fails if the directory doesn't exist.
 
 ```json
 {
@@ -95,7 +111,7 @@ JSON config file that lives in the pi session's working directory (`ctx.cwd`). S
 }
 ```
 
-### `autoresearch.checks.sh` (optional)
+### `.auto/checks.sh` (optional)
 
 Bash script (`set -euo pipefail`) for backpressure/correctness checks: tests, types, lint, etc. **Only create this file when the user's constraints require correctness validation** (e.g., "tests must pass", "types must check").
 
@@ -129,15 +145,15 @@ pnpm typecheck 2>&1 | grep -i error || true
 - **Don't thrash.** Repeatedly reverting the same idea? Try something structurally different.
 - **Crashes:** fix if trivial, otherwise log and move on. Don't over-invest.
 - **Think longer when stuck.** Re-read source files, study the profiling data, reason about what the CPU is actually doing. The best ideas come from deep understanding, not from trying random variations.
-- **Resuming:** if `autoresearch.md` exists, read it + git log, continue looping.
+- **Resuming:** if `.auto/prompt.md` exists, read it + git log, continue looping.
 
 **NEVER STOP.** The user may be away for hours. Keep going until interrupted.
 
 ## Ideas Backlog
 
-When you discover complex but promising optimizations that you won't pursue right now, **append them as bullets to `autoresearch.ideas.md`**. Don't let good ideas get lost.
+When you discover complex but promising optimizations that you won't pursue right now, **append them as bullets to `.auto/ideas.md`**. Don't let good ideas get lost.
 
-On resume (context limit, crash), check `autoresearch.ideas.md` — prune stale/tried entries, experiment with the rest. When all paths are exhausted, delete the file and write a final summary.
+On resume (context limit, crash), check `.auto/ideas.md` — prune stale/tried entries, experiment with the rest. When all paths are exhausted, delete the file and write a final summary.
 
 ## User Messages During Experiments
 

--- a/skills/autoresearch-finalize/SKILL.md
+++ b/skills/autoresearch-finalize/SKILL.md
@@ -10,8 +10,8 @@ Turn a noisy autoresearch branch into clean, independent branches — one per lo
 
 ## Step 1 — Analyze and Propose Groups
 
-1. Read `autoresearch.jsonl`. Filter to **kept** experiments only.
-2. Read `autoresearch.md` for context.
+1. Read `.auto/log.jsonl` (legacy: `autoresearch.jsonl`). Filter to **kept** experiments only.
+2. Read `.auto/prompt.md` (legacy: `autoresearch.md`) for context.
 3. Expand all short commit hashes to full hashes: `git rev-parse <short_hash>`
 4. Get the merge-base: `git merge-base HEAD main`
 5. For each kept commit, get the diff stat (use `$BASE..<commit>` for the first, `<prev_kept>..<commit>` for subsequent).
@@ -69,7 +69,7 @@ Then run:
 bash <SKILL_DIR>/finalize.sh /tmp/groups.json
 ```
 
-The script creates one branch per group from the merge-base, verifies the union matches the original branch, and prints a summary with all branches, cleanup commands, and any ideas from `autoresearch.ideas.md`.
+The script creates one branch per group from the merge-base, verifies the union matches the original branch, and prints a summary with all branches, cleanup commands, and any ideas from `.auto/ideas.md` (legacy: `autoresearch.ideas.md`).
 
 On creation failure: rolls back (deletes branches, restores original branch, pops stash).
 On verification failure: exits non-zero but leaves branches intact for inspection.

--- a/skills/autoresearch-finalize/finalize.sh
+++ b/skills/autoresearch-finalize/finalize.sh
@@ -44,6 +44,7 @@ fail() { cleanup_data; echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
 
 is_session_file() {
   case "/$1/" in
+    */.auto/*) return 0;;
     */autoresearch.*/*) return 0;;
     *) return 1;;
   esac
@@ -404,13 +405,20 @@ print_summary() {
   echo "Cleanup — after merging, delete the autoresearch branch and session files:"
   echo ""
   echo "  git branch -D $ORIG_BRANCH"
-  echo "  rm -f autoresearch.jsonl autoresearch.sh autoresearch.md autoresearch.ideas.md"
+  echo "  rm -r .auto    # session folder (current layout)"
+  echo "  rm -f autoresearch.jsonl autoresearch.sh autoresearch.md autoresearch.ideas.md    # legacy flat files, if any"
 
-  if [ -f "autoresearch.ideas.md" ]; then
+  local ideas_file=""
+  if [ -f ".auto/ideas.md" ]; then
+    ideas_file=".auto/ideas.md"
+  elif [ -f "autoresearch.ideas.md" ]; then
+    ideas_file="autoresearch.ideas.md"
+  fi
+  if [ -n "$ideas_file" ]; then
     echo ""
-    echo "Ideas backlog (from autoresearch.ideas.md):"
+    echo "Ideas backlog (from $ideas_file):"
     echo ""
-    sed 's/^/  /' autoresearch.ideas.md
+    sed 's/^/  /' "$ideas_file"
   fi
 
   echo ""

--- a/skills/autoresearch-hooks/SKILL.md
+++ b/skills/autoresearch-hooks/SKILL.md
@@ -8,7 +8,7 @@ description: Author pre/post-iteration hooks for an autoresearch session. Use wh
 Optional scripts that run at iteration boundaries in an autoresearch session. Two hooks, both transparent to the loop-running agent — their effect is a file on disk or a steer message.
 
 ```
-autoresearch.hooks/
+.auto/hooks/
   before.sh    # fires before each iteration (prospective)
   after.sh     # fires after each log_experiment (retrospective)
 ```
@@ -100,7 +100,7 @@ One JSON line. Parse with `jq`. Realistic example:
 
 ### Preservation
 
-`autoresearch.hooks/**` survives the auto-revert, like all paths matching `autoresearch.*`.
+`.auto/**` survives the auto-revert — the entire `.auto/` folder is preserved. (Legacy `autoresearch.*` paths are still preserved too, for in-flight sessions.)
 
 ---
 
@@ -111,13 +111,13 @@ Runnable reference scripts live in this skill's `examples/` directory — one fi
 - `examples/before/` — external search, qmd document search, anti-thrash, idea rotator, hypothesis reflection, context rotation
 - `examples/after/` — learnings journal, macOS notification on new best, auto-tag winning commits
 
-Each example is a complete, self-contained script with named constants, short helper functions, guard clauses, and intention-revealing names. Read the header comment for its purpose, copy to `autoresearch.hooks/<stage>.sh`, adapt.
+Each example is a complete, self-contained script with named constants, short helper functions, guard clauses, and intention-revealing names. Read the header comment for its purpose, copy to `.auto/hooks/<stage>.sh`, adapt.
 
 ---
 
 ## Steps to add a hook
 
-1. **Understand the session.** Read `autoresearch.md` for the objective and metric; glance at `autoresearch.sh` for the workload. Your hook should complement the loop, not duplicate it.
+1. **Understand the session.** Read `.auto/prompt.md` for the objective and metric; glance at `.auto/measure.sh` for the workload. Your hook should complement the loop, not duplicate it.
 
 2. **Clarify the user's intent.** What should happen, at which boundary? Research before / log after / notify on wins / intervene on thrash / etc.
 
@@ -126,10 +126,10 @@ Each example is a complete, self-contained script with named constants, short he
 4. **Copy, adapt, mark executable.**
 
    ```bash
-   mkdir -p autoresearch.hooks
-   cp "<skill-dir>/examples/before/external-search.sh" autoresearch.hooks/before.sh
+   mkdir -p .auto/hooks
+   cp "<skill-dir>/examples/before/external-search.sh" .auto/hooks/before.sh
    # ... adapt the script ...
-   chmod +x autoresearch.hooks/before.sh
+   chmod +x .auto/hooks/before.sh
    ```
 
 5. **Sanity-test with a piped mock** before relying on it in the loop:
@@ -151,12 +151,12 @@ Each example is a complete, self-contained script with named constants, short he
          goal: "test"
        }
      }
-   ' | ./autoresearch.hooks/before.sh
+   ' | ./.auto/hooks/before.sh
    ```
 
    For `after.sh`, swap `last_run: null` for a `run_entry` object (see the schema above).
 
-6. **Commit the hook** alongside other session files. It's preserved across reverts because the path matches `autoresearch.*`.
+6. **Commit the hook** alongside other session files. It's preserved across reverts because it lives under `.auto/`.
 
 ---
 

--- a/skills/autoresearch-hooks/examples/README.md
+++ b/skills/autoresearch-hooks/examples/README.md
@@ -1,12 +1,12 @@
 # Hook examples
 
-Reference scripts for `autoresearch.hooks/before.sh` and `autoresearch.hooks/after.sh`. Each file is a complete, self-contained example — pick the one closest to what you want, copy it to your session's `autoresearch.hooks/` directory, adapt, and mark executable.
+Reference scripts for `.auto/hooks/before.sh` and `.auto/hooks/after.sh`. Each file is a complete, self-contained example — pick the one closest to what you want, copy it to your session's `.auto/hooks/` directory, adapt, and mark executable.
 
 These scripts ship with the `autoresearch-hooks` skill. When the skill is active, paths resolve against the skill directory, so the agent can copy them with:
 
 ```bash
-cp "<skill-dir>/examples/before/external-search.sh" /path/to/session/autoresearch.hooks/before.sh
-chmod +x /path/to/session/autoresearch.hooks/before.sh
+cp "<skill-dir>/examples/before/external-search.sh" /path/to/session/.auto/hooks/before.sh
+chmod +x /path/to/session/.auto/hooks/before.sh
 ```
 
 The files here are **not** marked executable on purpose — they're references, not installed hooks. A `chmod +x` step is required when you wire one up.
@@ -20,15 +20,15 @@ For the hook contract (stdin schemas, stdout handling, timeouts, observability),
 | [`external-search.sh`](before/external-search.sh) | Mine agent notes for a query and fetch external material via your search tool of choice. |
 | [`qmd-search.sh`](before/qmd-search.sh) | Same shape, but targets a local [`qmd`](https://www.npmjs.com/package/qmd) BM25 / vector / rerank index over your project's markdown. |
 | [`anti-thrash.sh`](before/anti-thrash.sh) | After N consecutive discards, emit a steer suggesting a structural rethink. |
-| [`idea-rotator.sh`](before/idea-rotator.sh) | Surface the next unchecked bullet from `autoresearch.ideas.md` as a steer nudge. |
+| [`idea-rotator.sh`](before/idea-rotator.sh) | Surface the next unchecked bullet from `.auto/ideas.md` as a steer nudge. |
 | [`hypothesis-reflection.sh`](before/hypothesis-reflection.sh) | On a discard, ask a cheap model to critique the failed hypothesis and propose adjacent directions. |
-| [`context-rotation.sh`](before/context-rotation.sh) | Trim an oversized `autoresearch.md`, archiving the tail. |
+| [`context-rotation.sh`](before/context-rotation.sh) | Trim an oversized `.auto/prompt.md`, archiving the tail. |
 
 ## `after/` — fires after each `log_experiment`
 
 | Script | Purpose |
 | --- | --- |
-| [`learnings-journal.sh`](after/learnings-journal.sh) | Append one human-readable line per run to `autoresearch.learnings.md`. |
+| [`learnings-journal.sh`](after/learnings-journal.sh) | Append one human-readable line per run to `.auto/learnings.md`. |
 | [`macos-notify.sh`](after/macos-notify.sh) | Fire a native macOS banner only when the run is a new best. |
 | [`auto-tag-winners.sh`](after/auto-tag-winners.sh) | Tag every new best with a sortable git tag. |
 

--- a/skills/autoresearch-hooks/examples/after/learnings-journal.sh
+++ b/skills/autoresearch-hooks/examples/after/learnings-journal.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-readonly LEARNINGS_FILE="autoresearch.learnings.md"
+readonly LEARNINGS_FILE=".auto/learnings.md"
 
 run_number()     { jq -r '.run_entry.run' <<<"$1"; }
 run_status()     { jq -r '.run_entry.status' <<<"$1"; }
@@ -13,6 +13,7 @@ run_hypothesis() { jq -r '.run_entry.asi.hypothesis // "-"' <<<"$1"; }
 
 append_journal_line() {
   local file="$1" run="$2" status="$3" metric="$4" hyp="$5"
+  mkdir -p "$(dirname "$file")"
   printf 'run=%s status=%s metric=%s hyp=%s\n' "$run" "$status" "$metric" "$hyp" >> "$file"
 }
 

--- a/skills/autoresearch-hooks/examples/before/anti-thrash.sh
+++ b/skills/autoresearch-hooks/examples/before/anti-thrash.sh
@@ -16,13 +16,18 @@ recent_discard_count() {
 
 thrash_suggestions() {
   echo "⚠️ $1 consecutive discards. Consider:"
-  echo "  - Re-reading autoresearch.md and the benchmark script"
+  echo "  - Re-reading .auto/prompt.md and the benchmark script"
   echo "  - Trying something structurally different, not another variation"
   echo "  - Measuring what the CPU is actually spending time on"
 }
 
+resolve_jsonl() {
+  [ -f "$1/.auto/log.jsonl" ] && { echo "$1/.auto/log.jsonl"; return; }
+  echo "$1/autoresearch.jsonl"
+}
+
 input="$(cat)"
-jsonl="$(jq -r '.cwd' <<<"$input")/autoresearch.jsonl"
+jsonl="$(resolve_jsonl "$(jq -r '.cwd' <<<"$input")")"
 streak=$(recent_discard_count "$jsonl")
 
 [ "$streak" -lt "$STREAK_THRESHOLD" ] && exit 0

--- a/skills/autoresearch-hooks/examples/before/context-rotation.sh
+++ b/skills/autoresearch-hooks/examples/before/context-rotation.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# When autoresearch.md exceeds a size threshold, keep the preamble and
+# When the rules file exceeds a size threshold, keep the preamble and
 # archive the tail. Prevents session-document bloat from eating context.
 
 set -euo pipefail
@@ -18,9 +18,14 @@ archive_tail() {
   mv "$file.tmp" "$file"
 }
 
+resolve_prompt() {
+  [ -f "$1/.auto/prompt.md" ] && { echo "$1/.auto/prompt.md"; return; }
+  echo "$1/autoresearch.md"
+}
+
 input="$(cat)"
-md="$(jq -r '.cwd' <<<"$input")/autoresearch.md"
+md="$(resolve_prompt "$(jq -r '.cwd' <<<"$input")")"
 [ -f "$md" ] && file_too_large "$md" || exit 0
 
 archive_tail "$md"
-echo "Rotated autoresearch.md (kept first $KEEP_LINES lines, archived rest)."
+echo "Rotated $md (kept first $KEEP_LINES lines, archived rest)."

--- a/skills/autoresearch-hooks/examples/before/external-search.sh
+++ b/skills/autoresearch-hooks/examples/before/external-search.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-readonly RESEARCH_FILE="autoresearch.research.md"
+readonly RESEARCH_FILE=".auto/research.md"
 readonly RESULT_LIMIT=5
 
 query_from_agent_notes() {
@@ -28,5 +28,6 @@ query=$(query_from_agent_notes "$input")
 [ -z "$query" ] && exit 0
 
 workdir="$(jq -r '.cwd' <<<"$input")"
+mkdir -p "$(dirname "$workdir/$RESEARCH_FILE")"
 fetch_results "$query" > "$workdir/$RESEARCH_FILE"
 echo "Research saved → $RESEARCH_FILE (query: $query)"

--- a/skills/autoresearch-hooks/examples/before/idea-rotator.sh
+++ b/skills/autoresearch-hooks/examples/before/idea-rotator.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
-# If autoresearch.ideas.md exists, surface the top unchecked bullet
+# If the ideas backlog exists, surface the top unchecked bullet
 # as a steer nudge. Format assumes markdown checkboxes: `- [ ] idea`.
 
 set -euo pipefail
 
-readonly IDEAS_FILE="autoresearch.ideas.md"
+readonly IDEAS_FILE=".auto/ideas.md"
+readonly LEGACY_IDEAS_FILE="autoresearch.ideas.md"
 readonly UNCHECKED_PATTERN='^- \[ \]'
 
 first_unchecked_idea() {
   grep -m1 -E "$UNCHECKED_PATTERN" "$1" | sed 's/^- \[ \] //'
 }
 
+resolve_ideas() {
+  [ -f "$1/$IDEAS_FILE" ] && { echo "$1/$IDEAS_FILE"; return; }
+  [ -f "$1/$LEGACY_IDEAS_FILE" ] && { echo "$1/$LEGACY_IDEAS_FILE"; return; }
+}
+
 input="$(cat)"
-ideas="$(jq -r '.cwd' <<<"$input")/$IDEAS_FILE"
-[ -f "$ideas" ] || exit 0
+ideas="$(resolve_ideas "$(jq -r '.cwd' <<<"$input")")"
+[ -n "$ideas" ] && [ -f "$ideas" ] || exit 0
 
 next=$(first_unchecked_idea "$ideas")
 [ -z "$next" ] && exit 0
-echo "Next idea from $IDEAS_FILE: $next"
+echo "Next idea from $ideas: $next"

--- a/skills/autoresearch-hooks/examples/before/qmd-search.sh
+++ b/skills/autoresearch-hooks/examples/before/qmd-search.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-readonly DOCS_FILE="autoresearch.docs.md"
+readonly DOCS_FILE=".auto/docs.md"
 readonly RESULT_LIMIT=5
 
 query_from_agent_notes() {
@@ -33,5 +33,6 @@ query=$(query_from_agent_notes "$input")
 [ -z "$query" ] && exit 0
 
 workdir="$(jq -r '.cwd' <<<"$input")"
+mkdir -p "$(dirname "$workdir/$DOCS_FILE")"
 fetch_docs "$query" > "$workdir/$DOCS_FILE"
 echo "Docs saved → $DOCS_FILE (query: $query)"

--- a/tests/compaction.test.mjs
+++ b/tests/compaction.test.mjs
@@ -58,6 +58,28 @@ test("summary contains all persisted sources when present", () => {
   });
 });
 
+test("summary uses the .auto layout filenames when present", () => {
+  withTempWorkDir((workDir) => {
+    const autoDir = path.join(workDir, ".auto");
+    fs.mkdirSync(autoDir, { recursive: true });
+    fs.writeFileSync(path.join(autoDir, "prompt.md"), "# Rules\nDo not cheat.");
+    fs.writeFileSync(path.join(autoDir, "ideas.md"), "- Try memoization");
+    fs.writeFileSync(
+      path.join(autoDir, "log.jsonl"),
+      [
+        '{"type":"config","name":"Speed up parser","metricName":"total_us","metricUnit":"us","bestDirection":"lower"}',
+        '{"run":1,"commit":"aaa1111","metric":100,"status":"keep","description":"baseline","timestamp":1,"metrics":{}}',
+      ].join("\n") + "\n",
+    );
+
+    const summary = buildAutoresearchCompactionSummary(autoresearchSummaryPathsFor(workDir));
+
+    assert.match(summary, /## Experiment Rules \(\.auto\/prompt\.md\)/);
+    assert.match(summary, /## Ideas Backlog \(\.auto\/ideas\.md\)/);
+    assert.match(summary, /read additional lines from \.auto\/log\.jsonl\./);
+  });
+});
+
 test("session block omits baseline/best when no runs exist yet", () => {
   withTempWorkDir((workDir) => {
     writeJsonlLines(workDir, [

--- a/tests/finalize_test.sh
+++ b/tests/finalize_test.sh
@@ -731,6 +731,77 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Test: .auto/ session folder excluded (current layout)
+# ---------------------------------------------------------------------------
+
+test_auto_dir_session_artifacts() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  local REPO
+  REPO=$(mktemp -d)
+  cd "$REPO"
+  git init --quiet
+  git checkout -b main
+
+  mkdir -p libs/polaris
+  echo "original" > libs/polaris/component.ts
+  git add -A && git commit -m "initial" --quiet
+
+  git checkout -b autoresearch/auto-dir-test --quiet
+
+  # Current layout: everything under .auto/ (root and nested)
+  mkdir -p .auto libs/polaris/.auto
+  echo '{"type":"config"}' > .auto/log.jsonl
+  echo "# session" > .auto/prompt.md
+  echo "#!/bin/bash" > .auto/measure.sh
+  echo '{"type":"config"}' > libs/polaris/.auto/log.jsonl
+  echo "optimized" > libs/polaris/component.ts
+  git add -A && git commit -m "optimize + .auto session files" --quiet
+
+  local BASE FINAL
+  BASE=$(git merge-base HEAD main)
+  FINAL=$(git rev-parse HEAD)
+
+  cat > "$REPO/groups.json" << EOF
+{
+  "base": "$BASE",
+  "trunk": "main",
+  "final_tree": "$FINAL",
+  "goal": "test",
+  "groups": [
+    {
+      "title": "Optimize component",
+      "body": "Metric: 10ms → 5ms (-50%)",
+      "last_commit": "$FINAL",
+      "slug": "optimize"
+    }
+  ]
+}
+EOF
+
+  local OUTPUT
+  OUTPUT=$(bash "$FINALIZE" "$REPO/groups.json" 2>&1) || { fail_test ".auto dir session artifacts" "Script failed: $OUTPUT"; cleanup_repo "$REPO"; return; }
+
+  # Branch should only have component.ts, nothing under .auto/
+  local BRANCH="autoresearch/test/01-optimize"
+  for f in $(git diff-tree --no-commit-id --name-only -r "$(git rev-parse "$BRANCH")"); do
+    case "/$f/" in
+      */.auto/*)
+        fail_test ".auto dir session artifacts" "Session artifact '$f' leaked into branch"
+        cleanup_repo "$REPO"
+        return
+        ;;
+    esac
+  done
+
+  local CONTENT
+  CONTENT=$(git show "$BRANCH":libs/polaris/component.ts)
+  [ "$CONTENT" = "optimized" ] || { fail_test ".auto dir session artifacts" "component.ts wrong: $CONTENT"; cleanup_repo "$REPO"; return; }
+
+  pass ".auto dir session artifacts"
+  cleanup_repo "$REPO"
+}
+
+# ---------------------------------------------------------------------------
 # Test: verification failure leaves branches intact and returns to orig branch
 # ---------------------------------------------------------------------------
 
@@ -1015,6 +1086,7 @@ test_detached_head
 test_on_trunk
 test_basic_two_groups
 test_nested_session_artifacts
+test_auto_dir_session_artifacts
 test_verify_failure_leaves_branches
 test_stash_pop_on_rollback
 test_skipped_empty_group

--- a/tests/paths.test.mjs
+++ b/tests/paths.test.mjs
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  sessionFilePath,
+  sessionFileCandidates,
+  hookScriptPath,
+  ensureParentDir,
+  AUTO_DIR,
+} from "../extensions/pi-autoresearch/paths.ts";
+
+function freshDir() {
+  return fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-paths-"));
+}
+
+test("a brand-new session resolves to the .auto layout", () => {
+  const dir = freshDir();
+  assert.equal(sessionFilePath(dir, "log"), path.join(dir, AUTO_DIR, "log.jsonl"));
+  assert.equal(sessionFilePath(dir, "prompt"), path.join(dir, AUTO_DIR, "prompt.md"));
+  assert.equal(sessionFilePath(dir, "config"), path.join(dir, AUTO_DIR, "config.json"));
+});
+
+test("an existing legacy file is read in place for backwards compatibility", () => {
+  const dir = freshDir();
+  const legacy = path.join(dir, "autoresearch.jsonl");
+  fs.writeFileSync(legacy, "{}\n");
+  assert.equal(sessionFilePath(dir, "log"), legacy);
+});
+
+test("the .auto layout wins when both new and legacy files exist", () => {
+  const dir = freshDir();
+  fs.writeFileSync(path.join(dir, "autoresearch.jsonl"), "{}\n");
+  const current = path.join(dir, AUTO_DIR, "log.jsonl");
+  ensureParentDir(current);
+  fs.writeFileSync(current, "{}\n");
+  assert.equal(sessionFilePath(dir, "log"), current);
+});
+
+test("current sessions do not inherit stale legacy peer files", () => {
+  const dir = freshDir();
+  const currentLog = path.join(dir, AUTO_DIR, "log.jsonl");
+  ensureParentDir(currentLog);
+  fs.writeFileSync(currentLog, "{}\n");
+  fs.writeFileSync(path.join(dir, "autoresearch.config.json"), '{"maxIterations":1}\n');
+  fs.writeFileSync(path.join(dir, "autoresearch.checks.sh"), "#!/usr/bin/env bash\n");
+
+  assert.equal(sessionFilePath(dir, "config"), path.join(dir, AUTO_DIR, "config.json"));
+  assert.equal(sessionFilePath(dir, "checks"), path.join(dir, AUTO_DIR, "checks.sh"));
+});
+
+test("legacy files are used only when no current layout exists", () => {
+  const dir = freshDir();
+  const legacyConfig = path.join(dir, "autoresearch.config.json");
+  fs.writeFileSync(legacyConfig, '{"maxIterations":1}\n');
+  assert.equal(sessionFilePath(dir, "config"), legacyConfig);
+});
+
+test("session file candidates expose both paths for cleanup", () => {
+  const dir = freshDir();
+  assert.deepEqual(sessionFileCandidates(dir, "log"), {
+    current: path.join(dir, AUTO_DIR, "log.jsonl"),
+    legacy: path.join(dir, "autoresearch.jsonl"),
+  });
+});
+
+test("hook scripts prefer .auto/hooks and fall back to the legacy directory", () => {
+  const dir = freshDir();
+  assert.equal(hookScriptPath(dir, "before"), path.join(dir, AUTO_DIR, "hooks", "before.sh"));
+
+  const legacyHook = path.join(dir, "autoresearch.hooks", "after.sh");
+  ensureParentDir(legacyHook);
+  fs.writeFileSync(legacyHook, "#!/usr/bin/env bash\n");
+  assert.equal(hookScriptPath(dir, "after"), legacyHook);
+});
+
+test("current sessions ignore stale legacy hooks", () => {
+  const dir = freshDir();
+  const currentLog = path.join(dir, AUTO_DIR, "log.jsonl");
+  ensureParentDir(currentLog);
+  fs.writeFileSync(currentLog, "{}\n");
+  const legacyHook = path.join(dir, "autoresearch.hooks", "after.sh");
+  ensureParentDir(legacyHook);
+  fs.writeFileSync(legacyHook, "#!/usr/bin/env bash\n");
+
+  assert.equal(hookScriptPath(dir, "after"), path.join(dir, AUTO_DIR, "hooks", "after.sh"));
+});
+
+test("ensureParentDir creates missing parent directories", () => {
+  const dir = freshDir();
+  const target = path.join(dir, AUTO_DIR, "log.jsonl");
+  ensureParentDir(target);
+  assert.ok(fs.existsSync(path.dirname(target)));
+});


### PR DESCRIPTION
## Summary
- Move autoresearch session artifacts into a single `.auto/` directory while preserving legacy flat-file fallback for existing sessions
- Keep session path resolution layout-consistent so stale legacy peers do not leak into current `.auto/` sessions
- Update hooks, compaction summaries, finalize cleanup, docs, and examples for the new layout

## Tests
- `pnpm test`
- `bash tests/finalize_test.sh`