### PR TITLE
fix: avoid 'ctrl+shift+f' clash with pi's built-in TUI search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Avoid shortcut clash with pi's built-in TUI search by changing the fullscreen dashboard default from `ctrl+shift+f` to `ctrl+shift+d`.
 
 ## [1.6.2] - 2026-07-09
 

--- a/extensions/pi-autoresearch/shortcuts.ts
+++ b/extensions/pi-autoresearch/shortcuts.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
-export const DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT = "ctrl+shift+f";
+export const DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT = "ctrl+shift+d";
 
 const CONFIG_FILE_NAME = "pi-autoresearch.json";
 


### PR DESCRIPTION
**Problem**

The autoresearch fullscreen dashboard defaults to `ctrl+shift+f`, which is also pi's built-in binding for `tui.altScreen.search` (search the rendered transcript). Whichever registers second wins, so one of the two features silently stops working out of the box.

**Fix**

Change the default fullscreen-dashboard shortcut to `ctrl+shift+d`, which does not collide with any pi built-in binding. The shortcut remains reconfigurable via `pi-autoresearch.json` (set `fullscreenDashboard: null` to disable).

**Scoping**

- `shortcuts.ts`: default constant changed
- CHANGELOG entry added
- `tests/shortcuts.test.mjs`: all 7 pass

Verified against pi's built-in `ctrl+shift+*` map (`altScreen.search`, `altScreen.searchPrevious`, `app.model.cycleBackward`, `app.tree.filter.cycleBackward`, `altScreen.previous/nextPrompt`) — `ctrl+shift+d` is free.