### PR TITLE
Integrate active community autoresearch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - `/autoresearch` can infer loop controls from natural language, e.g. “for 50 runs” or “continue indefinitely”, and writes the matching config automatically.
 - Optional `ask_autoresearch_hint` tool. When enabled in `.auto/config.json`, the loop can ask a configured larger pi model for bounded, side-effect-free strategy advice after stalled or failed experiment attempts.
 
+### Fixed
+
+- Autoresearch now hard-blocks activation and experiment logging outside a git working tree unless `.auto/config.json` explicitly sets `allowNoGit: true`, preventing unsafe `nogit` keep/discard loops that cannot commit or revert.
+
 ## [1.6.0] - 2026-06-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `maxAutoResumeTurns` in `.auto/config.json` to tune the auto-resume safety valve. The default remains 20; `null` or `0` means intentional unlimited auto-resume.
 - `/autoresearch` can infer loop controls from natural language, e.g. “for 50 runs” or “continue indefinitely”, and writes the matching config automatically.
+- Optional `ask_autoresearch_hint` tool. When enabled in `.auto/config.json`, the loop can ask a configured larger pi model for bounded, side-effect-free strategy advice after stalled or failed experiment attempts.
 
 ## [1.6.0] - 2026-06-08
 
@@ -21,7 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- The `init_experiment`, `run_experiment`, and `log_experiment` tools are now revealed to the agent only while autoresearch mode is active, instead of being callable in every session. Outside autoresearch mode the tools are absent from the LLM's schema and system prompt, so the agent can no longer self-start a research loop — entry is via `/autoresearch` or resuming a session with an existing `autoresearch.jsonl`.
+- The `init_experiment`, `run_experiment`, and `log_experiment` tools are now revealed to the agent only while autoresearch mode is active, instead of being callable in every session. Outside autoresearch mode the tools are absent from the LLM's schema and system prompt, so the agent can no longer self-start a research loop — entry is via `/autoresearch` or resuming a session with an existing `.auto/log.jsonl`.
 
 ## [1.4.0] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `maxAutoResumeTurns` in `.auto/config.json` to tune the auto-resume safety valve. The default remains 20; `null` or `0` means intentional unlimited auto-resume.
+- `/autoresearch` can infer loop controls from natural language, e.g. “for 50 runs” or “continue indefinitely”, and writes the matching config automatically.
+
 ## [1.6.0] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pi install npm:pi-autoresearch
 ```
 /autoresearch optimize unit test runtime, monitor correctness
 /autoresearch model training, run 5 minutes of train.py and note the loss ratio as optimization target
+/autoresearch optimize bundle size for 50 runs
+/autoresearch continue indefinitely and never stop
 /autoresearch export
 /autoresearch off
 /autoresearch clear
@@ -208,7 +210,8 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "maxAutoResumeTurns": 50
 }
 ```
 
@@ -216,10 +219,11 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 |-------|------|-------------|
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays under the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
+| `maxAutoResumeTurns` | number \| null | Safety valve for automatic resume prompts after completed turns or compactions. Defaults to `20` to prevent accidental chat-only loops. Set to `null` or `0` for unlimited auto-resume. |
 
 ### Long-running loops and context
 
-The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `.auto/prompt.md`, the tail of `.auto/log.jsonl`, `.auto/ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works.
+The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `.auto/prompt.md`, the tail of `.auto/log.jsonl`, `.auto/ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works. For intentionally very long unattended sessions, raise or disable `maxAutoResumeTurns` so the safety valve does not stop the loop before your chosen run count.
 
 ---
 
@@ -337,6 +341,14 @@ Autoresearch loops run autonomously and can burn through tokens. Two ways to cap
      "maxIterations": 30
    }
    ```
+- **`maxAutoResumeTurns`** — cap or remove the auto-resume safety valve. The default is `20`; set `null` or `0` only when you intentionally want unattended runs to continue indefinitely:
+   ```json
+   {
+     "maxAutoResumeTurns": null
+   }
+   ```
+
+You can also set these verbally in `/autoresearch`: phrases like “run forever”, “continue indefinitely”, or “never stop” configure unlimited auto-resume; phrases like “for 50 runs” configure both `maxIterations` and enough auto-resume budget for that run count.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pi install npm:pi-autoresearch
 | `init_experiment` | One-time session config — name, metric, unit, direction |
 | `run_experiment` | Runs any command, times wall-clock duration, captures output |
 | `log_experiment` | Records result, auto-commits, updates widget and dashboard |
+| `ask_autoresearch_hint` | *(Optional)* Ask a configured larger model for concise strategy advice when the loop is stuck |
 
 ### `/autoresearch` command
 
@@ -211,7 +212,16 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 {
   "workingDir": "/path/to/project",
   "maxIterations": 50,
-  "maxAutoResumeTurns": 50
+  "maxAutoResumeTurns": 50,
+  "hints": {
+    "enabled": true,
+    "provider": "anthropic",
+    "model": "claude-opus-4-5",
+    "thinkingLevel": "high",
+    "maxRecentRuns": 8,
+    "maxCallsPerSession": 5,
+    "timeoutSeconds": 120
+  }
 }
 ```
 
@@ -220,6 +230,13 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays under the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
 | `maxAutoResumeTurns` | number \| null | Safety valve for automatic resume prompts after completed turns or compactions. Defaults to `20` to prevent accidental chat-only loops. Set to `null` or `0` for unlimited auto-resume. |
+| `hints` | object | Optional expensive-model hint tool config. Missing or `enabled: false` means no hint model calls are made. When enabled, `provider` and `model` must match a configured pi model. |
+
+`ask_autoresearch_hint` is a side-channel advisory tool. It never edits files,
+changes the active pi model, commits, reverts, or writes `.auto/log.jsonl`.
+The agent is guided to use it only after repeated discards/crashes, stalled
+progress, or unclear next hypotheses, and every suggestion still has to be
+validated through `run_experiment` and `log_experiment`.
 
 ### Long-running loops and context
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
   "workingDir": "/path/to/project",
   "maxIterations": 50,
   "maxAutoResumeTurns": 50,
