### PR TITLE
Raise auto-resume limit to 200 with consecutive-failure override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ All notable changes to this project will be documented in this file.
 
 - Raised the autoresearch auto-resume ceiling from 20 to 200 turns, while adding a stuck-loop override that stops auto-resume after more than 20 consecutive `discard` or `crash` results in the current segment.
 
-### Added
-
-- Added tests covering the 200-turn auto-resume ceiling and the consecutive discard/crash override.
-
 ## [1.6.1] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Raised the autoresearch auto-resume ceiling from 20 to 200 turns, while adding a stuck-loop override that stops auto-resume after more than 20 consecutive `discard` or `crash` results in the current segment.
+
+### Added
+
+- Added tests covering the 200-turn auto-resume ceiling and the consecutive discard/crash override.
+
 ## [1.6.1] - 2026-07-02
 
 ### Fixed

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -111,6 +111,41 @@ interface ExperimentState {
   confidence: number | null;
 }
 
+export const AUTORESUME_TURN_LIMIT = 200;
+export const CONSECUTIVE_FAILURE_OVERRIDE_LIMIT = 20;
+
+type AutoResumeGuardState = Pick<ExperimentState, "results" | "currentSegment">;
+type AutoResumeGuardRuntime = {
+  autoResumeTurns: number;
+  state: AutoResumeGuardState;
+};
+
+/** Count trailing discard/crash results in the current segment. */
+export function countConsecutiveDiscardOrCrashResults(state: AutoResumeGuardState): number {
+  let count = 0;
+  for (let i = state.results.length - 1; i >= 0; i--) {
+    const result = state.results[i];
+    if (result.segment !== state.currentSegment) break;
+    if (result.status === "discard" || result.status === "crash") {
+      count++;
+      continue;
+    }
+    break;
+  }
+  return count;
+}
+
+export function autoResumeStopReasonFor(runtime: AutoResumeGuardRuntime): string | null {
+  if (runtime.autoResumeTurns >= AUTORESUME_TURN_LIMIT) {
+    return `Autoresearch auto-resume limit reached (${AUTORESUME_TURN_LIMIT} turns)`;
+  }
+  const failures = countConsecutiveDiscardOrCrashResults(runtime.state);
+  if (failures > CONSECUTIVE_FAILURE_OVERRIDE_LIMIT) {
+    return `Autoresearch auto-resume stopped — ${failures} consecutive discards/crashes`;
+  }
+  return null;
+}
+
 interface RunDetails {
   command: string;
   exitCode: number | null;
@@ -1031,14 +1066,6 @@ function renderDashboardLines(
 // ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
-  // High ceiling so the loop keeps iterating across long sessions; the
-  // consecutive-failure override below is the real backstop against runaway
-  // discard/crash streaks.
-  const MAX_AUTORESUME_TURNS = 200;
-  // When this many discards or crashes land back-to-back in the current
-  // segment, stop auto-resuming regardless of the turn counter — the agent is
-  // clearly stuck and burning iterations without progress.
-  const MAX_CONSECUTIVE_FAILURES = 20;
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
 
@@ -1115,7 +1142,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!isAgentSettled(ctx)) return;
-    const stopReason = autoResumeStopReason(runtime);
+    const stopReason = autoResumeStopReasonFor(runtime);
     if (stopReason !== null) {
       cancelPendingResume(runtime);
       notifyAutoResumeLimitReached(ctx, stopReason);
@@ -1151,37 +1178,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   const shouldAutoResumeAfterCompact = (runtime: AutoresearchRuntime): boolean =>
     runtime.autoresearchMode;
-
-  /** Count trailing discard/crash results in the current segment. */
-  const consecutiveFailures = (state: ExperimentState): number => {
-    let count = 0;
-    for (let i = state.results.length - 1; i >= 0; i--) {
-      const r = state.results[i];
-      if (r.segment !== state.currentSegment) break;
-      if (r.status === "discard" || r.status === "crash") {
-        count++;
-      } else {
-        break;
-      }
-    }
-    return count;
-  };
-
-  // Why a stop reason (not a boolean): the notify message needs to explain
-  // *which* guard tripped — the turn ceiling or the consecutive-failure override.
-  const autoResumeStopReason = (runtime: AutoresearchRuntime): string | null => {
-    if (runtime.autoResumeTurns >= MAX_AUTORESUME_TURNS) {
-      return `Autoresearch auto-resume limit reached (${MAX_AUTORESUME_TURNS} turns)`;
-    }
-    const failures = consecutiveFailures(runtime.state);
-    if (failures > MAX_CONSECUTIVE_FAILURES) {
-      return `Autoresearch auto-resume stopped — ${failures} consecutive discards/crashes`;
-    }
-    return null;
-  };
-
-  const hasReachedAutoResumeLimit = (runtime: AutoresearchRuntime): boolean =>
-    autoResumeStopReason(runtime) !== null;
 
   const notifyAutoResumeLimitReached = (ctx: ExtensionContext, reason?: string | null): void => {
     ctx.ui.notify(reason ?? `Autoresearch auto-resume limit reached`, "info");
@@ -1494,7 +1490,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!gate(runtime)) return;
-    const stopReason = autoResumeStopReason(runtime);
+    const stopReason = autoResumeStopReasonFor(runtime);
     if (stopReason !== null) {
       notifyAutoResumeLimitReached(ctx, stopReason);
       return;

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1031,7 +1031,14 @@ function renderDashboardLines(
 // ---------------------------------------------------------------------------
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
-  const MAX_AUTORESUME_TURNS = 20;
+  // High ceiling so the loop keeps iterating across long sessions; the
+  // consecutive-failure override below is the real backstop against runaway
+  // discard/crash streaks.
+  const MAX_AUTORESUME_TURNS = 200;
+  // When this many discards or crashes land back-to-back in the current
+  // segment, stop auto-resuming regardless of the turn counter — the agent is
+  // clearly stuck and burning iterations without progress.
+  const MAX_CONSECUTIVE_FAILURES = 20;
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
 
@@ -1108,9 +1115,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!isAgentSettled(ctx)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
+    const stopReason = autoResumeStopReason(runtime);
+    if (stopReason !== null) {
       cancelPendingResume(runtime);
-      notifyAutoResumeLimitReached(ctx);
+      notifyAutoResumeLimitReached(ctx, stopReason);
       return;
     }
 
@@ -1144,14 +1152,39 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const shouldAutoResumeAfterCompact = (runtime: AutoresearchRuntime): boolean =>
     runtime.autoresearchMode;
 
-  const hasReachedAutoResumeLimit = (runtime: AutoresearchRuntime): boolean =>
-    runtime.autoResumeTurns >= MAX_AUTORESUME_TURNS;
+  /** Count trailing discard/crash results in the current segment. */
+  const consecutiveFailures = (state: ExperimentState): number => {
+    let count = 0;
+    for (let i = state.results.length - 1; i >= 0; i--) {
+      const r = state.results[i];
+      if (r.segment !== state.currentSegment) break;
+      if (r.status === "discard" || r.status === "crash") {
+        count++;
+      } else {
+        break;
+      }
+    }
+    return count;
+  };
 
-  const notifyAutoResumeLimitReached = (ctx: ExtensionContext): void => {
-    ctx.ui.notify(
-      `Autoresearch auto-resume limit reached (${MAX_AUTORESUME_TURNS} turns)`,
-      "info",
-    );
+  // Why a stop reason (not a boolean): the notify message needs to explain
+  // *which* guard tripped — the turn ceiling or the consecutive-failure override.
+  const autoResumeStopReason = (runtime: AutoresearchRuntime): string | null => {
+    if (runtime.autoResumeTurns >= MAX_AUTORESUME_TURNS) {
+      return `Autoresearch auto-resume limit reached (${MAX_AUTORESUME_TURNS} turns)`;
+    }
+    const failures = consecutiveFailures(runtime.state);
+    if (failures > MAX_CONSECUTIVE_FAILURES) {
+      return `Autoresearch auto-resume stopped — ${failures} consecutive discards/crashes`;
+    }
+    return null;
+  };
+
+  const hasReachedAutoResumeLimit = (runtime: AutoresearchRuntime): boolean =>
+    autoResumeStopReason(runtime) !== null;
+
+  const notifyAutoResumeLimitReached = (ctx: ExtensionContext, reason?: string | null): void => {
+    ctx.ui.notify(reason ?? `Autoresearch auto-resume limit reached`, "info");
   };
 
   const composeResumeMessage = (_ctx: ExtensionContext): string => {
@@ -1461,8 +1494,9 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       return;
     }
     if (!gate(runtime)) return;
-    if (hasReachedAutoResumeLimit(runtime)) {
-      notifyAutoResumeLimitReached(ctx);
+    const stopReason = autoResumeStopReason(runtime);
+    if (stopReason !== null) {
+      notifyAutoResumeLimitReached(ctx, stopReason);
       return;
     }
     schedulePendingResume(ctx, runtime, composeMessage(ctx));

--- a/tests/auto-resume-guards.test.mjs
+++ b/tests/auto-resume-guards.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AUTORESUME_TURN_LIMIT,
+  CONSECUTIVE_FAILURE_OVERRIDE_LIMIT,
+  autoResumeStopReasonFor,
+  countConsecutiveDiscardOrCrashResults,
+} from "../extensions/pi-autoresearch/index.ts";
+
+function result(status, segment = 0) {
+  return {
+    commit: status === "keep" ? "abcdef0" : "",
+    metric: status === "crash" ? 0 : 10,
+    metrics: {},
+    status,
+    description: status,
+    timestamp: 0,
+    segment,
+    confidence: null,
+  };
+}
+
+function state(results, currentSegment = 0) {
+  return { results, currentSegment };
+}
+
+function runtime(autoResumeTurns, results, currentSegment = 0) {
+  return {
+    autoResumeTurns,
+    state: state(results, currentSegment),
+  };
+}
+
+test("auto-resume turn ceiling is 200", () => {
+  assert.equal(AUTORESUME_TURN_LIMIT, 200);
+  assert.equal(autoResumeStopReasonFor(runtime(199, [])), null);
+  assert.match(
+    autoResumeStopReasonFor(runtime(200, [])),
+    /200 turns/,
+  );
+});
+
+test("consecutive discard/crash override stops after more than 20 failures", () => {
+  const failuresAtLimit = Array.from(
+    { length: CONSECUTIVE_FAILURE_OVERRIDE_LIMIT },
+    (_, index) => result(index % 2 === 0 ? "discard" : "crash"),
+  );
+  assert.equal(countConsecutiveDiscardOrCrashResults(state(failuresAtLimit)), 20);
+  assert.equal(autoResumeStopReasonFor(runtime(0, failuresAtLimit)), null);
+
+  const failuresPastLimit = [...failuresAtLimit, result("discard")];
+  assert.equal(countConsecutiveDiscardOrCrashResults(state(failuresPastLimit)), 21);
+  assert.match(
+    autoResumeStopReasonFor(runtime(0, failuresPastLimit)),
+    /21 consecutive discards\/crashes/,
+  );
+});
+
+test("consecutive failure override resets on keep and ignores previous segments", () => {
+  const failuresPastLimit = Array.from(
+    { length: CONSECUTIVE_FAILURE_OVERRIDE_LIMIT + 1 },
+    () => result("discard"),
+  );
+
+  assert.equal(
+    countConsecutiveDiscardOrCrashResults(state([...failuresPastLimit, result("keep")])),
+    0,
+  );
+  assert.equal(
+    autoResumeStopReasonFor(runtime(0, [...failuresPastLimit, result("keep")])),
+    null,
+  );
+
+  const previousSegmentFailures = failuresPastLimit.map((entry) => ({ ...entry, segment: 0 }));
+  const currentSegmentFailure = result("crash", 1);
+  assert.equal(
+    countConsecutiveDiscardOrCrashResults(
+      state([...previousSegmentFailures, currentSegmentFailure], 1),
+    ),
+    1,
+  );
+  assert.equal(
+    autoResumeStopReasonFor(
+      runtime(0, [...previousSegmentFailures, currentSegmentFailure], 1),
+    ),
+    null,
+  );
+});


### PR DESCRIPTION
## What

- Bumps `MAX_AUTORESUME_TURNS` from **20 → 200** so the experiment loop keeps iterating across long sessions.
- Adds a backstop: when more than **20 discards or crashes land back-to-back** in the current segment, auto-resume stops regardless of the turn counter — the agent is clearly stuck and burning iterations without progress.

## Why

20 turns was too tight a ceiling for real optimization runs, but raising it blindly risks runaway loops on a stuck agent. The consecutive-failure override keeps the higher ceiling while still cutting things off when there's no forward motion.

## How

- New `consecutiveFailures(state)` helper counts trailing `discard`/`crash` results in the current segment (stops at the first non-failure or segment boundary).
- `autoResumeStopReason(runtime)` returns which guard tripped — the 200-turn ceiling or the consecutive-failure override — so the notify message reflects the actual reason instead of a misleading turn count.

## Tests

All 43 existing tests pass (`pnpm test`).
