### PR TITLE
feat: freshContextPerIteration — a clean pi session per experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `freshContextPerIteration` config flag (default `false`). When enabled, autoresearch starts a genuinely fresh pi session after every experiment instead of relying on in-session compaction: the auto-resume choke point queues a new `/autoresearch-next` command whose handler calls `ctx.newSession(...)`, and the replacement session rehydrates all state from `.auto/*` + `git log` via `session_start`. Each experiment gets a clean model context; the filesystem is the sole memory between experiments. `maxIterations` and the consecutive-discard/crash stop still gate the handoff. `/autoresearch-next` can also be invoked manually to force a fresh iteration.
+
 ## [1.6.2] - 2026-07-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 ```json
 {
   "workingDir": "/path/to/project",
-  "maxIterations": 50
+  "maxIterations": 50,
+  "freshContextPerIteration": false
 }
 ```
 
@@ -216,10 +217,17 @@ Create `.auto/config.json` in your pi session directory to customize behavior:
 |-------|------|-------------|
 | `workingDir` | string | Override the directory for all autoresearch operations — file I/O, command execution, and git. Supports absolute or relative paths (resolved against the pi session cwd). The config file itself always stays under the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | number | Maximum experiments before auto-stopping. The agent is told to stop and won't run more experiments until a new segment is initialized. |
+| `freshContextPerIteration` | boolean | Start a fresh pi session after every experiment instead of relying on in-session compaction. Each iteration gets a clean model context and rehydrates state from `.auto/*` + `git log`. Default `false`. See [Long-running loops and context](#long-running-loops-and-context). |
 
 ### Long-running loops and context
 
 The loop is designed to run unattended across context limits. When pi's [auto-compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md) summarizes the older portion of the conversation, autoresearch detects the resulting idle and re-prompts the agent to re-read `.auto/prompt.md`, the tail of `.auto/log.jsonl`, `.auto/ideas.md`, and `git log` before continuing. All progress is persisted in those files, so the post-summary turn rehydrates from the source of truth instead of relying on whatever survived compaction. No tuning required — if pi's auto-compaction is enabled (the default), this just works.
+
+By default, isolation between experiments relies on that compaction/re-prompt cycle within a **single** pi session, so conversational assumptions from experiment N can still bias experiment N+15.
+
+Set **`freshContextPerIteration: true`** to instead start a genuinely fresh pi session after every experiment. When enabled, the auto-resume choke point queues the `/autoresearch-next` command; its handler waits for idle, then calls `ctx.newSession(...)`, tearing down the current session and kicking off a replacement. The replacement session has **no conversation history** and rehydrates entirely from disk — `.auto/prompt.md`, the tail of `.auto/log.jsonl` (which also re-enables autoresearch mode and the gated tools via `session_start`), `.auto/ideas.md`, and `git log` — then runs exactly one experiment. The filesystem becomes the sole memory between experiments, which forces `.auto/*` to actually be sufficient and gives each experiment a clean model context.
+
+Safety under `freshContextPerIteration`: `maxIterations` and the consecutive-discard/crash stop (both read from the persisted `.auto/log.jsonl`) still gate the handoff, so a saturated or runaway loop still stops. The 200-turn auto-resume ceiling is per-session and effectively resets each iteration (each fresh session runs ~one turn), so rely on `maxIterations` for a hard cap. Default is `false`. You can also invoke `/autoresearch-next` manually to force a fresh iteration.
 
 ---
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -464,6 +464,8 @@ function currentResults(results: ExperimentResult[], segment: number): Experimen
 interface AutoresearchConfig {
   maxIterations?: number;
   workingDir?: string;
+  /** Start a fresh pi session after each experiment instead of compacting in place (default: false). */
+  freshContextPerIteration?: boolean;
 }
 
 /** Read the config file (.auto/config.json, legacy autoresearch.config.json) from the given directory (always ctx.cwd) */