+  "allowNoGit": false,
   "hints": {
     "enabled": true,
     "provider": "anthropic",
@@ -230,6 +231,7 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays under the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
 | `maxAutoResumeTurns` | number \| null | Safety valve for automatic resume prompts after completed turns or compactions. Defaults to `20` to prevent accidental chat-only loops. Set to `null` or `0` for unlimited auto-resume. |
+| `allowNoGit` | boolean | Defaults to `false`. Autoresearch refuses to start or log experiments unless `workingDir` is inside a git working tree, because keep/discard needs commit/revert protection. Set `true` only for disposable throwaway sessions. |
 | `hints` | object | Optional expensive-model hint tool config. Missing or `enabled: false` means no hint model calls are made. When enabled, `provider` and `model` must match a configured pi model. |
 
 `ask_autoresearch_hint` is a side-channel advisory tool. It never edits files,
@@ -358,6 +360,7 @@ Autoresearch loops run autonomously and can burn through tokens. Two ways to cap
      "maxIterations": 30
    }
    ```
+- **Git protection** — by default, autoresearch refuses to run outside a git working tree. This prevents no-git `keep`/`discard` runs that cannot commit or revert safely. For disposable throwaway sessions only, set `"allowNoGit": true` in `.auto/config.json`.
 - **`maxAutoResumeTurns`** — cap or remove the auto-resume safety valve. The default is `20`; set `null` or `0` only when you intentionally want unattended runs to continue indefinitely:
    ```json
    {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pi install npm:pi-autoresearch
 | Subcommand | Description |
 |------------|-------------|
 | `/autoresearch <text>` | Enter autoresearch mode. If `.auto/prompt.md` exists, resumes the loop with `<text>` as context. Otherwise, sets up a new session. |
-| `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `.auto/log.jsonl` intact. |
+| `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `.auto/log.jsonl` intact. The manual-off choice is persisted outside the repo under `<agent-dir>/autoresearch/state/`, so `/tree`, compaction, and session reloads do not reactivate it. |
 | `/autoresearch clear` | Delete `.auto/log.jsonl`, reset all state, and turn autoresearch mode off. Use this for a clean start. |
 | `/autoresearch export` | Open a live dashboard in your browser. Auto-updates as experiments run. |
 

--- a/extensions/pi-autoresearch/hints.ts
+++ b/extensions/pi-autoresearch/hints.ts
@@ -1,0 +1,373 @@
+import { completeSimple, type AssistantMessage, type Model } from "@earendil-works/pi-ai";
+import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const DEFAULT_MAX_RECENT_RUNS = 8;
+const MIN_MAX_RECENT_RUNS = 1;
+const MAX_MAX_RECENT_RUNS = 20;
+
+const DEFAULT_MAX_CALLS_PER_SESSION = 5;
+const MIN_MAX_CALLS_PER_SESSION = 1;
+const MAX_MAX_CALLS_PER_SESSION = 20;
+
+const DEFAULT_TIMEOUT_SECONDS = 120;
+const MIN_TIMEOUT_SECONDS = 10;
+const MAX_TIMEOUT_SECONDS = 600;
+
+const DEFAULT_THINKING_LEVEL: HintThinkingLevel = "high";
+const HINT_FILE_MAX_CHARS = 3000;
+const EXTRA_CONTEXT_MAX_CHARS = 1500;
+const ASI_VALUE_MAX_CHARS = 180;
+
+type HintThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+export interface HintConfig {
+  enabled: boolean;
+  provider: string | null;
+  model: string | null;
+  thinkingLevel: HintThinkingLevel;
+  maxRecentRuns: number;
+  maxCallsPerSession: number;
+  timeoutSeconds: number;
+}
+
+export interface HintRun {
+  run?: number;
+  commit: string;
+  metric: number;
+  metrics: Record<string, number>;
+  status: "keep" | "discard" | "crash" | "checks_failed";
+  description: string;
+  segment: number;
+  confidence: number | null;
+  asi?: Record<string, unknown>;
+}
+
+export interface HintExperimentState {
+  name: string | null;
+  metricName: string;
+  metricUnit: string;
+  bestDirection: "lower" | "higher";
+  bestMetric: number | null;
+  currentSegment: number;
+  results: HintRun[];
+  confidence: number | null;
+}
+
+export interface HintPromptInput {
+  state: HintExperimentState;
+  workDir: string;
+  question: string;
+  extraContext?: string;
+  maxRecentRuns: number;
+  readFile?: (filePath: string) => string;
+}
+
+export interface HintRequestInput extends HintPromptInput {
+  model: Model;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  thinkingLevel: HintThinkingLevel;
+  timeoutSeconds: number;
+  signal?: AbortSignal;
+  complete?: typeof completeSimple;
+}
+
+export interface HintRequestResult {
+  text: string;
+  durationMs: number;
+  promptBytes: number;
+  stopReason: AssistantMessage["stopReason"];
+  usage: AssistantMessage["usage"] | null;
+}
+
+const HINT_SYSTEM_PROMPT = [
+  "You are a senior research advisor for pi-autoresearch.",
+  "Give concise strategy advice only. You cannot edit files, run commands, commit, or revert changes.",
+  "Return a likely diagnosis, 1-3 next experiments, and key failure modes.",
+  "The caller must validate every suggestion with run_experiment and log_experiment.",
+].join(" ");
+
+const HINT_THINKING_LEVELS = new Set<HintThinkingLevel>([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
+const ASI_HINT_KEYS = [
+  "hypothesis",
+  "next_action_hint",
+  "next_focus",
+  "rollback_reason",
+  "learned",
+  "bottleneck",
+  "failure_mode",
+  "error",
+];
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function trimString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function thinkingLevelFrom(value: unknown): HintThinkingLevel {
+  return typeof value === "string" && HINT_THINKING_LEVELS.has(value as HintThinkingLevel)
+    ? value as HintThinkingLevel
+    : DEFAULT_THINKING_LEVEL;
+}
+
+export function resolveHintConfig(config: { hints?: unknown } | null | undefined): HintConfig {
+  const raw = isObjectRecord(config?.hints) ? config.hints : null;
+  if (!raw || raw.enabled !== true) {
+    return {
+      enabled: false,
+      provider: null,
+      model: null,
+      thinkingLevel: DEFAULT_THINKING_LEVEL,
+      maxRecentRuns: DEFAULT_MAX_RECENT_RUNS,
+      maxCallsPerSession: DEFAULT_MAX_CALLS_PER_SESSION,
+      timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+    };
+  }
+
+  return {
+    enabled: true,
+    provider: trimString(raw.provider),
+    model: trimString(raw.model),
+    thinkingLevel: thinkingLevelFrom(raw.thinkingLevel),
+    maxRecentRuns: clampNumber(
+      raw.maxRecentRuns,
+      DEFAULT_MAX_RECENT_RUNS,
+      MIN_MAX_RECENT_RUNS,
+      MAX_MAX_RECENT_RUNS,
+    ),
+    maxCallsPerSession: clampNumber(
+      raw.maxCallsPerSession,
+      DEFAULT_MAX_CALLS_PER_SESSION,
+      MIN_MAX_CALLS_PER_SESSION,
+      MAX_MAX_CALLS_PER_SESSION,
+    ),
+    timeoutSeconds: clampNumber(
+      raw.timeoutSeconds,
+      DEFAULT_TIMEOUT_SECONDS,
+      MIN_TIMEOUT_SECONDS,
+      MAX_TIMEOUT_SECONDS,
+    ),
+  };
+}
+
+export function isHintConfigReady(config: HintConfig): config is HintConfig & { provider: string; model: string } {
+  return config.enabled && !!config.provider && !!config.model;
+}
+
+function readFileOrEmpty(filePath: string): string {
+  if (!fs.existsSync(filePath)) return "";
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars).trimEnd()}\n[truncated to ${maxChars} chars]`;
+}
+
+function formatMetric(value: number | null, unit: string): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${Number.isInteger(value) ? value : value.toFixed(3)}${unit}`;
+}
+
+function isBetter(value: number, current: number, direction: "lower" | "higher"): boolean {
+  return direction === "lower" ? value < current : value > current;
+}
+
+function findBestMetric(state: HintExperimentState): number | null {
+  let best: number | null = null;
+  for (const run of state.results) {
+    if (run.segment !== state.currentSegment) continue;
+    if (run.status !== "keep" || !Number.isFinite(run.metric) || run.metric <= 0) continue;
+    if (best === null || isBetter(run.metric, best, state.bestDirection)) best = run.metric;
+  }
+  return best;
+}
+
+function formatAsi(asi: Record<string, unknown> | undefined): string {
+  if (!asi) return "";
+  const parts: string[] = [];
+  for (const key of ASI_HINT_KEYS) {
+    const value = asi[key];
+    if (value === undefined) continue;
+    const text = typeof value === "string" ? value : JSON.stringify(value);
+    if (!text || text.trim() === "") continue;
+    parts.push(`${key}: ${truncateText(text.trim(), ASI_VALUE_MAX_CHARS).replace(/\n/g, " ")}`);
+  }
+  return parts.join(" | ");
+}
+
+function formatRun(run: HintRun, index: number, state: HintExperimentState): string {
+  const runNumber = run.run ?? index + 1;
+  const parts = [
+    `#${runNumber}`,
+    run.status,
+    `${state.metricName}=${formatMetric(run.metric, state.metricUnit)}`,
+    run.commit ? `commit=${run.commit}` : "",
+    run.description ? `desc=${run.description}` : "",
+    formatAsi(run.asi),
+  ].filter(Boolean);
+  return `- ${parts.join(" | ")}`;
+}
+
+function section(title: string, body: string): string {
+  const trimmed = body.trim();
+  return trimmed ? `## ${title}\n${trimmed}` : "";
+}
+
+export function buildHintPrompt(input: HintPromptInput): string {
+  const readFile = input.readFile ?? readFileOrEmpty;
+  const state = input.state;
+  const currentRuns = state.results.filter((run) => run.segment === state.currentSegment);
+  const recentRuns = currentRuns.slice(-input.maxRecentRuns);
+  const bestMetric = findBestMetric(state);
+
+  const sessionLines = [
+    `Goal: ${state.name ?? "-"}`,
+    `Metric: ${state.metricName}${state.metricUnit ? ` (${state.metricUnit})` : ""}; ${state.bestDirection} is better`,
+    `Runs in current segment: ${currentRuns.length}`,
+    `Baseline: ${formatMetric(state.bestMetric, state.metricUnit)}`,
+    `Best kept: ${formatMetric(bestMetric, state.metricUnit)}`,
+    state.confidence !== null ? `Confidence: ${state.confidence.toFixed(2)}x noise floor` : "",
+  ].filter(Boolean);
+
+  const recentRunsText = recentRuns.length > 0
+    ? recentRuns.map((run, i) => formatRun(run, state.results.indexOf(run), state)).join("\n")
+    : "No runs yet.";
+
+  const rules = truncateText(readFile(path.join(input.workDir, ".auto", "prompt.md")).trim(), HINT_FILE_MAX_CHARS);
+  const ideas = truncateText(readFile(path.join(input.workDir, ".auto", "ideas.md")).trim(), HINT_FILE_MAX_CHARS);
+  const extraContext = truncateText((input.extraContext ?? "").trim(), EXTRA_CONTEXT_MAX_CHARS);
+
+  return [
+    section("Session", sessionLines.join("\n")),
+    section(`Recent Runs (last ${recentRuns.length})`, recentRunsText),
+    section("Experiment Rules Excerpt", rules),
+    section("Ideas Backlog Excerpt", ideas),
+    section("Current Agent Question", input.question),
+    section("Extra Context From Current Agent", extraContext),
+    section(
+      "Response Contract",
+      [
+        "Give advice only; do not claim to have changed files or run tools.",
+        "Keep it short and actionable.",
+        "Recommend 1-3 next experiments and mention likely failure modes.",
+        "Favor changes that can be validated by the existing benchmark and checks.",
+      ].join("\n"),
+    ),
+  ].filter(Boolean).join("\n\n");
+}
+
+function textFromAssistantMessage(message: AssistantMessage): string {
+  return message.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+function createTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number) {
+  const controller = new AbortController();
+  let timedOut = false;
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  const onAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    didTimeout: () => timedOut,
+    dispose: () => {
+      clearTimeout(timeout);
+      if (signal) signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+export async function requestAutoresearchHint(input: HintRequestInput): Promise<HintRequestResult> {
+  const prompt = buildHintPrompt(input);
+  const timeout = createTimeoutSignal(input.signal, input.timeoutSeconds * 1000);
+  const t0 = Date.now();
+  const completionOptions: SimpleStreamOptions = {
+    apiKey: input.apiKey,
+    headers: input.headers,
+    signal: timeout.signal,
+    reasoning: input.thinkingLevel === "off" ? undefined : input.thinkingLevel,
+  };
+
+  try {
+    const response = await (input.complete ?? completeSimple)(
+      input.model,
+      {
+        systemPrompt: HINT_SYSTEM_PROMPT,
+        messages: [{
+          role: "user",
+          content: prompt,
+          timestamp: Date.now(),
+        }],
+      },
+      completionOptions,
+    );
+
+    if (timeout.didTimeout()) {
+      throw new Error(`Hint model timed out after ${input.timeoutSeconds}s`);
+    }
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "Hint model returned an error");
+    }
+    if (response.stopReason === "aborted") {
+      throw new Error(input.signal?.aborted ? "Hint model call was aborted" : "Hint model call was aborted or timed out");
+    }
+
+    const text = textFromAssistantMessage(response);
+    if (!text) throw new Error("Hint model returned no text");
+
+    return {
+      text,
+      durationMs: Date.now() - t0,
+      promptBytes: Buffer.byteLength(prompt, "utf-8"),
+      stopReason: response.stopReason,
+      usage: response.usage ?? null,
+    };
+  } catch (error) {
+    if (timeout.didTimeout()) {
+      throw new Error(`Hint model timed out after ${input.timeoutSeconds}s`);
+    }
+    if (input.signal?.aborted) {
+      throw new Error("Hint model call was aborted");
+    }
+    throw error;
+  } finally {
+    timeout.dispose();
+  }
+}

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -2654,17 +2654,20 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const dashboardSseClients = new Set<ServerResponse>();
 
   function openInBrowser(url: string): void {
-    if (process.platform === "win32") {
-      spawn("cmd", ["/c", "start", "", url], {
-        detached: true,
-        shell: true,
-        stdio: "ignore",
-      }).unref();
-      return;
-    }
-
-    const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-    spawn(openCmd, [url], { detached: true, stdio: "ignore" }).unref();
+    const child = process.platform === "win32"
+      ? spawn("cmd", ["/c", "start", "", url], {
+          detached: true,
+          shell: true,
+          stdio: "ignore",
+        })
+      : spawn(process.platform === "darwin" ? "open" : "xdg-open", [url], {
+          detached: true,
+          stdio: "ignore",
+        });
+    // Swallow launcher errors (e.g. xdg-open missing); caller prints the URL
+    // so the user can open it manually.
+    child.on("error", () => { /* ignore */ });
+    child.unref();
   }
 
   function stopDashboardServer(): void {

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -28,7 +28,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createServer, type Server, type ServerResponse } from "node:http";
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import { createHash, randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -456,6 +456,7 @@ export interface AutoresearchConfig {
   maxIterations?: number | null;
   maxAutoResumeTurns?: number | null;
   workingDir?: string;
+  allowNoGit?: boolean;
   hints?: unknown;
 }
 
@@ -599,6 +600,70 @@ function validateWorkDir(ctxCwd: string): string | null {
     return `workingDir "${workDir}" (from .auto/config.json) does not exist.`;
   }
   return null;
+}
+
+export interface AutoresearchGitSafetyResult {
+  ok: boolean;
+  workDir: string;
+  gitRoot?: string;
+  allowNoGit: boolean;
+  error?: string;
+  warning?: string;
+}
+
+/**
+ * Autoresearch relies on git for keep/discard safety. Refuse to start or log
+ * experiments outside a git working tree unless the user explicitly opts out.
+ */
+export function validateAutoresearchGitSafety(ctxCwd: string): AutoresearchGitSafetyResult {
+  const config = readConfig(ctxCwd);
+  const workDir = resolveWorkDir(ctxCwd);
+  const allowNoGit = config.allowNoGit === true;
+
+  const workDirError = validateWorkDir(ctxCwd);
+  if (workDirError) {
+    return { ok: false, workDir, allowNoGit, error: workDirError };
+  }
+
+  if (allowNoGit) {
+    return {
+      ok: true,
+      workDir,
+      allowNoGit,
+      warning: "allowNoGit=true: git keep/discard protection is disabled for this autoresearch session.",
+    };
+  }
+
+  const result = spawnSync("git", ["rev-parse", "--is-inside-work-tree", "--show-toplevel"], {
+    cwd: workDir,
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  const combined = `${result.stdout || ""}${result.stderr || ""}`.trim();
+  const lines = String(result.stdout || "").trim().split(/\r?\n/).filter(Boolean);
+
+  if (result.error) {
+    return {
+      ok: false,
+      workDir,
+      allowNoGit,
+      error: `Autoresearch git preflight failed in ${workDir}: ${result.error.message}`,
+    };
+  }
+
+  if (result.status !== 0 || lines[0] !== "true") {
+    return {
+      ok: false,
+      workDir,
+      allowNoGit,
+      error:
+        `Autoresearch requires workingDir to be inside a git working tree so keep/discard can commit or revert safely. ` +
+        `Refusing to run in ${workDir}.${combined ? ` Git said: ${combined.slice(0, 240)}` : ""} ` +
+        `Initialize git or set { "allowNoGit": true } in .auto/config.json only for throwaway sessions.`,
+    };
+  }
+
+  return { ok: true, workDir, gitRoot: lines[1], allowNoGit };
 }
 
 interface ManualOffState {
@@ -1898,6 +1963,14 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         };
       }
 
+      const gitSafety = validateAutoresearchGitSafety(ctx.cwd);
+      if (!gitSafety.ok) {
+        return {
+          content: [{ type: "text", text: `❌ ${gitSafety.error}` }],
+          details: { workDir: gitSafety.workDir, allowNoGit: gitSafety.allowNoGit },
+        };
+      }
+
       const isReinit = state.results.length > 0;
 
       state.name = params.name;
@@ -2015,6 +2088,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return {
           content: [{ type: "text", text: `❌ ${workDirError}` }],
           details: {},
+        };
+      }
+      const gitSafety = validateAutoresearchGitSafety(ctx.cwd);
+      if (!gitSafety.ok) {
+        return {
+          content: [{ type: "text", text: `❌ ${gitSafety.error}` }],
+          details: { workDir: gitSafety.workDir, allowNoGit: gitSafety.allowNoGit },
         };
       }
       const workDir = resolveWorkDir(ctx.cwd);
@@ -2533,6 +2613,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return {
           content: [{ type: "text", text: `❌ ${workDirError}` }],
           details: {},
+        };
+      }
+      const gitSafety = validateAutoresearchGitSafety(ctx.cwd);
+      if (!gitSafety.ok) {
+        return {
+          content: [{ type: "text", text: `❌ ${gitSafety.error}` }],
+          details: { workDir: gitSafety.workDir, allowNoGit: gitSafety.allowNoGit },
         };
       }
       const workDir = resolveWorkDir(ctx.cwd);
