### PR TITLE
Mention hidden holdout benchmark

### DIFF
--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1067,7 +1067,7 @@ function renderDashboardLines(
 
 export default function autoresearchExtension(pi: ExtensionAPI) {
   const BENCHMARK_GUARDRAIL =
-    "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks.";
+    "Be careful not to overfit to the benchmarks and do not cheat on the benchmarks. Your changes will be judged against a hidden holdout benchmark.";
 
   // Outlasts pi's internal retry (setTimeout 0) and compaction-continue
   // (setTimeout 100); see badlogic/pi-mono#2023, #2110.


### PR DESCRIPTION
This was a very interesting idea from [Dan Luu](https://danluu.com/benchpocalypse/). Even if a hidden holdout set _does not exist_, simply mentioning that one does causes the agent to produce more generalized code.