### PR TITLE
fix(auto-resume): wait out rate limits, stop on other agent errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-resume no longer replays failed turns. A turn that ended on a provider rate limit now resumes after the wait parsed from the error (plus a 1 min buffer, defaulting to 30 min when the provider gives no duration), and a turn that ended on any other agent error stops the loop with a notification instead of re-sending the resume message into the same failure.
+
 ## [1.6.2] - 2026-07-09
 
 ### Changed

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -52,6 +52,11 @@ import {
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
 import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
+import {
+  lastAssistantError,
+  rateLimitWaitMs,
+  RATE_LIMIT_BUFFER_MS,
+} from "./provider-errors.ts";
 import { sessionFilePath, sessionFileCandidates, ensureParentDir, AUTO_DIR } from "./paths.ts";
 
 // ---------------------------------------------------------------------------
@@ -187,6 +192,8 @@ interface AutoresearchRuntime {
   pendingResumeTimer: ReturnType<typeof setTimeout> | null;
   /** Resume message to send when the pending timer fires. */
   pendingResumeMessage: string | null;
+  /** Delay used when (re)scheduling the pending resume — longer while rate limited. */
+  pendingResumeDelayMs: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -734,6 +741,7 @@ function createSessionRuntime(): AutoresearchRuntime {
     state: createExperimentState(),
     pendingResumeTimer: null,
     pendingResumeMessage: null,
+    pendingResumeDelayMs: null,
   };
 }
 
@@ -1127,6 +1135,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const cancelPendingResume = (runtime: AutoresearchRuntime): void => {
     pausePendingResume(runtime);
     runtime.pendingResumeMessage = null;
+    runtime.pendingResumeDelayMs = null;
   };
 
   const markAutoResumeSent = (runtime: AutoresearchRuntime): void => {
@@ -1154,18 +1163,30 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     pi.sendUserMessage(message);
   };
 
-  const schedulePendingResume = (ctx: ExtensionContext, runtime: AutoresearchRuntime, message: string): void => {
+  const schedulePendingResume = (
+    ctx: ExtensionContext,
+    runtime: AutoresearchRuntime,
+    message: string,
+    delayMs: number = SETTLED_WINDOW_MS,
+  ): void => {
     pausePendingResume(runtime);
     runtime.pendingResumeMessage = message;
+    runtime.pendingResumeDelayMs = delayMs;
     runtime.pendingResumeTimer = setTimeout(
       () => sendPendingResumeIfReady(ctx, runtime),
-      SETTLED_WINDOW_MS,
+      delayMs,
     );
   };
 
   const reschedulePendingResume = (ctx: ExtensionContext, runtime: AutoresearchRuntime): void => {
     if (!hasPendingResume(runtime)) return;
-    schedulePendingResume(ctx, runtime, runtime.pendingResumeMessage!);
+    // Keep a rate-limit cooldown intact: rescheduling must not shorten the wait.
+    schedulePendingResume(
+      ctx,
+      runtime,
+      runtime.pendingResumeMessage!,
+      runtime.pendingResumeDelayMs ?? SETTLED_WINDOW_MS,
+    );
   };
 
   const hasRunExperimentsThisSession = (runtime: AutoresearchRuntime): boolean =>
@@ -1483,6 +1504,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     ctx: ExtensionContext,
     gate: (runtime: AutoresearchRuntime) => boolean,
     composeMessage: (ctx: ExtensionContext) => string = composeResumeMessage,
+    delayMs: number = SETTLED_WINDOW_MS,
   ): void => {
     const runtime = getRuntime(ctx);
     if (hasPendingResume(runtime)) {
@@ -1495,7 +1517,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       notifyAutoResumeLimitReached(ctx, stopReason);
       return;
     }
-    schedulePendingResume(ctx, runtime, composeMessage(ctx));
+    schedulePendingResume(ctx, runtime, composeMessage(ctx), delayMs);
   };
 
   pi.on("session_before_compact", async (event, ctx) => {
@@ -1507,10 +1529,33 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     ensurePendingResume(ctx, shouldAutoResumeAfterCompact, composeCompactionResumeMessage);
   });
 
-  pi.on("agent_end", async (_event, ctx) => {
+  pi.on("agent_end", async (event, ctx) => {
     const runtime = getRuntime(ctx);
     runtime.runningExperiment = null;
     if (overlayTui) overlayTui.requestRender();
+
+    // A failed turn ends like any other one, so resuming on the settle window
+    // replays the failure immediately. Wait out rate limits; stop on the rest.
+    const error = lastAssistantError(event.messages);
+    if (error !== null) {
+      if (!runtime.autoresearchMode) return;
+      const waitMs = rateLimitWaitMs(error);
+      if (waitMs === null) {
+        ctx.ui.notify(
+          `Autoresearch auto-resume stopped after an agent error: ${error.slice(0, 120)}`,
+          "warning",
+        );
+        return;
+      }
+      const totalWaitMs = waitMs + RATE_LIMIT_BUFFER_MS;
+      ctx.ui.notify(
+        `Rate limited — auto-resume in ${Math.ceil(totalWaitMs / 60_000)}min`,
+        "warning",
+      );
+      ensurePendingResume(ctx, shouldAutoResumeAfterTurn, composeResumeMessage, totalWaitMs);
+      return;
+    }
+
     ensurePendingResume(ctx, shouldAutoResumeAfterTurn);
   });
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -52,11 +52,7 @@ import {
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
 import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
-import {
-  lastAssistantError,
-  rateLimitWaitMs,
-  RATE_LIMIT_BUFFER_MS,
-} from "./provider-errors.ts";
+import { lastAssistantError, rateLimitWaitMs } from "./provider-errors.ts";
 import { sessionFilePath, sessionFileCandidates, ensureParentDir, AUTO_DIR } from "./paths.ts";
 
 // ---------------------------------------------------------------------------
@@ -193,7 +189,7 @@ interface AutoresearchRuntime {
   /** Resume message to send when the pending timer fires. */
   pendingResumeMessage: string | null;
   /** Delay used when (re)scheduling the pending resume — longer while rate limited. */
-  pendingResumeDelayMs: number | null;
+  pendingResumeDelayMs: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -730,6 +726,10 @@ function createExperimentState(): ExperimentState {
   };
 }
 
+// Outlasts pi's internal retry (setTimeout 0) and compaction-continue
+// (setTimeout 100); see badlogic/pi-mono#2023, #2110.
+const SETTLED_WINDOW_MS = 800;
+
 function createSessionRuntime(): AutoresearchRuntime {
   return {
     autoresearchMode: false,
@@ -741,7 +741,7 @@ function createSessionRuntime(): AutoresearchRuntime {
     state: createExperimentState(),
     pendingResumeTimer: null,
     pendingResumeMessage: null,
-    pendingResumeDelayMs: null,
+    pendingResumeDelayMs: SETTLED_WINDOW_MS,
   };
 }
 
@@ -1077,9 +1077,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const BENCHMARK_GUARDRAIL =
     "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
 
-  // Outlasts pi's internal retry (setTimeout 0) and compaction-continue
-  // (setTimeout 100); see badlogic/pi-mono#2023, #2110.
-  const SETTLED_WINDOW_MS = 800;
   const shortcuts = resolveAutoresearchShortcuts();
 
   const dashboardHintVariants = (): string[] => {
@@ -1135,7 +1132,6 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const cancelPendingResume = (runtime: AutoresearchRuntime): void => {
     pausePendingResume(runtime);
     runtime.pendingResumeMessage = null;
-    runtime.pendingResumeDelayMs = null;
   };
 
   const markAutoResumeSent = (runtime: AutoresearchRuntime): void => {
@@ -1181,12 +1177,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const reschedulePendingResume = (ctx: ExtensionContext, runtime: AutoresearchRuntime): void => {
     if (!hasPendingResume(runtime)) return;
     // Keep a rate-limit cooldown intact: rescheduling must not shorten the wait.
-    schedulePendingResume(
-      ctx,
-      runtime,
-      runtime.pendingResumeMessage!,
-      runtime.pendingResumeDelayMs ?? SETTLED_WINDOW_MS,
-    );
+    schedulePendingResume(ctx, runtime, runtime.pendingResumeMessage!, runtime.pendingResumeDelayMs);
   };
 
   const hasRunExperimentsThisSession = (runtime: AutoresearchRuntime): boolean =>
@@ -1504,7 +1495,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     ctx: ExtensionContext,
     gate: (runtime: AutoresearchRuntime) => boolean,
     composeMessage: (ctx: ExtensionContext) => string = composeResumeMessage,
-    delayMs: number = SETTLED_WINDOW_MS,
+    delayMs?: number,
   ): void => {
     const runtime = getRuntime(ctx);
     if (hasPendingResume(runtime)) {
@@ -1547,12 +1538,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         );
         return;
       }
-      const totalWaitMs = waitMs + RATE_LIMIT_BUFFER_MS;
       ctx.ui.notify(
-        `Rate limited — auto-resume in ${Math.ceil(totalWaitMs / 60_000)}min`,
+        `Rate limited — auto-resume in ${Math.ceil(waitMs / 60_000)}min`,
         "warning",
       );
-      ensurePendingResume(ctx, shouldAutoResumeAfterTurn, composeResumeMessage, totalWaitMs);
+      ensurePendingResume(ctx, shouldAutoResumeAfterTurn, composeResumeMessage, waitMs);
       return;
     }
 

--- a/extensions/pi-autoresearch/provider-errors.ts
+++ b/extensions/pi-autoresearch/provider-errors.ts
@@ -9,47 +9,36 @@
 
 /** Used when the provider says "rate limited" without saying for how long. */
 export const DEFAULT_RATE_LIMIT_WAIT_MS = 30 * 60_000;
-/** Added to every parsed wait — provider clocks and ours don't agree. */
-export const RATE_LIMIT_BUFFER_MS = 60_000;
+/** Added to every wait — provider clocks and ours don't agree. */
+const BUFFER_MS = 60_000;
 
 interface AssistantMessageLike {
   role?: string;
   stopReason?: string;
   errorMessage?: unknown;
-  content?: unknown;
 }
 
-const WAIT_PATTERNS: Array<{ re: RegExp; ms: number }> = [
-  { re: /(?:try again|retry|wait|reset)[^.\n]{0,40}?(\d+)\s*hours?/i, ms: 3_600_000 },
-  { re: /(?:try again|retry|wait|reset)[^.\n]{0,40}?(\d+)\s*min/i, ms: 60_000 },
-  { re: /retry[-\s]?after[":\s]*(\d+)\s*s(?:ec)?/i, ms: 1000 },
-];
-
 const RATE_LIMITED_RE = /rate.?limit|too many requests|usage limit|quota|429/i;
+const WAIT_RE = /(?:try again|retry|wait|reset)[^.\n]{0,40}?(\d+)\s*(h|m|s)/i;
+const UNIT_MS: Record<string, number> = { h: 3_600_000, m: 60_000, s: 1000 };
 
-/** Wait before resuming after `text`, or null if it isn't a rate limit. */
+/** How long to wait before resuming after `text`, or null if it isn't a rate limit. */
 export function rateLimitWaitMs(text: string): number | null {
   if (!RATE_LIMITED_RE.test(text)) return null;
-  for (const { re, ms } of WAIT_PATTERNS) {
-    const match = text.match(re);
-    if (!match) continue;
-    const value = Number.parseInt(match[1], 10);
-    if (Number.isNaN(value) || value <= 0) continue;
-    return value * ms;
-  }
-  return DEFAULT_RATE_LIMIT_WAIT_MS;
+  const match = text.match(WAIT_RE);
+  const value = match ? Number.parseInt(match[1], 10) : 0;
+  if (match && value > 0) return value * UNIT_MS[match[2].toLowerCase()] + BUFFER_MS;
+  return DEFAULT_RATE_LIMIT_WAIT_MS + BUFFER_MS;
 }
 
 /** Error text of the final assistant message, or null if the turn succeeded. */
-export function lastAssistantError(messages: AssistantMessageLike[] | undefined): string | null {
-  if (!messages) return null;
+export function lastAssistantError(messages: AssistantMessageLike[]): string | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (message?.role !== "assistant") continue;
     if (message.stopReason !== "error") return null;
-    return typeof message.errorMessage === "string" && message.errorMessage.length > 0
-      ? message.errorMessage
-      : "Assistant turn failed";
+    const error = message.errorMessage;
+    return typeof error === "string" && error ? error : "Assistant turn failed";
   }
   return null;
 }

--- a/extensions/pi-autoresearch/provider-errors.ts
+++ b/extensions/pi-autoresearch/provider-errors.ts
@@ -1,0 +1,55 @@
+/**
+ * Provider error handling for auto-resume.
+ *
+ * A turn that died on a provider 429 ends like any other turn, so the default
+ * settle-window resume fires straight back into the cooldown. Parse the wait
+ * out of the error and delay the resume past it; for errors that are not
+ * transient, don't resume at all — replaying them just burns the loop.
+ */
+
+/** Used when the provider says "rate limited" without saying for how long. */
+export const DEFAULT_RATE_LIMIT_WAIT_MS = 30 * 60_000;
+/** Added to every parsed wait — provider clocks and ours don't agree. */
+export const RATE_LIMIT_BUFFER_MS = 60_000;
+
+interface AssistantMessageLike {
+  role?: string;
+  stopReason?: string;
+  errorMessage?: unknown;
+  content?: unknown;
+}
+
+const WAIT_PATTERNS: Array<{ re: RegExp; ms: number }> = [
+  { re: /(?:try again|retry|wait|reset)[^.\n]{0,40}?(\d+)\s*hours?/i, ms: 3_600_000 },
+  { re: /(?:try again|retry|wait|reset)[^.\n]{0,40}?(\d+)\s*min/i, ms: 60_000 },
+  { re: /retry[-\s]?after[":\s]*(\d+)\s*s(?:ec)?/i, ms: 1000 },
+];
+
+const RATE_LIMITED_RE = /rate.?limit|too many requests|usage limit|quota|429/i;
+
+/** Wait before resuming after `text`, or null if it isn't a rate limit. */
+export function rateLimitWaitMs(text: string): number | null {
+  if (!RATE_LIMITED_RE.test(text)) return null;
+  for (const { re, ms } of WAIT_PATTERNS) {
+    const match = text.match(re);
+    if (!match) continue;
+    const value = Number.parseInt(match[1], 10);
+    if (Number.isNaN(value) || value <= 0) continue;
+    return value * ms;
+  }
+  return DEFAULT_RATE_LIMIT_WAIT_MS;
+}
+
+/** Error text of the final assistant message, or null if the turn succeeded. */
+export function lastAssistantError(messages: AssistantMessageLike[] | undefined): string | null {
+  if (!messages) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role !== "assistant") continue;
+    if (message.stopReason !== "error") return null;
+    return typeof message.errorMessage === "string" && message.errorMessage.length > 0
+      ? message.errorMessage
+      : "Assistant turn failed";
+  }
+  return null;
+}

--- a/tests/provider-errors.test.mjs
+++ b/tests/provider-errors.test.mjs
@@ -7,16 +7,20 @@ import {
   rateLimitWaitMs,
 } from "../extensions/pi-autoresearch/provider-errors.ts";
 
+// Every wait carries a 1 min buffer on top of what the provider said.
+const BUFFER = 60_000;
+
 test("parses the wait out of rate limit errors", () => {
-  assert.equal(rateLimitWaitMs("rate limit exceeded, try again in 17 minutes"), 17 * 60_000);
-  assert.equal(rateLimitWaitMs("usage limit reached · resets in 2 hours"), 2 * 3_600_000);
-  assert.equal(rateLimitWaitMs('{"type":"rate_limit_error"} retry-after: 45s'), 45_000);
+  assert.equal(rateLimitWaitMs("rate limit exceeded, try again in 17 minutes"), 17 * 60_000 + BUFFER);
+  assert.equal(rateLimitWaitMs("usage limit reached · resets in 2 hours"), 2 * 3_600_000 + BUFFER);
+  assert.equal(rateLimitWaitMs('{"type":"rate_limit_error"} retry-after: 45s'), 45_000 + BUFFER);
 });
 
 test("falls back to a default wait when no duration is given", () => {
-  assert.equal(rateLimitWaitMs("429 Too Many Requests"), DEFAULT_RATE_LIMIT_WAIT_MS);
-  assert.equal(rateLimitWaitMs("quota exceeded for this key"), DEFAULT_RATE_LIMIT_WAIT_MS);
-  assert.equal(rateLimitWaitMs("rate limit hit, try again in 0 min"), DEFAULT_RATE_LIMIT_WAIT_MS);
+  const fallback = DEFAULT_RATE_LIMIT_WAIT_MS + BUFFER;
+  assert.equal(rateLimitWaitMs("429 Too Many Requests"), fallback);
+  assert.equal(rateLimitWaitMs("quota exceeded for this key"), fallback);
+  assert.equal(rateLimitWaitMs("rate limit hit, try again in 0 min"), fallback);
 });
 
 test("non rate limit errors are not waits", () => {
@@ -39,7 +43,6 @@ test("reads the error off the final assistant message only", () => {
   assert.equal(lastAssistantError(recovered), null);
 
   assert.equal(lastAssistantError([]), null);
-  assert.equal(lastAssistantError(undefined), null);
   assert.equal(
     lastAssistantError([{ role: "assistant", stopReason: "error" }]),
     "Assistant turn failed",

--- a/tests/provider-errors.test.mjs
+++ b/tests/provider-errors.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_RATE_LIMIT_WAIT_MS,
+  lastAssistantError,
+  rateLimitWaitMs,
+} from "../extensions/pi-autoresearch/provider-errors.ts";
+
+test("parses the wait out of rate limit errors", () => {
+  assert.equal(rateLimitWaitMs("rate limit exceeded, try again in 17 minutes"), 17 * 60_000);
+  assert.equal(rateLimitWaitMs("usage limit reached · resets in 2 hours"), 2 * 3_600_000);
+  assert.equal(rateLimitWaitMs('{"type":"rate_limit_error"} retry-after: 45s'), 45_000);
+});
+
+test("falls back to a default wait when no duration is given", () => {
+  assert.equal(rateLimitWaitMs("429 Too Many Requests"), DEFAULT_RATE_LIMIT_WAIT_MS);
+  assert.equal(rateLimitWaitMs("quota exceeded for this key"), DEFAULT_RATE_LIMIT_WAIT_MS);
+  assert.equal(rateLimitWaitMs("rate limit hit, try again in 0 min"), DEFAULT_RATE_LIMIT_WAIT_MS);
+});
+
+test("non rate limit errors are not waits", () => {
+  assert.equal(rateLimitWaitMs("400 invalid request: context length exceeded"), null);
+  assert.equal(rateLimitWaitMs("connection reset by peer"), null);
+});
+
+test("reads the error off the final assistant message only", () => {
+  const failed = [
+    { role: "assistant", stopReason: "stop" },
+    { role: "user", content: "go" },
+    { role: "assistant", stopReason: "error", errorMessage: "429 rate limit" },
+  ];
+  assert.equal(lastAssistantError(failed), "429 rate limit");
+
+  const recovered = [
+    { role: "assistant", stopReason: "error", errorMessage: "429 rate limit" },
+    { role: "assistant", stopReason: "stop" },
+  ];
+  assert.equal(lastAssistantError(recovered), null);
+
+  assert.equal(lastAssistantError([]), null);
+  assert.equal(lastAssistantError(undefined), null);
+  assert.equal(
+    lastAssistantError([{ role: "assistant", stopReason: "error" }]),
+    "Assistant turn failed",
+  );
+});


### PR DESCRIPTION
## Problem

A turn that dies on a provider rate limit ends through `agent_end` like any successful turn, so `ensurePendingResume` schedules the resume on the 800 ms settle window and the loop walks straight back into the cooldown. Every retry fails the same way until `AUTORESUME_TURN_LIMIT` or the consecutive-failure override trips — the session is spent, and nothing tells the user why.

Same shape for non-transient failures (bad request, context overflow, network): the resume message replays a turn that cannot succeed.

In practice the 429 often arrives as a bare JSON error body with no `Retry-After` header, so the wait has to be read out of the message text.

## Change

`agent_end` now looks at the final assistant message before scheduling:

- **Rate limited** — resume is scheduled with the wait parsed from the error text (`try again in 17 minutes`, `resets in 2 hours`, `retry-after: 45s`), plus a 1 min buffer. No duration in the message means a 30 min default. The user gets a notification with the ETA.
- **Any other agent error** — no resume; notify and let the user decide.
- **Clean turn** — unchanged.

`schedulePendingResume` takes an optional delay (default `SETTLED_WINDOW_MS`, so every existing call site behaves exactly as before), and `reschedulePendingResume` reuses the stored delay so a settle-window reschedule cannot shorten an active cooldown.

## Notes

- New pure module `extensions/pi-autoresearch/provider-errors.ts` (~55 lines) — no I/O, no session state.
- 4 new tests in `tests/provider-errors.test.mjs`; full suite is 50 passing.
- Verified by loading the patched extension in pi.