@@ -3339,6 +3426,15 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.state.maxExperiments = readMaxExperiments(ctx.cwd);
         runtime.autoResumeTurns = 0;
         configNote = notes.length > 0 ? ` Config: ${notes.join(", ")}.` : "";
+      }
+
+      const gitSafety = validateAutoresearchGitSafety(ctx.cwd);
+      if (!gitSafety.ok) {
+        ctx.ui.notify(`Autoresearch blocked: ${gitSafety.error}`, "error");
+        return;
+      }
+      if (gitSafety.warning) {
+        ctx.ui.notify(`Autoresearch warning: ${gitSafety.warning}`, "info");
       }
 
       if (runtime.autoresearchMode) {

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1126,6 +1126,29 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // Outlasts pi's internal retry (setTimeout 0) and compaction-continue
   // (setTimeout 100); see badlogic/pi-mono#2023, #2110.
   const SETTLED_WINDOW_MS = 800;
+  const STALE_EXTENSION_CONTEXT_MARKER = "extension ctx is stale after session replacement or reload";
+
+  const isStaleExtensionContextError = (error: unknown): boolean =>
+    error instanceof Error && error.message.includes(STALE_EXTENSION_CONTEXT_MARKER);
+
+  const runIgnoringStaleExtensionContext = (run: () => void): void => {
+    try {
+      run();
+    } catch (error) {
+      if (isStaleExtensionContextError(error)) return;
+      throw error;
+    }
+  };
+
+  const runIgnoringStaleExtensionContextAsync = async (run: () => Promise<void>): Promise<void> => {
+    try {
+      await run();
+    } catch (error) {
+      if (isStaleExtensionContextError(error)) return;
+      throw error;
+    }
+  };
+
   const shortcuts = resolveAutoresearchShortcuts();
 
   const dashboardHintVariants = (): string[] => {
@@ -1203,7 +1226,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     pausePendingResume(runtime);
     runtime.pendingResumeMessage = message;
     runtime.pendingResumeTimer = setTimeout(
-      () => sendPendingResumeIfReady(ctx, runtime),
+      () => {
+        runIgnoringStaleExtensionContext(() => sendPendingResumeIfReady(ctx, runtime));
+      },
       SETTLED_WINDOW_MS,
     );
   };
@@ -1230,11 +1255,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   const notifyAutoResumeLimitReached = (ctx: ExtensionContext): void => {
-    const limit = readMaxAutoResumeTurns(ctx.cwd);
-    ctx.ui.notify(
-      `Autoresearch auto-resume limit reached (${limit ?? "unlimited"} turns)`,
-      "info",
-    );
+    runIgnoringStaleExtensionContext(() => {
+      const limit = readMaxAutoResumeTurns(ctx.cwd);
+      ctx.ui.notify(
+        `Autoresearch auto-resume limit reached (${limit ?? "unlimited"} turns)`,
+        "info",
+      );
+    });
   };
 
   const composeResumeMessage = (_ctx: ExtensionContext): string => {
@@ -1330,9 +1357,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   const clearSessionUi = (ctx: ExtensionContext) => {
     clearOverlay();
-    if (ctx.hasUI) {
-      ctx.ui.setWidget("autoresearch", undefined);
-    }
+    runIgnoringStaleExtensionContext(() => {
+      if (ctx.hasUI) {
+        ctx.ui.setWidget("autoresearch", undefined);
+      }
+    });
   };
 
   const autoresearchHelp = () =>
@@ -1437,7 +1466,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   const updateWidget = (ctx: ExtensionContext) => {
-    if (!ctx.hasUI) return;
+    let hasUI = false;
+    runIgnoringStaleExtensionContext(() => {
+      hasUI = ctx.hasUI;
+    });
+    if (!hasUI) return;
 
     const runtime = getRuntime(ctx);
     const state = runtime.state;
@@ -1506,22 +1539,32 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }));
   };
 