@@ -483,6 +485,16 @@ function readMaxExperiments(cwd: string): number | null {
   return (typeof config.maxIterations === "number" && config.maxIterations > 0)
     ? Math.floor(config.maxIterations)
     : null;
+}
+
+/**
+ * Read `freshContextPerIteration` from the config file (default: false).
+ * When true, autoresearch starts a fresh pi session after every experiment
+ * instead of relying on in-session compaction, so each iteration gets a clean
+ * model context and rehydrates state from `.auto/*` + git.
+ */
+export function readFreshContextPerIteration(cwd: string): boolean {
+  return readConfig(cwd).freshContextPerIteration === true;
 }
 
 /**
@@ -1151,7 +1163,15 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
     cancelPendingResume(runtime);
     markAutoResumeSent(runtime);
-    pi.sendUserMessage(message);
+    // Fresh-context mode: hand off to a brand-new session instead of prompting
+    // in place. newSession() must run from a command handler, so queue the
+    // /autoresearch-next command; its handler tears down this session and kicks
+    // off the replacement, which rehydrates state from .auto/* + git.
+    if (readFreshContextPerIteration(ctx.cwd)) {
+      pi.sendUserMessage("/autoresearch-next");
+    } else {
+      pi.sendUserMessage(message);
+    }
   };
 
   const schedulePendingResume = (ctx: ExtensionContext, runtime: AutoresearchRuntime, message: string): void => {
@@ -1198,6 +1218,20 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       "Run the next iteration now.",
       "Pick the most promising hypothesis from the ideas backlog or the latest `next:` hints in recent runs, then call run_experiment + log_experiment.",
       "Do not re-read .auto/prompt.md or .auto/log.jsonl — the compaction summary already contains them.",
+      BENCHMARK_GUARDRAIL,
+    ].join(" ");
+  };
+
+  // Fresh-context handoff kickoff. Unlike the compaction resume, the
+  // replacement session has NO history and NO compaction summary, so it must
+  // rehydrate everything from disk itself.
+  const composeFreshSessionResumeMessage = (_ctx: ExtensionContext): string => {
+    return [
+      "Run the next autoresearch iteration in a fresh session.",
+      "You have NO conversation history from previous experiments — rehydrate all state from disk first:",
+      "read .auto/prompt.md (experiment rules), the tail of .auto/log.jsonl (config header + recent results), .auto/ideas.md if present, and recent git log.",
+      "Then pick the single most promising hypothesis and run exactly one experiment: call run_experiment + log_experiment.",
+      "Do not call init_experiment — the loop is already initialized.",
       BENCHMARK_GUARDRAIL,
     ].join(" ");
   };
@@ -3062,6 +3096,35 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       // must stay `/skill:...`-prefixed for command expansion.
       const message = activationSteer && rulesLoaded ? `${activationSteer}\n\n${kickoff}` : kickoff;
       sendWhenReady(ctx, message);
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // /autoresearch-next — fresh-context handoff between experiments.
+  //
+  // newSession() may only be called from a command handler (calling it from a
+  // timer/event callback can deadlock), so when freshContextPerIteration is
+  // enabled the auto-resume choke point queues this command instead of
+  // prompting in place. The current session is torn down and the replacement
+  // session rehydrates all state from .auto/* + git via session_start, giving
+  // each experiment a clean model context. Also invokable manually to force a
+  // fresh iteration.
+  // -----------------------------------------------------------------------
+  pi.registerCommand("autoresearch-next", {
+    description: "Start a fresh session and run the next autoresearch iteration",
+    handler: async (_args, ctx) => {
+      if (!getRuntime(ctx).autoresearchMode) return;
+      // Fully settle first: waits out retries, compaction-continues, queued msgs.
+      await ctx.waitForIdle();
+      const kickoff = composeFreshSessionResumeMessage(ctx);
+      const parentSession = ctx.sessionManager.getSessionFile();
+      await ctx.newSession({
+        parentSession,
+        withSession: async (freshCtx) => {
+          // Only the replacement-session ctx is valid here; old pi/ctx are stale.
+          await freshCtx.sendUserMessage(kickoff);
+        },
+      });
     },
   });
 }

--- a/tests/fresh-context.test.mjs
+++ b/tests/fresh-context.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import autoresearchExtension, {
+  readFreshContextPerIteration,
+} from "../extensions/pi-autoresearch/index.ts";
+
+const AUTORESEARCH_TOOLS = ["init_experiment", "log_experiment", "run_experiment"];
+
+async function writeConfig(cwd, config) {
+  await mkdir(join(cwd, ".auto"), { recursive: true });
+  await writeFile(join(cwd, ".auto", "config.json"), JSON.stringify(config) + "\n");
+}
+
+// A same-cwd persisted log makes session_start auto-activate autoresearch mode.
+async function writeSameCwdLog(cwd, config = {}) {
+  await writeConfig(cwd, config);
+  await writeFile(
+    join(cwd, ".auto", "log.jsonl"),
+    [
+      JSON.stringify({
+        type: "config",
+        name: "Fresh-context research",
+        metricName: "runtime_ms",
+        metricUnit: "ms",
+        bestDirection: "lower",
+      }),
+      JSON.stringify({
+        run: 1,
+        commit: "abcdef0",
+        metric: 10,
+        metrics: {},
+        status: "keep",
+        description: "baseline",
+        timestamp: Date.now(),
+      }),
+    ].join("\n") + "\n",
+  );
+}
+
+// Minimal harness: enough of the pi extension + session ctx surface to drive
+// session_start and the /autoresearch-next command handler, capturing the
+// newSession() handoff and any messages sent into the replacement session.
+function createHarness({ cwd, initialActiveTools = [] }) {
+  const commands = new Map();
+  const handlers = new Map();
+  const newSessionCalls = [];
+  const freshMessages = [];
+  let activeTools = [...initialActiveTools];
+
+  autoresearchExtension({
+    on(name, handler) {
+      handlers.set(name, handler);
+    },
+    appendEntry() {},
+    registerTool() {},
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
+    registerShortcut() {},
+    getActiveTools() {
+      return activeTools;
+    },
+    setActiveTools(nextTools) {
+      activeTools = [...nextTools];
+    },
+    sendUserMessage() {},
+  });
+
+  const ctx = {
+    cwd,
+    hasUI: true,
+    isIdle: () => true,
+    hasPendingMessages: () => false,
+    waitForIdle: async () => {},
+    sessionManager: {
+      getSessionId: () => `test:${cwd}`,
+      getBranch: () => [],
+      getSessionFile: () => `${cwd}/.auto/session.jsonl`,
+    },
+    async newSession(options) {
+      newSessionCalls.push(options);
+      if (options?.withSession) {
+        await options.withSession({
+          sendUserMessage: (content) => freshMessages.push(content),
+        });
+      }
+      return { cancelled: false };
+    },
+    ui: {
+      setWidget() {},
+      notify() {},
+    },
+  };
+
+  return {
+    commands,
+    handlers,
+    ctx,
+    newSessionCalls,
+    freshMessages,
+    activeTools: () => activeTools,
+  };
+}
+
+test("readFreshContextPerIteration defaults to false when unset", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-fresh-"));
+  try {
+    assert.equal(readFreshContextPerIteration(cwd), false);
+    await writeConfig(cwd, { maxIterations: 50 });
+    assert.equal(readFreshContextPerIteration(cwd), false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("readFreshContextPerIteration reads the boolean flag from config", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-fresh-"));
+  try {
+    await writeConfig(cwd, { freshContextPerIteration: true });
+    assert.equal(readFreshContextPerIteration(cwd), true);
+
+    await writeConfig(cwd, { freshContextPerIteration: false });
+    assert.equal(readFreshContextPerIteration(cwd), false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("readFreshContextPerIteration only treats a real boolean true as enabled", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-fresh-"));
+  try {
+    // Truthy-but-not-true values must not silently enable the feature.
+    await writeConfig(cwd, { freshContextPerIteration: "true" });
+    assert.equal(readFreshContextPerIteration(cwd), false);
+
+    await writeConfig(cwd, { freshContextPerIteration: 1 });
+    assert.equal(readFreshContextPerIteration(cwd), false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("/autoresearch-next starts a fresh session and kicks off a rehydrating experiment", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-fresh-"));
+  try {
+    await writeSameCwdLog(cwd, { freshContextPerIteration: true });
+
+    const harness = createHarness({ cwd });
+    // session_start auto-activates autoresearch mode from the same-cwd log.
+    await harness.handlers.get("session_start")({}, harness.ctx);
+    assert.deepEqual(harness.activeTools().sort(), AUTORESEARCH_TOOLS.sort());
+
+    await harness.commands.get("autoresearch-next").handler("", harness.ctx);
+
+    assert.equal(harness.newSessionCalls.length, 1);
+    assert.equal(
+      harness.newSessionCalls[0].parentSession,
+      `${cwd}/.auto/session.jsonl`,
+    );
+    assert.equal(harness.freshMessages.length, 1);
+    // The kickoff must instruct the history-less session to rehydrate from disk.
+    assert.match(harness.freshMessages[0], /fresh session/i);
+    assert.match(harness.freshMessages[0], /rehydrate/i);
+    assert.match(harness.freshMessages[0], /log\.jsonl/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("/autoresearch-next is a no-op when autoresearch mode is inactive", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-fresh-"));
+  try {
+    // No persisted log => session_start leaves autoresearch mode off.
+    const harness = createHarness({ cwd });
+    await harness.handlers.get("session_start")({}, harness.ctx);
+
+    await harness.commands.get("autoresearch-next").handler("", harness.ctx);
+
+    assert.equal(harness.newSessionCalls.length, 0);
+    assert.equal(harness.freshMessages.length, 0);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an opt-in **`freshContextPerIteration`** config flag (default `false`) that starts a genuinely fresh pi session after every experiment, instead of relying on in-session auto-compaction.

Today the loop keeps running in a single pi session and leans on Pi's auto-compaction between experiments. That works, but conversational assumptions accumulate — experiment N+15 can be biased by leftover context from earlier runs, and it never really proves that `.auto/*` is sufficient as the experiment memory. This flag makes the filesystem the *sole* memory between experiments, giving each one a clean model context.

## How it works

```
agent_end → schedulePendingResume (timer)
  → sendPendingResumeIfReady            ← single send choke point
        flag OFF: pi.sendUserMessage(message)          (unchanged behavior)
        flag ON:  pi.sendUserMessage("/autoresearch-next")
  → /autoresearch-next handler:
        await ctx.waitForIdle()
        ctx.newSession({ parentSession, withSession: fresh => fresh.sendUserMessage(kickoff) })
  → old session torn down (session_shutdown)
  → fresh session_start → reconstructState rehydrates from .auto/log.jsonl,
    re-enables autoresearch mode + gated tools
  → agent reads .auto/prompt.md + log tail + ideas.md + git log, runs ONE experiment
  → loop, clean context each time
```

Two deliberate design points, both matching the documented Pi extension API:

- **`ctx.newSession()` may only be called from a command handler** — calling it from a timer/event callback can deadlock. So rather than calling it directly in the resume timer, the choke point queues a new `/autoresearch-next` command (the same `sendUserMessage("/cmd")` pattern the docs use for `reload-runtime`), whose handler performs the handoff.
- **`withSession` uses only the fresh replacement-session ctx** to send the kickoff; the old `pi`/`ctx` are treated as stale.

## Safety

- `maxIterations` and the consecutive-discard/crash stop both read the persisted `.auto/log.jsonl`, so they survive session resets and still gate the handoff (checked in `ensurePendingResume` **and** `sendPendingResumeIfReady`, before the new branch). A saturated or runaway loop still stops.
- The 200-turn auto-resume ceiling is per-session, so it effectively resets each iteration (each fresh session runs ~one turn) — rely on `maxIterations` for a hard cap. Noted in the README.
- `/autoresearch-next` can also be invoked manually to force a fresh iteration.

## Changes

- `extensions/pi-autoresearch/index.ts`: `freshContextPerIteration` config field + exported `readFreshContextPerIteration()`, `composeFreshSessionResumeMessage()`, the `/autoresearch-next` command, and the one-line branch in `sendPendingResumeIfReady`.
- `tests/fresh-context.test.mjs`: config-reader cases (default/false/true/non-boolean) + `/autoresearch-next` handoff wiring, including the inactive-mode no-op.
- README (config table + "Long-running loops and context") and CHANGELOG.

Default is `false`, so existing behavior is unchanged.

## Testing

`pnpm test` → **51 passing** (5 new). `node --experimental-strip-types --check` clean.
