### PR TITLE
Fix autoresearch activation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Redirected `workingDir` logs no longer auto-activate autoresearch in unrelated pi sessions.
+- `/autoresearch off` now persists across `/tree`, compaction, and reloads: a manual off is recorded as a session activation decision and is no longer overridden just because `log.jsonl` still exists.
 
 ## [1.6.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Redirected `workingDir` logs no longer auto-activate autoresearch in unrelated pi sessions.
+
 ## [1.6.0] - 2026-06-08
 
 ### Changed

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -14,6 +14,7 @@
  */
 
 import type {
+  CustomEntry,
   ExtensionAPI,
   ExtensionContext,
   SessionBeforeCompactEvent,
@@ -460,6 +461,61 @@ function resolveWorkDir(ctxCwd: string): string {
   return path.isAbsolute(config.workingDir)
     ? config.workingDir
     : path.resolve(ctxCwd, config.workingDir);
+}
+
+function canonicalPath(existingPath: string): string {
+  try {
+    return fs.realpathSync.native(existingPath);
+  } catch {
+    return path.resolve(existingPath);
+  }
+}
+
+function samePath(a: string, b: string): boolean {
+  return canonicalPath(a) === canonicalPath(b);
+}
+
+const AUTORESEARCH_ACTIVATION_ENTRY = "pi-autoresearch.activation";
+
+interface AutoresearchActivationEntryData {
+  version?: number;
+  workDir?: string;
+  active?: boolean;
+}
+
+export function shouldAutoActivateAutoresearch(
+  ctxCwd: string,
+  workDir: string,
+  hasPersistedLog: boolean,
+  sessionActivated: boolean = false,
+): boolean {
+  if (!hasPersistedLog) return false;
+  return samePath(ctxCwd, workDir) || sessionActivated;
+}
+
+function autoresearchActivationData(entry: CustomEntry): AutoresearchActivationEntryData | null {
+  if (entry.customType !== AUTORESEARCH_ACTIVATION_ENTRY) return null;
+
+  const data = entry.data as AutoresearchActivationEntryData | undefined;
+  if (typeof data?.workDir !== "string") return null;
+
+  return data;
+}
+
+function hasActiveAutoresearchActivation(ctx: ExtensionContext, workDir: string): boolean {
+  const canonicalWorkDir = canonicalPath(workDir);
+  let active = false;
+
+  for (const entry of ctx.sessionManager.getBranch()) {
+    if (entry.type !== "custom") continue;
+
+    const data = autoresearchActivationData(entry);
+    if (!data || canonicalPath(data.workDir) !== canonicalWorkDir) continue;
+
+    active = data.active === true;
+  }
+
+  return active;
 }
 
 /**
@@ -1009,6 +1065,16 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     pi.setActiveTools([...activeTools]);
   };
 
+  const recordAutoresearchActivation = (ctxCwd: string, workDir: string, active: boolean): void => {
+    if (samePath(ctxCwd, workDir)) return;
+
+    pi.appendEntry(AUTORESEARCH_ACTIVATION_ENTRY, {
+      version: 1,
+      workDir: canonicalPath(workDir),
+      active,
+    });
+  };
+
   const isAgentSettled = (ctx: ExtensionContext): boolean =>
     ctx.isIdle() && !ctx.hasPendingMessages();
 
@@ -1220,9 +1286,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     // Primary: read from .auto/log.jsonl (alongside .auto/prompt.md and .auto/measure.sh)
     const jsonlPath = autoresearchJsonlPath(workDir);
+    const hasPersistedLog = fs.existsSync(jsonlPath);
     let loadedFromJsonl = false;
     try {
-      if (fs.existsSync(jsonlPath)) {
+      if (hasPersistedLog) {
         const reconstructed = reconstructJsonlState(fs.readFileSync(jsonlPath, "utf-8"));
         state.name = reconstructed.name;
         state.metricName = reconstructed.metricName;
@@ -1275,8 +1342,18 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     // Read max experiments from config file
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
-    // Auto-enter autoresearch mode only when a persisted experiment log exists
-    setAutoresearchMode(ctx, fs.existsSync(autoresearchJsonlPath(workDir)));
+    // Auto-enter autoresearch mode only when a persisted experiment log exists.
+    // Redirected workingDir sessions must also be bound to this pi session;
+    // otherwise unrelated chats launched from a shared cwd would activate it.
+    setAutoresearchMode(
+      ctx,
+      shouldAutoActivateAutoresearch(
+        ctx.cwd,
+        workDir,
+        hasPersistedLog,
+        hasActiveAutoresearchActivation(ctx, workDir),
+      ),
+    );
 
     updateWidget(ctx);
   };
@@ -1286,6 +1363,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     const runtime = getRuntime(ctx);
     const state = runtime.state;
+
+    if (!runtime.autoresearchMode) {
+      ctx.ui.setWidget("autoresearch", undefined);
+      return;
+    }
 
     if (state.results.length === 0) {
       if (!runtime.runningExperiment) {
@@ -1520,6 +1602,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       const wasInactive = !runtime.autoresearchMode;
+      recordAutoresearchActivation(ctx.cwd, workDir, true);
       setAutoresearchMode(ctx, true);
       updateWidget(ctx);
 
@@ -2346,6 +2429,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const limitReached = state.maxExperiments !== null && segmentCount >= state.maxExperiments;
       if (limitReached) {
         text += `\n\n🛑 Maximum experiments reached (${state.maxExperiments}). STOP the experiment loop now.`;
+        recordAutoresearchActivation(ctx.cwd, workDir, false);
         setAutoresearchMode(ctx, false);
         ctx.abort();
       } else if (runtime.autoresearchMode) {
@@ -2460,6 +2544,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       handler: async (ctx) => {
         const runtime = getRuntime(ctx);
         const state = runtime.state;
+        if (!runtime.autoresearchMode) {
+          ctx.ui.notify("Autoresearch mode is not active", "info");
+          return;
+        }
         if (state.results.length === 0) {
           ctx.ui.notify("No experiments yet", "info");
           return;
@@ -2835,7 +2923,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
       if (command === "off") {
         const wasRunning = !ctx.isIdle();
+        const workDir = resolveWorkDir(ctx.cwd);
 
+        recordAutoresearchActivation(ctx.cwd, workDir, false);
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
@@ -2861,6 +2951,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       if (command === "clear") {
         const workDir = resolveWorkDir(ctx.cwd);
         const jsonlPaths = sessionFileCandidates(workDir, "log");
+        recordAutoresearchActivation(ctx.cwd, workDir, false);
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
@@ -2900,10 +2991,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         return;
       }
 
+      const workDir = resolveWorkDir(ctx.cwd);
+      recordAutoresearchActivation(ctx.cwd, workDir, true);
       setAutoresearchMode(ctx, true);
       runtime.autoResumeTurns = 0;
-
-      const workDir = resolveWorkDir(ctx.cwd);
       const rulesLoaded = hasAutoresearchRules(ctx);
       // No .auto/prompt.md yet — load the create skill so the agent follows the
       // setup guidelines. `/skill:<name>` is expanded to the full SKILL.md by

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -487,10 +487,15 @@ export function shouldAutoActivateAutoresearch(
   ctxCwd: string,
   workDir: string,
   hasPersistedLog: boolean,
-  sessionActivated: boolean = false,
+  recordedDecision: boolean | null = null,
 ): boolean {
   if (!hasPersistedLog) return false;
-  return samePath(ctxCwd, workDir) || sessionActivated;
+  // An explicit `/autoresearch on|off` in this session always wins, so a manual
+  // off survives /tree, compaction, and reloads instead of snapping back on.
+  if (recordedDecision !== null) return recordedDecision;
+  // With no recorded decision, same-cwd sessions default on (a log implies intent);
+  // redirected workingDir sessions default off until this session opts in.
+  return samePath(ctxCwd, workDir);
 }
 
 function autoresearchActivationData(entry: CustomEntry): AutoresearchActivationEntryData | null {
@@ -502,9 +507,9 @@ function autoresearchActivationData(entry: CustomEntry): AutoresearchActivationE
   return data;
 }
 
-function hasActiveAutoresearchActivation(ctx: ExtensionContext, workDir: string): boolean {
+function recordedActivationDecision(ctx: ExtensionContext, workDir: string): boolean | null {
   const canonicalWorkDir = canonicalPath(workDir);
-  let active = false;
+  let decision: boolean | null = null;
 
   for (const entry of ctx.sessionManager.getBranch()) {
     if (entry.type !== "custom") continue;
@@ -512,10 +517,10 @@ function hasActiveAutoresearchActivation(ctx: ExtensionContext, workDir: string)
     const data = autoresearchActivationData(entry);
     if (!data || canonicalPath(data.workDir) !== canonicalWorkDir) continue;
 
-    active = data.active === true;
+    decision = data.active === true;
   }
 
-  return active;
+  return decision;
 }
 
 /**
@@ -1065,9 +1070,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     pi.setActiveTools([...activeTools]);
   };
 
-  const recordAutoresearchActivation = (ctxCwd: string, workDir: string, active: boolean): void => {
-    if (samePath(ctxCwd, workDir)) return;
-
+  const recordAutoresearchActivation = (workDir: string, active: boolean): void => {
     pi.appendEntry(AUTORESEARCH_ACTIVATION_ENTRY, {
       version: 1,
       workDir: canonicalPath(workDir),
@@ -1343,15 +1346,16 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     state.maxExperiments = readMaxExperiments(ctx.cwd);
 
     // Auto-enter autoresearch mode only when a persisted experiment log exists.
-    // Redirected workingDir sessions must also be bound to this pi session;
-    // otherwise unrelated chats launched from a shared cwd would activate it.
+    // A recorded `/autoresearch on|off` in this session wins; otherwise same-cwd
+    // sessions default on and redirected workingDir sessions default off, so
+    // unrelated chats launched from a shared cwd never activate it.
     setAutoresearchMode(
       ctx,
       shouldAutoActivateAutoresearch(
         ctx.cwd,
         workDir,
         hasPersistedLog,
-        hasActiveAutoresearchActivation(ctx, workDir),
+        recordedActivationDecision(ctx, workDir),
       ),
     );
 
@@ -1602,7 +1606,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       const wasInactive = !runtime.autoresearchMode;
-      recordAutoresearchActivation(ctx.cwd, workDir, true);
+      recordAutoresearchActivation(workDir, true);
       setAutoresearchMode(ctx, true);
       updateWidget(ctx);
 
@@ -2429,7 +2433,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       const limitReached = state.maxExperiments !== null && segmentCount >= state.maxExperiments;
       if (limitReached) {
         text += `\n\n🛑 Maximum experiments reached (${state.maxExperiments}). STOP the experiment loop now.`;
-        recordAutoresearchActivation(ctx.cwd, workDir, false);
+        recordAutoresearchActivation(workDir, false);
         setAutoresearchMode(ctx, false);
         ctx.abort();
       } else if (runtime.autoresearchMode) {
@@ -2925,7 +2929,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         const wasRunning = !ctx.isIdle();
         const workDir = resolveWorkDir(ctx.cwd);
 
-        recordAutoresearchActivation(ctx.cwd, workDir, false);
+        recordAutoresearchActivation(workDir, false);
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
@@ -2951,7 +2955,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       if (command === "clear") {
         const workDir = resolveWorkDir(ctx.cwd);
         const jsonlPaths = sessionFileCandidates(workDir, "log");
-        recordAutoresearchActivation(ctx.cwd, workDir, false);
+        recordAutoresearchActivation(workDir, false);
         setAutoresearchMode(ctx, false);
         runtime.autoResumeTurns = 0;
         runtime.experimentsThisSession = 0;
@@ -2992,7 +2996,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       const workDir = resolveWorkDir(ctx.cwd);
-      recordAutoresearchActivation(ctx.cwd, workDir, true);
+      recordAutoresearchActivation(workDir, true);
       setAutoresearchMode(ctx, true);
       runtime.autoResumeTurns = 0;
       const rulesLoaded = hasAutoresearchRules(ctx);

--- a/tests/activation.test.mjs
+++ b/tests/activation.test.mjs
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import autoresearchExtension, {
+  shouldAutoActivateAutoresearch,
+} from "../extensions/pi-autoresearch/index.ts";
+
+const ACTIVATION_ENTRY = "pi-autoresearch.activation";
+const AUTORESEARCH_TOOLS = ["init_experiment", "log_experiment", "run_experiment"];
+
+function createHarness({ cwd, branch = [], initialActiveTools = [] }) {
+  const commands = new Map();
+  const handlers = new Map();
+  const widgets = [];
+  const notifications = [];
+  const appendedEntries = [];
+  const sentMessages = [];
+  let activeTools = [...initialActiveTools];
+  let aborted = false;
+
+  autoresearchExtension({
+    on(name, handler) {
+      handlers.set(name, handler);
+    },
+    appendEntry(customType, data) {
+      appendedEntries.push({ customType, data });
+    },
+    registerTool() {},
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
+    registerShortcut() {},
+    getActiveTools() {
+      return activeTools;
+    },
+    setActiveTools(nextTools) {
+      activeTools = [...nextTools];
+    },
+    sendUserMessage(content, options) {
+      sentMessages.push({ content, options });
+    },
+  });
+
+  const ctx = {
+    cwd,
+    hasUI: true,
+    isIdle: () => true,
+    hasPendingMessages: () => false,
+    abort() {
+      aborted = true;
+    },
+    sessionManager: {
+      getSessionId: () => `test:${cwd}`,
+      getBranch: () => branch,
+    },
+    ui: {
+      setWidget(name, widget) {
+        widgets.push({ name, widget });
+      },
+      notify(message, level) {
+        notifications.push({ message, level });
+      },
+    },
+  };
+
+  return {
+    appendedEntries,
+    commands,
+    handlers,
+    ctx,
+    notifications,
+    sentMessages,
+    widgets,
+    activeTools: () => activeTools,
+    aborted: () => aborted,
+  };
+}
+
+function activationEntry(workDir, active = true) {
+  return {
+    type: "custom",
+    customType: ACTIVATION_ENTRY,
+    data: {
+      version: 1,
+      workDir,
+      active,
+    },
+  };
+}
+
+function staleLogExperimentEntry() {
+  return {
+    type: "message",
+    message: {
+      role: "toolResult",
+      toolName: "log_experiment",
+      details: {
+        state: {
+          results: [
+            {
+              commit: "abcdef0",
+              metric: 12,
+              metrics: {},
+              status: "crash",
+              description: "stale run from deleted log",
+              timestamp: Date.now(),
+              segment: 0,
+              confidence: null,
+            },
+          ],
+          bestMetric: 12,
+          bestDirection: "lower",
+          metricName: "quote_field_usec",
+          metricUnit: "µs",
+          secondaryMetrics: [],
+          name: "PickPeriod backend quote field optimization",
+          currentSegment: 0,
+          maxExperiments: null,
+          confidence: null,
+        },
+      },
+    },
+  };
+}
+
+async function writeRedirectedSession(cwd, workDir, config = {}) {
+  await mkdir(join(cwd, ".auto"), { recursive: true });
+  await writeFile(
+    join(cwd, ".auto", "config.json"),
+    JSON.stringify({ workingDir: workDir, ...config }) + "\n",
+  );
+  await mkdir(join(workDir, ".auto"), { recursive: true });
+  await writeFile(
+    join(workDir, ".auto", "log.jsonl"),
+    [
+      JSON.stringify({
+        type: "config",
+        name: "Redirected research",
+        metricName: "runtime_ms",
+        metricUnit: "ms",
+        bestDirection: "lower",
+      }),
+      JSON.stringify({
+        run: 1,
+        commit: "abcdef0",
+        metric: 10,
+        metrics: {},
+        status: "crash",
+        description: "baseline",
+        timestamp: Date.now(),
+      }),
+    ].join("\n") + "\n",
+  );
+}
+
+test("same-cwd persisted logs still auto-activate autoresearch", () => {
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/repo", true),
+    true,
+  );
+});
+
+test("missing persisted logs never auto-activate autoresearch", () => {
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/repo", false),
+    false,
+  );
+});
+
+test("redirected workingDir logs require a pi-session activation", () => {
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/other-worktree", true),
+    false,
+  );
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/other-worktree", true, true),
+    true,
+  );
+});
+
+test("session startup does not show a redirected workingDir dashboard without a session activation", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+  const workDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-workdir-"));
+
+  try {
+    await writeRedirectedSession(cwd, workDir);
+
+    const harness = createHarness({
+      cwd,
+      initialActiveTools: AUTORESEARCH_TOOLS,
+    });
+    await harness.handlers.get("session_start")({}, harness.ctx);
+
+    assert.deepEqual(harness.activeTools(), []);
+    assert.equal(harness.widgets.at(-1)?.name, "autoresearch");
+    assert.equal(harness.widgets.at(-1)?.widget, undefined);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(workDir, { recursive: true, force: true });
+  }
+});
+
+test("session startup activates redirected workingDir dashboards when this pi session activated it", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+  const workDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-workdir-"));
+
+  try {
+    await writeRedirectedSession(cwd, workDir);
+
+    const harness = createHarness({
+      cwd,
+      branch: [activationEntry(workDir)],
+    });
+    await harness.handlers.get("session_start")({}, harness.ctx);
+
+    assert.deepEqual(harness.activeTools().sort(), AUTORESEARCH_TOOLS.sort());
+    assert.equal(harness.widgets.at(-1)?.name, "autoresearch");
+    assert.equal(typeof harness.widgets.at(-1)?.widget, "function");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(workDir, { recursive: true, force: true });
+  }
+});
+
+test("session startup keeps redirected workingDir inactive when deactivation is latest", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+  const workDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-workdir-"));
+
+  try {
+    await writeRedirectedSession(cwd, workDir);
+
+    const harness = createHarness({
+      cwd,
+      branch: [activationEntry(workDir), activationEntry(workDir, false)],
+      initialActiveTools: AUTORESEARCH_TOOLS,
+    });
+    await harness.handlers.get("session_start")({}, harness.ctx);
+
+    assert.deepEqual(harness.activeTools(), []);
+    assert.equal(harness.widgets.at(-1)?.name, "autoresearch");
+    assert.equal(harness.widgets.at(-1)?.widget, undefined);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(workDir, { recursive: true, force: true });
+  }
+});
+
+test("starting autoresearch binds redirected workingDir activation to the pi session", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+  const workDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-workdir-"));
+
+  try {
+    await mkdir(join(cwd, ".auto"), { recursive: true });
+    await writeFile(
+      join(cwd, ".auto", "config.json"),
+      JSON.stringify({ workingDir: workDir }) + "\n",
+    );
+
+    const harness = createHarness({ cwd });
+    await harness.commands.get("autoresearch").handler("optimize runtime", harness.ctx);
+
+    assert.deepEqual(harness.activeTools().sort(), AUTORESEARCH_TOOLS.sort());
+    assert.equal(harness.appendedEntries.length, 1);
+    assert.equal(harness.appendedEntries[0].customType, ACTIVATION_ENTRY);
+    assert.equal(harness.appendedEntries[0].data.active, true);
+    assert.equal(harness.appendedEntries[0].data.workDir, await realpath(workDir));
+    assert.equal(harness.sentMessages.length, 1);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(workDir, { recursive: true, force: true });
+  }
+});
+
+test("deleted logs do not leave a stale autoresearch widget from session history", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+
+  try {
+    const harness = createHarness({
+      cwd,
+      branch: [staleLogExperimentEntry()],
+      initialActiveTools: AUTORESEARCH_TOOLS,
+    });
+    await harness.handlers.get("session_start")({}, harness.ctx);
+
+    assert.deepEqual(harness.activeTools(), []);
+    assert.equal(harness.widgets.at(-1)?.name, "autoresearch");
+    assert.equal(harness.widgets.at(-1)?.widget, undefined);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/tests/activation.test.mjs
+++ b/tests/activation.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -156,6 +157,31 @@ async function writeRedirectedSession(cwd, workDir, config = {}) {
   );
 }
 
+async function writeSameCwdLog(cwd) {
+  await mkdir(join(cwd, ".auto"), { recursive: true });
+  await writeFile(
+    join(cwd, ".auto", "log.jsonl"),
+    [
+      JSON.stringify({
+        type: "config",
+        name: "Same-cwd research",
+        metricName: "runtime_ms",
+        metricUnit: "ms",
+        bestDirection: "lower",
+      }),
+      JSON.stringify({
+        run: 1,
+        commit: "abcdef0",
+        metric: 10,
+        metrics: {},
+        status: "crash",
+        description: "baseline",
+        timestamp: Date.now(),
+      }),
+    ].join("\n") + "\n",
+  );
+}
+
 test("same-cwd persisted logs still auto-activate autoresearch", () => {
   assert.equal(
     shouldAutoActivateAutoresearch("/repo", "/repo", true),
@@ -173,6 +199,24 @@ test("missing persisted logs never auto-activate autoresearch", () => {
 test("redirected workingDir logs require a pi-session activation", () => {
   assert.equal(
     shouldAutoActivateAutoresearch("/repo", "/other-worktree", true),
+    false,
+  );
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/other-worktree", true, true),
+    true,
+  );
+});
+
+test("a recorded manual off keeps same-cwd sessions inactive despite a persisted log", () => {
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/repo", true, false),
+    false,
+  );
+});
+
+test("a recorded activation reactivates a redirected off decision on later start", () => {
+  assert.equal(
+    shouldAutoActivateAutoresearch("/repo", "/other-worktree", true, false),
     false,
   );
   assert.equal(
@@ -271,6 +315,66 @@ test("starting autoresearch binds redirected workingDir activation to the pi ses
   } finally {
     await rm(cwd, { recursive: true, force: true });
     await rm(workDir, { recursive: true, force: true });
+  }
+});
+
+test("session startup keeps same-cwd sessions inactive when a manual off is recorded", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+
+  try {
+    await writeSameCwdLog(cwd);
+
+    const harness = createHarness({
+      cwd,
+      branch: [activationEntry(cwd, false)],
+      initialActiveTools: AUTORESEARCH_TOOLS,
+    });
+    await harness.handlers.get("session_start")({}, harness.ctx);
+
+    assert.deepEqual(harness.activeTools(), []);
+    assert.equal(harness.widgets.at(-1)?.name, "autoresearch");
+    assert.equal(harness.widgets.at(-1)?.widget, undefined);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("/autoresearch off records a manual off decision for same-cwd sessions", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+
+  try {
+    await writeSameCwdLog(cwd);
+
+    const harness = createHarness({ cwd, initialActiveTools: AUTORESEARCH_TOOLS });
+    await harness.commands.get("autoresearch").handler("off", harness.ctx);
+
+    assert.deepEqual(harness.activeTools(), []);
+    assert.equal(harness.appendedEntries.length, 1);
+    assert.equal(harness.appendedEntries[0].customType, ACTIVATION_ENTRY);
+    assert.equal(harness.appendedEntries[0].data.active, false);
+    assert.equal(harness.appendedEntries[0].data.workDir, await realpath(cwd));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("/autoresearch clear turns off, deletes the log, and records a manual off decision", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+
+  try {
+    await writeSameCwdLog(cwd);
+
+    const harness = createHarness({ cwd, initialActiveTools: AUTORESEARCH_TOOLS });
+    await harness.commands.get("autoresearch").handler("clear", harness.ctx);
+
+    assert.deepEqual(harness.activeTools(), []);
+    assert.equal(existsSync(join(cwd, ".auto", "log.jsonl")), false);
+    assert.equal(harness.appendedEntries.length, 1);
+    assert.equal(harness.appendedEntries[0].customType, ACTIVATION_ENTRY);
+    assert.equal(harness.appendedEntries[0].data.active, false);
+    assert.equal(harness.appendedEntries[0].data.workDir, await realpath(cwd));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes autoresearch activating in the wrong Pi session when `.auto/config.json` redirects `workingDir` to another research directory.

## Why

`workingDir` lets one session run autoresearch somewhere else (for example, a separate worktree). Before this change, a redirected session inferred activation from persisted autoresearch state in the target directory. That made unrelated chats launched from a shared cwd look like they were part of the research loop.

## What changed

Activation is now bound to the Pi **session**, not just the target directory:

- **Same-directory sessions** keep the existing auto-resume behavior.
- **Redirected `workingDir` sessions** only auto-activate when *this* Pi session previously activated autoresearch (via `/autoresearch`, `init_experiment`, etc.).
- The activation state is recorded as a custom Pi session entry, so it survives restarts/reloads but does not leak into other chats sharing the cwd.
- `/autoresearch off`, `/autoresearch clear`, and max-experiments reached record deactivation, so reloads stay inactive after deactivation.
- Inactive autoresearch no longer leaves a stale dashboard/widget behind.

No new config fields.

## Behavior change to note

A redirected `workingDir` session that previously auto-activated only because the target already had autoresearch state now needs `/autoresearch` once to bind activation to that Pi session. Same-cwd auto-resume is unaffected.

## Scope

Fixes cwd/workDir activation scope only. It does not make autoresearch branch-aware; autoresearch state remains directory-scoped.

## Testing

- `pnpm test` — 38 passing, including coverage for the session-marker and deactivation-wins behavior.
- Live Pi smoke test against a real research dir:
  - launched from the research dir → activates (tools + dashboard).
  - launched from another cwd with `workingDir` redirect, unrelated session → stays inactive.
  - start in a redirected session → reload → reactivates from the session marker.
  - latest deactivation marker / `/autoresearch off` → reload stays inactive.