-  pi.on("session_start", async (_e, ctx) => reconstructState(ctx));
-  pi.on("session_tree", async (_e, ctx) => reconstructState(ctx));
+  pi.on("session_start", async (_e, ctx) => {
+    await runIgnoringStaleExtensionContextAsync(async () => reconstructState(ctx));
+  });
+  pi.on("session_tree", async (_e, ctx) => {
+    await runIgnoringStaleExtensionContextAsync(async () => reconstructState(ctx));
+  });
   pi.on("session_before_switch", async () => {
     clearOverlay();
   });
   pi.on("session_shutdown", async (_e, ctx) => {
-    clearSessionUi(ctx);
-    cancelPendingResume(getRuntime(ctx));
-    runtimeStore.clear(getSessionKey(ctx));
-    stopDashboardServer();
+    runIgnoringStaleExtensionContext(() => {
+      const sessionKey = getSessionKey(ctx);
+      const runtime = getRuntime(ctx);
+      cancelPendingResume(runtime);
+      clearSessionUi(ctx);
+      runtimeStore.clear(sessionKey);
+      stopDashboardServer();
+    });
   });
 
   pi.on("agent_start", async (_event, ctx) => {
-    const runtime = getRuntime(ctx);
-    runtime.experimentsThisSession = 0;
-    pausePendingResume(runtime);
+    await runIgnoringStaleExtensionContextAsync(async () => {
+      const runtime = getRuntime(ctx);
+      runtime.experimentsThisSession = 0;
+      pausePendingResume(runtime);
+    });
   });
 
   const ensurePendingResume = (
@@ -1543,19 +1586,27 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   };
 
   pi.on("session_before_compact", async (event, ctx) => {
-    pausePendingResume(getRuntime(ctx));
-    return autoresearchCompactionFor(ctx, event);
+    let result: ReturnType<typeof autoresearchCompactionFor> | undefined;
+    await runIgnoringStaleExtensionContextAsync(async () => {
+      pausePendingResume(getRuntime(ctx));
+      result = autoresearchCompactionFor(ctx, event);
+    });
+    return result;
   });
 
   pi.on("session_compact", async (_event, ctx) => {
-    ensurePendingResume(ctx, shouldAutoResumeAfterCompact, composeCompactionResumeMessage);
+    await runIgnoringStaleExtensionContextAsync(async () => {
+      ensurePendingResume(ctx, shouldAutoResumeAfterCompact, composeCompactionResumeMessage);
+    });
   });
 
   pi.on("agent_end", async (_event, ctx) => {
-    const runtime = getRuntime(ctx);
-    runtime.runningExperiment = null;
-    if (overlayTui) overlayTui.requestRender();
-    ensurePendingResume(ctx, shouldAutoResumeAfterTurn);
+    await runIgnoringStaleExtensionContextAsync(async () => {
+      const runtime = getRuntime(ctx);
+      runtime.runningExperiment = null;
+      if (overlayTui) overlayTui.requestRender();
+      ensurePendingResume(ctx, shouldAutoResumeAfterTurn);
+    });
   });
 
   // When in autoresearch mode, add a static note to the system prompt.

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -51,6 +51,11 @@ import {
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
 import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
+import {
+  isHintConfigReady,
+  requestAutoresearchHint,
+  resolveHintConfig,
+} from "./hints.ts";
 import { sessionFilePath, sessionFileCandidates, ensureParentDir, AUTO_DIR } from "./paths.ts";
 
 // ---------------------------------------------------------------------------
@@ -148,6 +153,8 @@ interface LogDetails {
 interface AutoresearchRuntime {
   autoresearchMode: boolean;
   experimentsThisSession: number;
+  hintsThisSession: number;
+  hintInFlight: boolean;
   autoResumeTurns: number;
   lastRunChecks: { pass: boolean; output: string; duration: number } | null;
   lastRunDuration: number | null;
@@ -177,6 +184,20 @@ const RunParams = Type.Object({
     Type.Number({
       description:
         "Kill .auto/checks.sh after this many seconds (default: 300). Only relevant when the checks file exists.",
+    })
+  ),
+});
+
+const HintParams = Type.Object({
+  question: Type.String({
+    minLength: 1,
+    description:
+      "Focused question for the configured larger hint model. Ask for strategy help, not code execution.",
+  }),
+  extra_context: Type.Optional(
+    Type.String({
+      description:
+        "Optional short context from the current agent. Do not include secrets, raw logs, or large file dumps.",
     })
   ),
 });
@@ -435,6 +456,7 @@ export interface AutoresearchConfig {
   maxIterations?: number | null;
   maxAutoResumeTurns?: number | null;
   workingDir?: string;
+  hints?: unknown;
 }
 
 export interface InferredAutoresearchConfig {
@@ -781,6 +803,8 @@ function createSessionRuntime(): AutoresearchRuntime {
   return {
     autoresearchMode: false,
     experimentsThisSession: 0,
+    hintsThisSession: 0,
+    hintInFlight: false,
     autoResumeTurns: 0,
     lastRunChecks: null,
     lastRunDuration: null,
@@ -1393,6 +1417,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     runtime.lastRunDuration = null;
     runtime.runningExperiment = null;
     runtime.experimentsThisSession = 0;
+    runtime.hintsThisSession = 0;
+    runtime.hintInFlight = false;
     runtime.autoResumeTurns = 0;
     runtime.state = createExperimentState();
 
@@ -1646,9 +1672,199 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       extra += `\n\n💡 Ideas backlog exists at ${ideasPath} — check it for promising experiment paths. Prune stale entries.`;
     }
 
+    const hintConfig = resolveHintConfig(readConfig(ctx.cwd));
+    if (isHintConfigReady(hintConfig)) {
+      extra +=
+        "\n\n## Autoresearch Hints (ACTIVE)" +
+        `\nask_autoresearch_hint is configured for ${hintConfig.provider}/${hintConfig.model}.` +
+        "\nUse ask_autoresearch_hint only after repeated discards/crashes, stalled progress, or unclear next hypotheses." +
+        "\nAsk one focused question. Treat the response as advisory, then validate any suggestion with run_experiment and log_experiment.";
+    }
+
     return {
       systemPrompt: event.systemPrompt + extra,
     };
+  });
+
+  // -----------------------------------------------------------------------
+  // ask_autoresearch_hint tool — optional side-channel strategy advice
+  // -----------------------------------------------------------------------
+
+  registerGatedTool({
+    name: "ask_autoresearch_hint",
+    label: "Ask Hint",
+    description:
+      "Ask the configured larger model for concise autoresearch strategy advice. Side-effect free and disabled unless .auto/config.json enables hints.",
+    parameters: HintParams,
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const runtime = getRuntime(ctx);
+      const question = params.question.trim();
+      if (!question) {
+        return {
+          content: [{ type: "text", text: "Hint unavailable: question must not be empty." }],
+          details: {},
+        };
+      }
+
+      const workDirError = validateWorkDir(ctx.cwd);
+      if (workDirError) {
+        return {
+          content: [{ type: "text", text: `Hint unavailable: ${workDirError}` }],
+          details: {},
+        };
+      }
+
+      const config = resolveHintConfig(readConfig(ctx.cwd));
+      if (!config.enabled) {
+        return {
+          content: [{
+            type: "text",
+            text: "Hint unavailable: hints are disabled. Set hints.enabled=true in .auto/config.json to allow expensive model calls."
+          }],
+          details: { enabled: false },
+        };
+      }
+
+      if (!isHintConfigReady(config)) {
+        return {
+          content: [{
+            type: "text",
+            text: "Hint unavailable: hints.enabled is true, but hints.provider and hints.model must both be set in .auto/config.json."
+          }],
+          details: { enabled: true, provider: config.provider, model: config.model },
+        };
+      }
+
+      if (runtime.hintInFlight) {
+        return {
+          content: [{ type: "text", text: "Hint unavailable: another hint request is already in flight." }],
+          details: { inFlight: true },
+        };
+      }
+
+      if (runtime.hintsThisSession >= config.maxCallsPerSession) {
+        return {
+          content: [{
+            type: "text",
+            text: `Hint unavailable: maxCallsPerSession reached (${config.maxCallsPerSession}). Continue with local experiments or raise the limit deliberately.`,
+          }],
+          details: {
+            hintsThisSession: runtime.hintsThisSession,
+            maxCallsPerSession: config.maxCallsPerSession,
+          },
+        };
+      }
+
+      const modelRegistry = ctx.modelRegistry;
+      if (!modelRegistry?.find || !modelRegistry?.getApiKeyAndHeaders) {
+        return {
+          content: [{
+            type: "text",
+            text: "Hint unavailable: this pi version does not expose modelRegistry.find/getApiKeyAndHeaders to extensions.",
+          }],
+          details: {},
+        };
+      }
+
+      const model = modelRegistry.find(config.provider, config.model);
+      if (!model) {
+        return {
+          content: [{
+            type: "text",
+            text: `Hint unavailable: model ${config.provider}/${config.model} was not found in pi's model registry.`,
+          }],
+          details: { provider: config.provider, model: config.model },
+        };
+      }
+
+      const workDir = resolveWorkDir(ctx.cwd);
+      runtime.hintInFlight = true;
+
+      try {
+        const auth = await modelRegistry.getApiKeyAndHeaders(model);
+        if (!auth.ok) {
+          return {
+            content: [{
+              type: "text",
+              text: `Hint unavailable: no usable auth for ${config.provider}/${config.model}: ${auth.error}`,
+            }],
+            details: { provider: config.provider, model: config.model },
+          };
+        }
+
+        runtime.hintsThisSession++;
+        const hint = await requestAutoresearchHint({
+          state: runtime.state,
+          workDir,
+          question,
+          extraContext: params.extra_context,
+          maxRecentRuns: config.maxRecentRuns,
+          model,
+          apiKey: auth.apiKey,
+          headers: auth.headers,
+          thinkingLevel: config.thinkingLevel,
+          timeoutSeconds: config.timeoutSeconds,
+          signal,
+        });
+
+        const callsRemaining = Math.max(0, config.maxCallsPerSession - runtime.hintsThisSession);
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Hint from ${config.provider}/${config.model}:\n\n${hint.text}` +
+              "\n\nValidate any suggestion with run_experiment and log_experiment before keeping changes.",
+          }],
+          details: {
+            provider: config.provider,
+            model: config.model,
+            durationMs: hint.durationMs,
+            promptBytes: hint.promptBytes,
+            stopReason: hint.stopReason,
+            usage: hint.usage,
+            hintsThisSession: runtime.hintsThisSession,
+            callsRemaining,
+          },
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text",
+            text: `Hint unavailable: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          details: {
+            provider: config.provider,
+            model: config.model,
+            hintsThisSession: runtime.hintsThisSession,
+          },
+        };
+      } finally {
+        runtime.hintInFlight = false;
+      }
+    },
+
+    renderCall(args, theme) {
+      let text = theme.fg("toolTitle", theme.bold("ask_autoresearch_hint "));
+      text += theme.fg("muted", args.question ?? "");
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const output = result.content[0]?.type === "text" ? result.content[0].text : "";
+      const details = result.details as { provider?: string; model?: string; durationMs?: number } | undefined;
+      if (details?.provider && details?.model && details?.durationMs !== undefined) {
+        return new Text(
+          theme.fg("accent", `hint ${details.provider}/${details.model} `) +
+            theme.fg("dim", `${(details.durationMs / 1000).toFixed(1)}s`) +
+            "\n" +
+            output,
+          0,
+          0,
+        );
+      }
+      return new Text(output, 0, 0);
+    },
   });
 
   // -----------------------------------------------------------------------
@@ -3054,6 +3270,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
+        runtime.hintsThisSession = 0;
+        runtime.hintInFlight = false;
         runtime.lastRunChecks = null;
         runtime.lastRunDuration = null;
         runtime.runningExperiment = null;
@@ -3080,6 +3298,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
+        runtime.hintsThisSession = 0;
+        runtime.hintInFlight = false;
         runtime.lastRunChecks = null;
         runtime.lastRunDuration = null;
         runtime.runningExperiment = null;

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -19,7 +19,7 @@ import type {
   SessionBeforeCompactEvent,
   Theme,
 } from "@earendil-works/pi-coding-agent";
-import { truncateTail, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
+import { truncateTail, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Text, truncateToWidth, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
@@ -30,7 +30,7 @@ import { createServer, type Server, type ServerResponse } from "node:http";
 
 import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 
 import {
@@ -577,6 +577,57 @@ function validateWorkDir(ctxCwd: string): string | null {
     return `workingDir "${workDir}" (from .auto/config.json) does not exist.`;
   }
   return null;
+}
+
+interface ManualOffState {
+  manualOff: boolean;
+  cwd: string;
+  workDir: string;
+  updatedAt: number;
+}
+
+function manualOffStatePath(ctxCwd: string, workDir: string): string {
+  const key = createHash("sha256")
+    .update(JSON.stringify({ cwd: path.resolve(ctxCwd), workDir: path.resolve(workDir) }))
+    .digest("hex")
+    .slice(0, 32);
+  return path.join(getAgentDir(), "autoresearch", "state", `${key}.json`);
+}
+
+function isManuallyOff(ctxCwd: string, workDir: string): boolean {
+  try {
+    const statePath = manualOffStatePath(ctxCwd, workDir);
+    if (!fs.existsSync(statePath)) return false;
+    const state = JSON.parse(fs.readFileSync(statePath, "utf-8")) as Partial<ManualOffState>;
+    return state.manualOff === true;
+  } catch {
+    return false;
+  }
+}
+
+function setManualOff(ctxCwd: string, workDir: string): void {
+  try {
+    const statePath = manualOffStatePath(ctxCwd, workDir);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    const state: ManualOffState = {
+      manualOff: true,
+      cwd: path.resolve(ctxCwd),
+      workDir: path.resolve(workDir),
+      updatedAt: Date.now(),
+    };
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+  } catch {
+    // Best effort only — the current runtime is still switched off.
+  }
+}
+
+function clearManualOff(ctxCwd: string, workDir: string): void {
+  try {
+    const statePath = manualOffStatePath(ctxCwd, workDir);
+    if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+  } catch {
+    // Best effort only — failure should not block explicit activation.
+  }
 }
 
 /** Baseline = first experiment in current segment */
@@ -1378,8 +1429,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     // Read max experiments from config file
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
-    // Auto-enter autoresearch mode only when a persisted experiment log exists
-    setAutoresearchMode(ctx, fs.existsSync(autoresearchJsonlPath(workDir)));
+    // Auto-enter autoresearch mode only when a persisted experiment log exists,
+    // unless the user explicitly disabled it with `/autoresearch off`.
+    setAutoresearchMode(ctx, fs.existsSync(autoresearchJsonlPath(workDir)) && !isManuallyOff(ctx.cwd, workDir));
 
     updateWidget(ctx);
   };
@@ -1389,6 +1441,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     const runtime = getRuntime(ctx);
     const state = runtime.state;
+
+    if (!runtime.autoresearchMode && !runtime.runningExperiment) {
+      ctx.ui.setWidget("autoresearch", undefined);
+      return;
+    }
 
     if (state.results.length === 0) {
       if (!runtime.runningExperiment) {
@@ -1624,6 +1681,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       const wasInactive = !runtime.autoresearchMode;
       setAutoresearchMode(ctx, true);
+      clearManualOff(ctx.cwd, workDir);
       updateWidget(ctx);
 
       if (wasInactive) {
@@ -2949,6 +3007,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.lastRunDuration = null;
         runtime.runningExperiment = null;
         cancelPendingResume(runtime);
+        setManualOff(ctx.cwd, resolveWorkDir(ctx.cwd));
         stopDashboardServer();
         clearSessionUi(ctx);
         if (wasRunning) ctx.abort();
@@ -2975,6 +3034,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         runtime.runningExperiment = null;
         cancelPendingResume(runtime);
         runtime.state = createExperimentState();
+        clearManualOff(ctx.cwd, resolveWorkDir(ctx.cwd));
         stopDashboardServer();
         updateWidget(ctx);
 
@@ -3021,6 +3081,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       runtime.autoResumeTurns = 0;
 
       const workDir = resolveWorkDir(ctx.cwd);
+      clearManualOff(ctx.cwd, workDir);
       const rulesLoaded = hasAutoresearchRules(ctx);
       // No .auto/prompt.md yet — load the create skill so the agent follows the
       // setup guidelines. `/skill:<name>` is expanded to the full SKILL.md by

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -60,6 +60,12 @@ const EXPERIMENT_MAX_LINES = 10;
 const EXPERIMENT_MAX_BYTES = 4 * 1024; // 4KB
 
 // ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_MAX_AUTORESUME_TURNS = 20;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -425,13 +431,20 @@ function currentResults(results: ExperimentResult[], segment: number): Experimen
   return results.filter((r) => r.segment === segment);
 }
 
-interface AutoresearchConfig {
-  maxIterations?: number;
+export interface AutoresearchConfig {
+  maxIterations?: number | null;
+  maxAutoResumeTurns?: number | null;
   workingDir?: string;
 }
 
+export interface InferredAutoresearchConfig {
+  maxIterations?: number;
+  clearMaxIterations?: boolean;
+  maxAutoResumeTurns?: number | null;
+}
+
 /** Read the config file (.auto/config.json, legacy autoresearch.config.json) from the given directory (always ctx.cwd) */
-function readConfig(cwd: string): AutoresearchConfig {
+export function readConfig(cwd: string): AutoresearchConfig {
   try {
     const configPath = autoresearchConfigPath(cwd);
     if (!fs.existsSync(configPath)) return {};
@@ -442,11 +455,97 @@ function readConfig(cwd: string): AutoresearchConfig {
 }
 
 /** Read maxExperiments from the config file (if it exists) */
-function readMaxExperiments(cwd: string): number | null {
+export function readMaxExperiments(cwd: string): number | null {
   const config = readConfig(cwd);
   return (typeof config.maxIterations === "number" && config.maxIterations > 0)
     ? Math.floor(config.maxIterations)
     : null;
+}
+
+/**
+ * Read the auto-resume safety valve from autoresearch.config.json.
+ * Undefined preserves the conservative default. null or 0 means unlimited.
+ */
+export function readMaxAutoResumeTurns(cwd: string): number | null {
+  const config = readConfig(cwd);
+  if (config.maxAutoResumeTurns === null || config.maxAutoResumeTurns === 0) return null;
+  return (typeof config.maxAutoResumeTurns === "number" && config.maxAutoResumeTurns > 0)
+    ? Math.floor(config.maxAutoResumeTurns)
+    : DEFAULT_MAX_AUTORESUME_TURNS;
+}
+
+function parsePositiveInteger(value: string): number | null {
+  const parsed = Number.parseInt(value.replace(/[,_]/g, ""), 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/** Infer loop controls from natural-language `/autoresearch ...` arguments. */
+export function inferAutoresearchConfigFromPrompt(prompt: string): InferredAutoresearchConfig | null {
+  const text = prompt
+    .toLowerCase()
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return null;
+
+  const inferred: InferredAutoresearchConfig = {};
+
+  const autoResumeMatch = text.match(
+    /\b(?:for|after|limit(?:ed)?(?: to)?|stop after|only)?\s*(\d[\d,_]*)\s*(?:auto[- ]?resumes?|auto[- ]?resume turns?|resume turns?)\b/,
+  );
+  if (autoResumeMatch) {
+    const count = parsePositiveInteger(autoResumeMatch[1]);
+    if (count !== null) inferred.maxAutoResumeTurns = count;
+  }
+
+  const runMatch = text.match(
+    /\b(?:for|after|limit(?:ed)?(?: to)?|stop after|only)\s+(\d[\d,_]*)\s+(?:runs?|iterations?|experiments?)\b/,
+  );
+  if (runMatch) {
+    const count = parsePositiveInteger(runMatch[1]);
+    if (count !== null) {
+      inferred.maxIterations = count;
+      if (inferred.maxAutoResumeTurns === undefined) inferred.maxAutoResumeTurns = count;
+    }
+  }
+
+  const wantsUnlimited =
+    /\b(?:run|continue|resume|loop)\s+(?:indefinitely|infinite(?:ly)?|forever|without stopping)\b/.test(text) ||
+    /\b(?:indefinitely|forever)\s+(?:run|continue|resume|loop)\b/.test(text) ||
+    /\bunlimited\s+auto[- ]?resume\b/.test(text) ||
+    /\b(?:no|without)\s+(?:auto[- ]?resume\s+)?limits?\b/.test(text) ||
+    /\bnever\s+stopp?ing?\b/.test(text) ||
+    /\bdon'?t\s+stop\b/.test(text);
+
+  if (wantsUnlimited) {
+    inferred.maxAutoResumeTurns = null;
+    if (inferred.maxIterations === undefined) inferred.clearMaxIterations = true;
+  }
+
+  return Object.keys(inferred).length > 0 ? inferred : null;
+}
+
+export function applyInferredAutoresearchConfig(cwd: string, inferred: InferredAutoresearchConfig): string[] {
+  const configPath = autoresearchConfigPath(cwd);
+  const config = readConfig(cwd);
+  const notes: string[] = [];
+
+  if (inferred.clearMaxIterations) {
+    delete config.maxIterations;
+    notes.push("maxIterations=unlimited");
+  }
+  if (inferred.maxIterations !== undefined) {
+    config.maxIterations = inferred.maxIterations;
+    notes.push(`maxIterations=${inferred.maxIterations}`);
+  }
+  if (inferred.maxAutoResumeTurns !== undefined) {
+    config.maxAutoResumeTurns = inferred.maxAutoResumeTurns;
+    notes.push(`maxAutoResumeTurns=${inferred.maxAutoResumeTurns === null ? "unlimited" : inferred.maxAutoResumeTurns}`);
+  }
+
+  ensureParentDir(configPath);
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  return notes;
 }
 
 /**
@@ -970,7 +1069,6 @@ function renderDashboardLines(
 // ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
-  const MAX_AUTORESUME_TURNS = 20;
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
 
@@ -1039,7 +1137,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!isAgentSettled(ctx)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    if (hasReachedAutoResumeLimit(ctx, runtime)) {
       cancelPendingResume(runtime);
       notifyAutoResumeLimitReached(ctx);
       return;
@@ -1075,12 +1173,15 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const shouldAutoResumeAfterCompact = (runtime: AutoresearchRuntime): boolean =>
     runtime.autoresearchMode;
 
-  const hasReachedAutoResumeLimit = (runtime: AutoresearchRuntime): boolean =>
-    runtime.autoResumeTurns >= MAX_AUTORESUME_TURNS;
+  const hasReachedAutoResumeLimit = (ctx: ExtensionContext, runtime: AutoresearchRuntime): boolean => {
+    const limit = readMaxAutoResumeTurns(ctx.cwd);
+    return limit !== null && runtime.autoResumeTurns >= limit;
+  };
 
   const notifyAutoResumeLimitReached = (ctx: ExtensionContext): void => {
+    const limit = readMaxAutoResumeTurns(ctx.cwd);
     ctx.ui.notify(
-      `Autoresearch auto-resume limit reached (${MAX_AUTORESUME_TURNS} turns)`,
+      `Autoresearch auto-resume limit reached (${limit ?? "unlimited"} turns)`,
       "info",
     );
   };
@@ -1196,6 +1297,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "Examples:",
       "  /autoresearch optimize unit test runtime, monitor correctness",
       "  /autoresearch model training, run 5 minutes of train.py and note the loss ratio as optimization target",
+      "  /autoresearch optimize bundle size for 50 runs",
+      "  /autoresearch continue indefinitely and never stop",
       "  /autoresearch export",
     ].join("\n");
 
@@ -1375,7 +1478,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!gate(runtime)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    if (hasReachedAutoResumeLimit(ctx, runtime)) {
       notifyAutoResumeLimitReached(ctx);
       return;
     }
@@ -2898,8 +3001,19 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return;
       }
 
+      const inferredConfig = inferAutoresearchConfigFromPrompt(trimmedArgs);
+      let configNote = "";
+      if (inferredConfig) {
+        const notes = applyInferredAutoresearchConfig(ctx.cwd, inferredConfig);
+        runtime.state.maxExperiments = readMaxExperiments(ctx.cwd);
+        runtime.autoResumeTurns = 0;
+        configNote = notes.length > 0 ? ` Config: ${notes.join(", ")}.` : "";
+      }
+
       if (runtime.autoresearchMode) {
-        ctx.ui.notify("Autoresearch already active — use '/autoresearch off' to stop first", "info");
+        const resume = `Autoresearch mode already active.${configNote} ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`;
+        ctx.ui.notify(`Autoresearch mode already active.${configNote}`, "info");
+        sendWhenReady(ctx, resume);
         return;
       }
 
@@ -2914,13 +3028,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       // are appended as the session goal. Must be sent as its own message that
       // STARTS with `/skill:` so expansion triggers — don't prepend hook output.
       const kickoff = rulesLoaded
-        ? `Autoresearch mode active. ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`
-        : `/skill:autoresearch-create ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`.replace(/\s+/g, " ").trim();
+        ? `Autoresearch mode active.${configNote} ${trimmedArgs} ${BENCHMARK_GUARDRAIL}`
+        : `/skill:autoresearch-create ${trimmedArgs} ${configNote} ${BENCHMARK_GUARDRAIL}`.replace(/\s+/g, " ").trim();
 
       ctx.ui.notify(
         rulesLoaded
-          ? "Autoresearch mode ON — rules loaded from .auto/prompt.md"
-          : "Autoresearch mode ON — no .auto/prompt.md found, loading autoresearch-create skill",
+          ? `Autoresearch mode ON — rules loaded from .auto/prompt.md${configNote}`
+          : `Autoresearch mode ON — no .auto/prompt.md found, loading autoresearch-create skill${configNote}`,
         "info",
       );
 

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -102,14 +102,18 @@ Use `log_experiment`'s `asi` parameter to annotate each run with **whatever woul
 JSON config file that lives in `.auto/` under the pi session's working directory (`ctx.cwd`). Supported fields:
 
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
+- **`maxAutoResumeTurns`** (number or null) — maximum automatic resume prompts before the safety valve stops the loop. Defaults to 20. Set to `null` or `0` for intentional unlimited auto-resume.
 - **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`.auto/log.jsonl`, `.auto/prompt.md`, `.auto/measure.sh`, `.auto/checks.sh`, `.auto/ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays under `ctx.cwd`. Fails if the directory doesn't exist.
 
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "maxAutoResumeTurns": 50
 }
 ```
+
+The `/autoresearch` command also understands common natural-language loop controls and writes this config automatically. Phrases like “for 50 runs” set `maxIterations` and the auto-resume budget; phrases like “run forever”, “continue indefinitely”, or “never stop” set unlimited auto-resume and remove the experiment cap.
 
 ### `.auto/checks.sh` (optional)
 

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -104,6 +104,7 @@ JSON config file that lives in `.auto/` under the pi session's working directory
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
 - **`maxAutoResumeTurns`** (number or null) — maximum automatic resume prompts before the safety valve stops the loop. Defaults to 20. Set to `null` or `0` for intentional unlimited auto-resume.
 - **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`.auto/log.jsonl`, `.auto/prompt.md`, `.auto/measure.sh`, `.auto/checks.sh`, `.auto/ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays under `ctx.cwd`. Fails if the directory doesn't exist.
+- **`hints`** (object) — optional expensive-model hint tool config. Do not create this by default. Only add it when the user explicitly wants `ask_autoresearch_hint` to call a configured larger pi model for advisory strategy help.
 
 ```json
 {
@@ -114,6 +115,22 @@ JSON config file that lives in `.auto/` under the pi session's working directory
 ```
 
 The `/autoresearch` command also understands common natural-language loop controls and writes this config automatically. Phrases like “for 50 runs” set `maxIterations` and the auto-resume budget; phrases like “run forever”, “continue indefinitely”, or “never stop” set unlimited auto-resume and remove the experiment cap.
+
+When the user explicitly wants the hint tool, add:
+
+```json
+{
+  "hints": {
+    "enabled": true,
+    "provider": "anthropic",
+    "model": "claude-opus-4-5",
+    "thinkingLevel": "high",
+    "maxRecentRuns": 8,
+    "maxCallsPerSession": 5,
+    "timeoutSeconds": 120
+  }
+}
+```
 
 ### `.auto/checks.sh` (optional)
 

--- a/skills/autoresearch-create/SKILL.md
+++ b/skills/autoresearch-create/SKILL.md
@@ -32,10 +32,11 @@ All session files live in a single `.auto/` subfolder at the working directory r
 ## Setup
 
 1. Ask (or infer): **Goal**, **Command**, **Metric** (+ direction), **Files in scope**, **Constraints**.
-2. `git checkout -b autoresearch/<goal>-<date>`
-3. Read the source files. Understand the workload deeply before writing anything.
-4. `mkdir -p .auto`, then write `.auto/prompt.md` and `.auto/measure.sh` (see below). Commit both.
-5. `init_experiment` → run baseline → `log_experiment` → start looping immediately.
+2. Verify the effective working directory is inside git: `git rev-parse --is-inside-work-tree`. If not, stop and ask the user to initialize git or explicitly set `allowNoGit: true` for a throwaway session.
+3. `git checkout -b autoresearch/<goal>-<date>`
+4. Read the source files. Understand the workload deeply before writing anything.
+5. `mkdir -p .auto`, then write `.auto/prompt.md` and `.auto/measure.sh` (see below). Commit both.
+6. `init_experiment` → run baseline → `log_experiment` → start looping immediately.
 
 ### `.auto/prompt.md`
 
@@ -104,13 +105,15 @@ JSON config file that lives in `.auto/` under the pi session's working directory
 - **`maxIterations`** (number) — maximum experiments before auto-stopping.
 - **`maxAutoResumeTurns`** (number or null) — maximum automatic resume prompts before the safety valve stops the loop. Defaults to 20. Set to `null` or `0` for intentional unlimited auto-resume.
 - **`workingDir`** (string) — override the directory for all autoresearch operations: file I/O (`.auto/log.jsonl`, `.auto/prompt.md`, `.auto/measure.sh`, `.auto/checks.sh`, `.auto/ideas.md`), command execution, and git operations. Supports absolute paths or relative paths (resolved against `ctx.cwd`). The config file itself always stays under `ctx.cwd`. Fails if the directory doesn't exist.
+- **`allowNoGit`** (boolean) — defaults to `false`. The extension refuses to start or log experiments unless `workingDir` is inside a git working tree, because keep/discard needs commit/revert protection. Set to `true` only for disposable throwaway sessions after explicit user approval.
 - **`hints`** (object) — optional expensive-model hint tool config. Do not create this by default. Only add it when the user explicitly wants `ask_autoresearch_hint` to call a configured larger pi model for advisory strategy help.
 
 ```json
 {
   "workingDir": "/path/to/project",
   "maxIterations": 50,
-  "maxAutoResumeTurns": 50
+  "maxAutoResumeTurns": 50,
+  "allowNoGit": false
 }
 ```
 

--- a/tests/autoresume-config.test.mjs
+++ b/tests/autoresume-config.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  applyInferredAutoresearchConfig,
+  DEFAULT_MAX_AUTORESUME_TURNS,
+  inferAutoresearchConfigFromPrompt,
+  readMaxAutoResumeTurns,
+  readMaxExperiments,
+} from "../extensions/pi-autoresearch/index.ts";
+
+test("auto-resume defaults to the conservative built-in safety valve", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    assert.equal(readMaxAutoResumeTurns(dir), DEFAULT_MAX_AUTORESUME_TURNS);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("auto-resume config supports finite and unlimited values", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    const autoDir = join(dir, ".auto");
+    const configPath = join(autoDir, "config.json");
+    await mkdir(autoDir, { recursive: true });
+
+    await writeFile(configPath, JSON.stringify({ maxAutoResumeTurns: 75 }));
+    assert.equal(readMaxAutoResumeTurns(dir), 75);
+
+    await writeFile(configPath, JSON.stringify({ maxAutoResumeTurns: null }));
+    assert.equal(readMaxAutoResumeTurns(dir), null);
+
+    await writeFile(configPath, JSON.stringify({ maxAutoResumeTurns: 0 }));
+    assert.equal(readMaxAutoResumeTurns(dir), null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("natural-language run counts configure experiment and auto-resume budgets", () => {
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("optimize bundle size for 50 runs"), {
+    maxIterations: 50,
+    maxAutoResumeTurns: 50,
+  });
+
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("continue for 1,000 experiments"), {
+    maxIterations: 1000,
+    maxAutoResumeTurns: 1000,
+  });
+});
+
+test("natural-language resume counts configure only the auto-resume budget", () => {
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("continue for 80 auto-resume turns"), {
+    maxAutoResumeTurns: 80,
+  });
+});
+
+test("natural-language unlimited phrases remove caps and allow indefinite auto-resume", () => {
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("continue indefinitely and never stop"), {
+    clearMaxIterations: true,
+    maxAutoResumeTurns: null,
+  });
+
+  assert.deepEqual(inferAutoresearchConfigFromPrompt("run forever for 25 runs"), {
+    maxIterations: 25,
+    maxAutoResumeTurns: null,
+  });
+});
+
+test("natural-language parser avoids unrelated durations and product words", () => {
+  assert.equal(
+    inferAutoresearchConfigFromPrompt("model training, run 5 minutes of train.py"),
+    null,
+  );
+  assert.equal(
+    inferAutoresearchConfigFromPrompt("optimize infinite scroll performance"),
+    null,
+  );
+});
+
+test("applying inferred config preserves unrelated fields", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-config-"));
+  try {
+    await mkdir(join(dir, ".auto"), { recursive: true });
+    await writeFile(
+      join(dir, ".auto", "config.json"),
+      JSON.stringify({ workingDir: "../project", maxIterations: 10 }),
+    );
+
+    const notes = applyInferredAutoresearchConfig(dir, {
+      clearMaxIterations: true,
+      maxAutoResumeTurns: null,
+    });
+
+    assert.deepEqual(notes, ["maxIterations=unlimited", "maxAutoResumeTurns=unlimited"]);
+    assert.equal(readMaxExperiments(dir), null);
+    assert.equal(readMaxAutoResumeTurns(dir), null);
+    assert.deepEqual(JSON.parse(await readFile(join(dir, ".auto", "config.json"), "utf-8")), {
+      workingDir: "../project",
+      maxAutoResumeTurns: null,
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/git-safety.test.mjs
+++ b/tests/git-safety.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { validateAutoresearchGitSafety } from "../extensions/pi-autoresearch/index.ts";
+
+test("git safety preflight blocks autoresearch outside a git work tree", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-git-"));
+  try {
+    const result = validateAutoresearchGitSafety(dir);
+    assert.equal(result.ok, false);
+    assert.equal(result.allowNoGit, false);
+    assert.match(result.error ?? "", /requires workingDir to be inside a git working tree/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("git safety preflight allows explicit throwaway no-git sessions", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-git-"));
+  try {
+    await mkdir(join(dir, ".auto"), { recursive: true });
+    await writeFile(join(dir, ".auto", "config.json"), JSON.stringify({ allowNoGit: true }));
+
+    const result = validateAutoresearchGitSafety(dir);
+    assert.equal(result.ok, true);
+    assert.equal(result.allowNoGit, true);
+    assert.match(result.warning ?? "", /git keep\/discard protection is disabled/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("git safety preflight accepts nested directories inside a git work tree", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-autoresearch-git-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    await mkdir(join(dir, "packages", "demo"), { recursive: true });
+    await mkdir(join(dir, ".auto"), { recursive: true });
+    await writeFile(join(dir, ".auto", "config.json"), JSON.stringify({ workingDir: "packages/demo" }));
+
+    const result = validateAutoresearchGitSafety(dir);
+    assert.equal(result.ok, true);
+    assert.equal(result.allowNoGit, false);
+    assert.equal(result.gitRoot, await realpath(dir));
+    assert.equal(await realpath(result.workDir), await realpath(join(dir, "packages", "demo")));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/hints.test.mjs
+++ b/tests/hints.test.mjs
@@ -1,0 +1,300 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import test from "node:test";
+import { tmpdir } from "node:os";
+
+import {
+  buildHintPrompt,
+  isHintConfigReady,
+  requestAutoresearchHint,
+  resolveHintConfig,
+} from "../extensions/pi-autoresearch/hints.ts";
+import autoresearchExtension from "../extensions/pi-autoresearch/index.ts";
+
+function sampleState() {
+  return {
+    name: "Speed up parser",
+    metricName: "total_ms",
+    metricUnit: "ms",
+    bestDirection: "lower",
+    bestMetric: 100,
+    currentSegment: 0,
+    confidence: 1.5,
+    results: [
+      {
+        commit: "aaa1111",
+        metric: 100,
+        metrics: {},
+        status: "keep",
+        description: "baseline",
+        timestamp: 1,
+        segment: 0,
+        confidence: null,
+        asi: { hypothesis: "baseline" },
+      },
+      {
+        commit: "bbb2222",
+        metric: 130,
+        metrics: {},
+        status: "discard",
+        description: "inline everything",
+        timestamp: 2,
+        segment: 0,
+        confidence: 1.5,
+        asi: {
+          hypothesis: "inline hot parser path",
+          rollback_reason: "larger function hurt optimizer",
+          next_action_hint: "try cache shape metadata",
+        },
+      },
+    ],
+  };
+}
+
+test("hint config defaults to disabled", () => {
+  const config = resolveHintConfig({});
+
+  assert.equal(config.enabled, false);
+  assert.equal(config.provider, null);
+  assert.equal(config.model, null);
+  assert.equal(config.thinkingLevel, "high");
+  assert.equal(config.maxRecentRuns, 8);
+  assert.equal(config.maxCallsPerSession, 5);
+  assert.equal(config.timeoutSeconds, 120);
+  assert.equal(isHintConfigReady(config), false);
+});
+
+test("hint config accepts enabled provider/model and clamps numeric limits", () => {
+  const config = resolveHintConfig({
+    hints: {
+      enabled: true,
+      provider: " anthropic ",
+      model: " claude-opus ",
+      thinkingLevel: "xhigh",
+      maxRecentRuns: 100,
+      maxCallsPerSession: 0,
+      timeoutSeconds: 2,
+    },
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.provider, "anthropic");
+  assert.equal(config.model, "claude-opus");
+  assert.equal(config.thinkingLevel, "xhigh");
+  assert.equal(config.maxRecentRuns, 20);
+  assert.equal(config.maxCallsPerSession, 1);
+  assert.equal(config.timeoutSeconds, 10);
+  assert.equal(isHintConfigReady(config), true);
+});
+
+test("hint config falls back on invalid thinking level and incomplete model config", () => {
+  const config = resolveHintConfig({
+    hints: {
+      enabled: true,
+      provider: "",
+      model: "claude",
+      thinkingLevel: "surprise",
+    },
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.provider, null);
+  assert.equal(config.model, "claude");
+  assert.equal(config.thinkingLevel, "high");
+  assert.equal(isHintConfigReady(config), false);
+});
+
+test("hint prompt includes bounded session, recent runs, rules, ideas, and question", () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  try {
+    fs.mkdirSync(path.join(workDir, ".auto"), { recursive: true });
+    fs.writeFileSync(path.join(workDir, ".auto", "prompt.md"), `# Rules\n${"A".repeat(4000)}`);
+    fs.writeFileSync(path.join(workDir, ".auto", "ideas.md"), "- try memoization\n- try batching");
+
+    const prompt = buildHintPrompt({
+      state: sampleState(),
+      workDir,
+      question: "We have two discards; what should we try next?",
+      extraContext: "Focus on low-risk parser optimizations.",
+      maxRecentRuns: 1,
+    });
+
+    assert.match(prompt, /Goal: Speed up parser/);
+    assert.match(prompt, /Metric: total_ms \(ms\); lower is better/);
+    assert.doesNotMatch(prompt, /#1 \| keep/);
+    assert.match(prompt, /#2 \| discard \| total_ms=130ms/);
+    assert.match(prompt, /rollback_reason: larger function hurt optimizer/);
+    assert.match(prompt, /try memoization/);
+    assert.match(prompt, /We have two discards/);
+    assert.match(prompt, /Focus on low-risk parser optimizations/);
+    assert.match(prompt, /\[truncated to 3000 chars\]/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("requestAutoresearchHint uses injected completion and extracts text", async () => {
+  let captured = null;
+  const fakeComplete = async (model, context, options) => {
+    captured = { model, context, options };
+    return {
+      role: "assistant",
+      content: [{ type: "text", text: "Try one smaller cache experiment." }],
+      timestamp: Date.now(),
+      stopReason: "stop",
+      usage: {
+        input: 10,
+        output: 7,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 17,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    };
+  };
+
+  const result = await requestAutoresearchHint({
+    model: { id: "hint-model" },
+    apiKey: "key",
+    headers: { "x-test": "1" },
+    state: sampleState(),
+    workDir: tmpdir(),
+    question: "What next?",
+    maxRecentRuns: 2,
+    thinkingLevel: "off",
+    timeoutSeconds: 10,
+    complete: fakeComplete,
+  });
+
+  assert.equal(result.text, "Try one smaller cache experiment.");
+  assert.equal(result.stopReason, "stop");
+  assert.equal(result.usage.output, 7);
+  assert.equal(captured.options.apiKey, "key");
+  assert.equal(captured.options.headers["x-test"], "1");
+  assert.equal(captured.options.reasoning, undefined);
+  assert.match(captured.context.systemPrompt, /strategy advice only/);
+});
+
+function collectHintTool() {
+  let hintTool = null;
+  autoresearchExtension({
+    on() {},
+    registerCommand() {},
+    registerShortcut() {},
+    registerTool(tool) {
+      if (tool.name === "ask_autoresearch_hint") hintTool = tool;
+    },
+  });
+  return hintTool;
+}
+
+function fakeContext(workDir, modelRegistry) {
+  return {
+    cwd: workDir,
+    sessionManager: {
+      getSessionId() {
+        return "hint-test-session";
+      },
+    },
+    modelRegistry,
+  };
+}
+
+test("hint tool disabled config does not touch model registry", async () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  let findCalls = 0;
+  try {
+    const tool = collectHintTool();
+    const result = await tool.execute(
+      "call-1",
+      { question: "What next?" },
+      undefined,
+      undefined,
+      fakeContext(workDir, {
+        find() {
+          findCalls++;
+        },
+      }),
+    );
+
+    assert.equal(findCalls, 0);
+    assert.match(result.content[0].text, /hints are disabled/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("hint tool incomplete config does not touch model registry", async () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  let findCalls = 0;
+  try {
+    fs.mkdirSync(path.join(workDir, ".auto"), { recursive: true });
+    fs.writeFileSync(
+      path.join(workDir, ".auto", "config.json"),
+      JSON.stringify({ hints: { enabled: true, model: "claude" } }),
+    );
+
+    const tool = collectHintTool();
+    const result = await tool.execute(
+      "call-1",
+      { question: "What next?" },
+      undefined,
+      undefined,
+      fakeContext(workDir, {
+        find() {
+          findCalls++;
+        },
+      }),
+    );
+
+    assert.equal(findCalls, 0);
+    assert.match(result.content[0].text, /provider and hints\.model/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("hint tool blocks concurrent calls while auth is resolving", async () => {
+  const workDir = fs.mkdtempSync(path.join(tmpdir(), "pi-autoresearch-hints-"));
+  try {
+    fs.mkdirSync(path.join(workDir, ".auto"), { recursive: true });
+    fs.writeFileSync(
+      path.join(workDir, ".auto", "config.json"),
+      JSON.stringify({
+        hints: {
+          enabled: true,
+          provider: "anthropic",
+          model: "claude",
+        },
+      }),
+    );
+
+    let resolveAuth;
+    const authPromise = new Promise((resolve) => {
+      resolveAuth = resolve;
+    });
+
+    const tool = collectHintTool();
+    const ctx = fakeContext(workDir, {
+      find() {
+        return { id: "claude", provider: "anthropic", api: "anthropic-messages" };
+      },
+      getApiKeyAndHeaders() {
+        return authPromise;
+      },
+    });
+
+    const first = tool.execute("call-1", { question: "What next?" }, undefined, undefined, ctx);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const second = await tool.execute("call-2", { question: "What next?" }, undefined, undefined, ctx);
+    assert.match(second.content[0].text, /already in flight/);
+
+    resolveAuth({ ok: false, error: "missing key" });
+    const firstResult = await first;
+    assert.match(firstResult.content[0].text, /missing key/);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/tests/stale-context-source.test.mjs
+++ b/tests/stale-context-source.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../extensions/pi-autoresearch/index.ts", import.meta.url), "utf-8");
+
+test("autoresearch guards UI cleanup against stale Pi contexts", () => {
+  assert.match(source, /function runIgnoringStaleExtensionContext|const runIgnoringStaleExtensionContext/, "expected stale-context guard helper");
+  assert.match(source, /runIgnoringStaleExtensionContext\(\(\) => \{\s*if \(ctx\.hasUI\)/s, "expected ctx.hasUI UI cleanup to be wrapped by stale-context guard");
+});
+
+test("autoresearch cancels pending resume timers before session shutdown UI work", () => {
+  const shutdownIndex = source.indexOf('pi.on("session_shutdown"');
+  assert.notEqual(shutdownIndex, -1, "expected session_shutdown handler");
+  const shutdownBlock = source.slice(shutdownIndex, shutdownIndex + 500);
+  assert.match(shutdownBlock, /cancelPendingResume/, "expected shutdown to cancel pending auto-resume timers");
+  assert.ok(
+    shutdownBlock.indexOf("cancelPendingResume") < shutdownBlock.indexOf("clearSessionUi"),
+    "expected auto-resume cancellation before UI cleanup can touch stale ctx",
+  );
+});


### PR DESCRIPTION
## Summary

This is a curated integration branch for several community PRs that had drifted behind `main` after the `.auto/` layout migration and the `@earendil-works` package rename.

Integrated and rebased onto current `main`:

- #63 — swallow browser launcher errors in `/autoresearch export`
- #70 — configurable `maxAutoResumeTurns`, including `null`/`0` for intentional unlimited auto-resume and natural-language `/autoresearch` loop-control inference
- #61 — persist manual `/autoresearch off` outside the repo so session reconstruction does not reactivate just because `.auto/log.jsonl` exists
- #57 — guard delayed auto-resume / shutdown UI cleanup against stale Pi extension contexts
- #65 — optional `ask_autoresearch_hint` advisory tool, updated for `.auto/config.json`, `@earendil-works/*`, and gated behind autoresearch mode

Notes from the rebase:

- Kept the current `.auto/` layout and legacy fallback behavior.
- Kept `/skill:autoresearch-create ...` expansion intact when no `.auto/prompt.md` exists.
- Stored manual-off markers under the active Pi agent dir (`<agent-dir>/autoresearch/state/`) instead of hard-coding `~/.pi`.
- Made inferred config creation create `.auto/` before writing `.auto/config.json`.
- Left #62 out because #70 is a superset.
- Left draft #31 out for now: it is still legacy-layout based and its knowledge-store shell test was not green in local diagnosis.

## Verification

- `npm test` → 47/47 pass
- `bash tests/finalize_test.sh` → 19/19 pass
- `npm pack --dry-run --json` includes the new `extensions/pi-autoresearch/hints.ts`

