### PR TITLE
feat: make keyboard shortcuts opt-in, add /autoresearch dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [1.7.0] - 2026-08-18
-
 ### Changed
 
 - **Breaking:** no keyboard shortcuts are bound by default anymore. The fullscreen dashboard default chord `ctrl+shift+f` collided with pi 0.84.2's new built-in transcript search (#86) — and any hardcoded default will eventually collide with a future pi built-in. Shortcuts are now strictly opt-in via `<agent-dir>/extensions/pi-autoresearch.json`. To restore the old behavior: `{ "shortcuts": { "fullscreenDashboard": "ctrl+shift+f" } }`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-18
+
+### Changed
+
+- **Breaking:** no keyboard shortcuts are bound by default anymore. The fullscreen dashboard default chord `ctrl+shift+f` collided with pi 0.84.2's new built-in transcript search (#86) — and any hardcoded default will eventually collide with a future pi built-in. Shortcuts are now strictly opt-in via `<agent-dir>/extensions/pi-autoresearch.json`. To restore the old behavior: `{ "shortcuts": { "fullscreenDashboard": "ctrl+shift+f" } }`.
+
+### Added
+
+- `/autoresearch dashboard` subcommand opens the fullscreen dashboard overlay — the keyboard-free way to reach it.
+- The `export` (`/autoresearch export`) and `off` (`/autoresearch off`) actions can now be bound to opt-in shortcuts alongside `fullscreenDashboard`.
+- README guidance (aimed at agents) for verifying a chord against the installed pi's built-in keymap before writing it to the shortcut config.
+
 ## [1.6.2] - 2026-07-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ pi install npm:pi-autoresearch
 | `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `.auto/log.jsonl` intact. |
 | `/autoresearch clear` | Delete `.auto/log.jsonl`, reset all state, and turn autoresearch mode off. Use this for a clean start. |
 | `/autoresearch export` | Open a live dashboard in your browser. Auto-updates as experiments run. |
+| `/autoresearch dashboard` | Open the fullscreen scrollable dashboard overlay in the terminal. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
 
 **Examples:**
 
@@ -55,35 +56,71 @@ pi install npm:pi-autoresearch
 /autoresearch optimize unit test runtime, monitor correctness
 /autoresearch model training, run 5 minutes of train.py and note the loss ratio as optimization target
 /autoresearch export
+/autoresearch dashboard
 /autoresearch off
 /autoresearch clear
 ```
 
-### Keyboard shortcuts
+### Keyboard shortcuts (opt-in)
 
-| Shortcut     | Description |
-|--------------|-------------|
-| `Ctrl+Shift+F` | Open fullscreen scrollable dashboard overlay. Navigate with `↑`/`↓`/`j`/`k`, `PageUp`/`PageDown`/`u`/`d`, `g`/`G` for top/bottom, `Escape` or `q` to close. |
+No keyboard shortcuts are bound by default — pi's built-in keymap grows with every
+release, so any default chord eventually collides with it (this happened with
+`ctrl+shift+f` vs. pi's transcript search). Every action is available as a
+`/autoresearch` subcommand instead.
 
-To avoid conflicts with other pi extensions, override or disable these shortcuts in
-`<agent-dir>/extensions/pi-autoresearch.json`. `<agent-dir>` is the active pi profile
-config directory (usually `~/.pi/agent`, or `PI_CODING_AGENT_DIR` when set):
+If you prefer chords, opt in via `<agent-dir>/extensions/pi-autoresearch.json`.
+`<agent-dir>` is the active pi profile config directory (usually `~/.pi/agent`,
+or `PI_CODING_AGENT_DIR` when set):
 
 ```json
 {
   "shortcuts": {
-    "fullscreenDashboard": "ctrl+shift+y"
+    "fullscreenDashboard": "ctrl+shift+y",
+    "export": "alt+shift+e",
+    "off": null
   }
 }
 ```
 
-Use `null` to skip registering a shortcut. Omitted shortcuts keep their defaults.
+| Config key | Action | Command equivalent |
+|------------|--------|--------------------|
+| `fullscreenDashboard` | Open the fullscreen dashboard overlay | `/autoresearch dashboard` |
+| `export` | Open the browser dashboard | `/autoresearch export` |
+| `off` | Turn autoresearch mode off | `/autoresearch off` |
+
+Omitted or `null` keys stay unbound. Pick chords that don't clash with
+[pi's built-in keybindings](https://github.com/badlogic/pi-mono/blob/main/docs/keybindings.md)
+or other extensions — extension shortcuts win conflicts, so a clashing chord
+hijacks the built-in action.
+
+#### Picking a free chord (guidance for agents)
+
+Don't guess a chord — check it against the installed pi's keymap first:
+
+```bash
+PI_ROOT=$(ls -d ~/.pi/pkg/pi-* 2>/dev/null | sort -V | tail -1)
+[ -n "$PI_ROOT" ] || PI_ROOT="$(npm root -g)/@earendil-works/pi-coding-agent"
+node --input-type=module -e '
+const { KEYBINDINGS } = await import(process.argv[1] + "/dist/core/keybindings.js");
+const taken = new Set(Object.values(KEYBINDINGS).flatMap(b => [b.defaultKeys].flat()).map(k => k.toLowerCase()));
+console.log(taken.has(process.argv[2].toLowerCase()) ? "TAKEN" : "FREE");
+' "$PI_ROOT" ctrl+shift+y
+```
+
+Chords in `<agent-dir>/keybindings.json` values are also taken. Write a
+verified-free chord into `<agent-dir>/extensions/pi-autoresearch.json` (merge
+with existing contents), then `/reload` pi and confirm no `Extension shortcut
+conflict` warning appears.
+
+Good candidates as of pi 0.84.x: `ctrl+shift+y`, `ctrl+shift+u`, `alt+shift+f`,
+`ctrl+alt+d`. Always re-verify — pi's keymap grows over time, which is exactly
+why this extension binds nothing by default.
 
 ### UI
 
 - **Dashboard widget** — always visible above the editor: a full results table with columns for commit, metric, status, and description.
 - **Confidence score** — after 3+ runs, shows how the best improvement compares to the session noise floor. ≥2.0× (green) = likely real, 1.0–2.0× (yellow) = above noise but marginal, <1.0× (red) = within noise.
-- **Fullscreen overlay** — `Ctrl+Shift+F` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
+- **Fullscreen overlay** — `/autoresearch dashboard` opens a scrollable full-terminal dashboard. Shows a live spinner with elapsed time for running experiments.
 
 ### Skills
 
@@ -157,7 +194,7 @@ The agent reads `.auto/log.jsonl`, groups kept experiments into logical changese
 ### 4. Monitor progress
 
 - **Widget** — full results table, always visible above the editor
-- **`Ctrl+Shift+F`** — fullscreen scrollable dashboard overlay (config key: `shortcuts.fullscreenDashboard`)
+- **`/autoresearch dashboard`** — fullscreen scrollable dashboard overlay (optional chord: `shortcuts.fullscreenDashboard`)
 - **`/autoresearch export`** — open a live browser dashboard with chart and share card
 - **`Escape`** — interrupt anytime and ask for a summary
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,29 @@ Each key binds its `/autoresearch` subcommand: `fullscreenDashboard` → `dashbo
 
 Pick a chord that's free in [pi's built-in keybindings](https://github.com/badlogic/pi-mono/blob/main/docs/keybindings.md)
 and your `<agent-dir>/keybindings.json` — extension shortcuts win conflicts, so a
-clashing chord hijacks the built-in action. `ctrl+shift+y`, `ctrl+shift+u`,
-`alt+shift+f`, and `ctrl+alt+d` are free as of pi 0.84.x. After `/reload`, confirm
-pi shows no `Extension shortcut conflict` warning.
+clashing chord hijacks the built-in action.
+
+#### Picking a free chord (guidance for agents)
+
+Don't guess a chord — check it against the installed pi's built-in keymap first:
+
+```bash
+PI_ROOT=$(ls -d ~/.pi/pkg/pi-* 2>/dev/null | sort -V | tail -1)
+[ -n "$PI_ROOT" ] || PI_ROOT="$(npm root -g)/@earendil-works/pi-coding-agent"
+node --input-type=module -e '
+const { KEYBINDINGS } = await import(process.argv[1] + "/dist/core/keybindings.js");
+const taken = new Set(Object.values(KEYBINDINGS).flatMap(({ defaultKeys }) => defaultKeys).map((key) => key.toLowerCase()));
+console.log(taken.has(process.argv[2].toLowerCase()) ? "TAKEN" : "FREE");
+' "$PI_ROOT" ctrl+shift+y
+```
+
+Chords in `<agent-dir>/keybindings.json` values are also taken. Write a
+verified-free chord into `<agent-dir>/extensions/pi-autoresearch.json`, then
+`/reload` pi and confirm no `Extension shortcut conflict` warning appears.
+
+`ctrl+shift+y`, `ctrl+shift+u`, `alt+shift+f`, and `ctrl+alt+d` are free as of
+pi 0.84.x. Always re-verify — pi's keymap grows over time, which is why this
+extension binds nothing by default.
 
 ### UI
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ pi install npm:pi-autoresearch
 
 ### Keyboard shortcuts (opt-in)
 
-No keyboard shortcuts are bound by default — pi's built-in keymap grows with every
-release, so any default chord eventually collides with it (this happened with
-`ctrl+shift+f` vs. pi's transcript search). Every action is available as a
-`/autoresearch` subcommand instead.
+No shortcuts are bound by default — pi's built-in keymap grows with every release,
+so any default chord eventually collides with it (this happened with `ctrl+shift+f`
+vs. pi's transcript search). Every action is available as a `/autoresearch`
+subcommand instead.
 
-If you prefer chords, opt in via `<agent-dir>/extensions/pi-autoresearch.json`.
-`<agent-dir>` is the active pi profile config directory (usually `~/.pi/agent`,
-or `PI_CODING_AGENT_DIR` when set):
+To opt in, add chords to `<agent-dir>/extensions/pi-autoresearch.json`
+(`<agent-dir>` is usually `~/.pi/agent`, or `PI_CODING_AGENT_DIR` when set).
+Omitted or `null` keys stay unbound:
 
 ```json
 {
@@ -82,39 +82,14 @@ or `PI_CODING_AGENT_DIR` when set):
 }
 ```
 
-| Config key | Action | Command equivalent |
-|------------|--------|--------------------|
-| `fullscreenDashboard` | Open the fullscreen dashboard overlay | `/autoresearch dashboard` |
-| `export` | Open the browser dashboard | `/autoresearch export` |
-| `off` | Turn autoresearch mode off | `/autoresearch off` |
+Each key binds its `/autoresearch` subcommand: `fullscreenDashboard` → `dashboard`,
+`export` → `export`, `off` → `off`.
 
-Omitted or `null` keys stay unbound. Pick chords that don't clash with
-[pi's built-in keybindings](https://github.com/badlogic/pi-mono/blob/main/docs/keybindings.md)
-or other extensions — extension shortcuts win conflicts, so a clashing chord
-hijacks the built-in action.
-
-#### Picking a free chord (guidance for agents)
-
-Don't guess a chord — check it against the installed pi's keymap first:
-
-```bash
-PI_ROOT=$(ls -d ~/.pi/pkg/pi-* 2>/dev/null | sort -V | tail -1)
-[ -n "$PI_ROOT" ] || PI_ROOT="$(npm root -g)/@earendil-works/pi-coding-agent"
-node --input-type=module -e '
-const { KEYBINDINGS } = await import(process.argv[1] + "/dist/core/keybindings.js");
-const taken = new Set(Object.values(KEYBINDINGS).flatMap(b => [b.defaultKeys].flat()).map(k => k.toLowerCase()));
-console.log(taken.has(process.argv[2].toLowerCase()) ? "TAKEN" : "FREE");
-' "$PI_ROOT" ctrl+shift+y
-```
-
-Chords in `<agent-dir>/keybindings.json` values are also taken. Write a
-verified-free chord into `<agent-dir>/extensions/pi-autoresearch.json` (merge
-with existing contents), then `/reload` pi and confirm no `Extension shortcut
-conflict` warning appears.
-
-Good candidates as of pi 0.84.x: `ctrl+shift+y`, `ctrl+shift+u`, `alt+shift+f`,
-`ctrl+alt+d`. Always re-verify — pi's keymap grows over time, which is exactly
-why this extension binds nothing by default.
+Pick a chord that's free in [pi's built-in keybindings](https://github.com/badlogic/pi-mono/blob/main/docs/keybindings.md)
+and your `<agent-dir>/keybindings.json` — extension shortcuts win conflicts, so a
+clashing chord hijacks the built-in action. `ctrl+shift+y`, `ctrl+shift+u`,
+`alt+shift+f`, and `ctrl+alt+d` are free as of pi 0.84.x. After `/reload`, confirm
+pi shows no `Extension shortcut conflict` warning.
 
 ### UI
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -22,7 +22,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { truncateTail, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
-import { Text, truncateToWidth, matchesKey, visibleWidth, type KeyId } from "@earendil-works/pi-tui";
+import { Text, truncateToWidth, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -2576,7 +2576,17 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // Fullscreen scrollable dashboard overlay
   // -----------------------------------------------------------------------
 
+  function canOpenFullscreenDashboard(ctx: ExtensionContext): boolean {
+    const mode = (ctx as ExtensionContext & { mode?: string }).mode;
+    return mode === undefined ? ctx.hasUI : mode === "tui";
+  }
+
   async function openFullscreenDashboard(ctx: ExtensionContext): Promise<void> {
+    if (!canOpenFullscreenDashboard(ctx)) {
+      ctx.ui.notify("The fullscreen dashboard is only available in TUI mode", "info");
+      return;
+    }
+
     const runtime = getRuntime(ctx);
     const state = runtime.state;
     if (!runtime.autoresearchMode) {
@@ -2743,8 +2753,7 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   for (const action of SHORTCUT_ACTIONS) {
     const chord = shortcuts[action];
-    // Config values are arbitrary user strings; pi validates chords at registration.
-    if (chord) pi.registerShortcut(chord as KeyId, shortcutActions[action]);
+    if (chord) pi.registerShortcut(chord, shortcutActions[action]);
   }
 
   // -----------------------------------------------------------------------

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -8,7 +8,7 @@
  * - `run_experiment` tool — runs any command, times it, captures output, detects pass/fail
  * - `log_experiment` tool — records results with session-persisted state
  * - Status widget showing experiment count + best metric
- * - Configurable shortcut to open the fullscreen dashboard overlay
+ * - Fullscreen dashboard overlay via /autoresearch dashboard (opt-in shortcuts available)
  * - Adds autoresearch guidance to the system prompt and points the agent at .auto/prompt.md
  * - Injects .auto/prompt.md into context on every turn via before_agent_start
  */
@@ -22,7 +22,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { truncateTail, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
-import { Text, truncateToWidth, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
+import { Text, truncateToWidth, matchesKey, visibleWidth, type KeyId } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -51,7 +51,7 @@ import {
   autoresearchSummaryPathsFor,
   buildAutoresearchCompactionSummary,
 } from "./compaction.ts";
-import { resolveAutoresearchShortcuts } from "./shortcuts.ts";
+import { resolveAutoresearchShortcuts, SHORTCUT_ACTIONS } from "./shortcuts.ts";
 import { sessionFilePath, sessionFileCandidates, ensureParentDir, AUTO_DIR } from "./paths.ts";
 
 // ---------------------------------------------------------------------------
@@ -1075,11 +1075,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   const shortcuts = resolveAutoresearchShortcuts();
 
   const dashboardHintVariants = (): string[] => {
-    if (!shortcuts.fullscreenDashboard) return [];
-    return [
-      `${shortcuts.fullscreenDashboard} fullscreen`,
-      shortcuts.fullscreenDashboard,
-    ];
+    if (shortcuts.fullscreenDashboard) {
+      return [
+        `${shortcuts.fullscreenDashboard} fullscreen`,
+        shortcuts.fullscreenDashboard,
+      ];
+    }
+    return ["/autoresearch dashboard fullscreen", "/autoresearch dashboard"];
   };
 
   const runtimeStore = createRuntimeStore();
@@ -1283,18 +1285,20 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
   const autoresearchHelp = () =>
     [
-      "Usage: /autoresearch [off|clear|export|<text>]",
+      "Usage: /autoresearch [off|clear|export|dashboard|<text>]",
       "",
       "<text> enters autoresearch mode and starts or resumes the loop.",
       "off leaves autoresearch mode.",
       "clear deletes the session log (.auto/log.jsonl) and turns autoresearch mode off.",
       "export opens a local live dashboard for the session log in your browser.",
+      "dashboard opens the fullscreen dashboard overlay in the terminal.",
 
       "",
       "Examples:",
       "  /autoresearch optimize unit test runtime, monitor correctness",
       "  /autoresearch model training, run 5 minutes of train.py and note the loss ratio as optimization target",
       "  /autoresearch export",
+      "  /autoresearch dashboard",
     ].join("\n");
 
   // -----------------------------------------------------------------------
@@ -2569,152 +2573,175 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Fullscreen scrollable dashboard overlay shortcut
+  // Fullscreen scrollable dashboard overlay
   // -----------------------------------------------------------------------
 
-  if (shortcuts.fullscreenDashboard) {
-    pi.registerShortcut(shortcuts.fullscreenDashboard, {
-      description: "Fullscreen autoresearch dashboard",
-      handler: async (ctx) => {
-        const runtime = getRuntime(ctx);
-        const state = runtime.state;
-        if (!runtime.autoresearchMode) {
-          ctx.ui.notify("Autoresearch mode is not active", "info");
-          return;
+  async function openFullscreenDashboard(ctx: ExtensionContext): Promise<void> {
+    const runtime = getRuntime(ctx);
+    const state = runtime.state;
+    if (!runtime.autoresearchMode) {
+      ctx.ui.notify("Autoresearch mode is not active", "info");
+      return;
+    }
+    if (state.results.length === 0) {
+      ctx.ui.notify("No experiments yet", "info");
+      return;
+    }
+
+    await ctx.ui.custom<void>(
+      (tui, theme, _kb, done) => {
+      let scrollOffset = 0;
+      let lastViewportRows = 8;
+      let lastTotalRows = 0;
+      overlayTui = tui;
+
+      spinnerInterval = setInterval(() => {
+        spinnerFrame = (spinnerFrame + 1) % SPINNER.length;
+        if (runtime.runningExperiment) tui.requestRender();
+      }, 80);
+
+      const buildOverlayContent = (renderWidth: number): string[] => {
+        const content = renderDashboardLines(state, renderWidth, theme, 0);
+        if (runtime.runningExperiment) {
+          const elapsed = formatElapsed(Date.now() - runtime.runningExperiment.startedAt);
+          const frame = SPINNER[spinnerFrame % SPINNER.length];
+          const nextIdx = state.results.length + 1;
+          content.push(
+            truncateToWidth(
+              `  ${theme.fg("dim", String(nextIdx).padEnd(3))}` +
+                theme.fg("warning", `${frame} running… ${elapsed}`),
+              renderWidth,
+              "…",
+              true
+            )
+          );
         }
-        if (state.results.length === 0) {
-          ctx.ui.notify("No experiments yet", "info");
-          return;
-        }
+        return content;
+      };
 
-        await ctx.ui.custom<void>(
-          (tui, theme, _kb, done) => {
-          let scrollOffset = 0;
-          let lastViewportRows = 8;
-          let lastTotalRows = 0;
-          overlayTui = tui;
+      return {
+        render(width: number): string[] {
+          const { height } = getTuiSize(tui);
+          const safeWidth = Math.max(1, width || getTuiSize(tui).width);
+          const viewportRows = Math.max(4, height - 4);
+          const content = buildOverlayContent(safeWidth);
 
-          spinnerInterval = setInterval(() => {
-            spinnerFrame = (spinnerFrame + 1) % SPINNER.length;
-            if (runtime.runningExperiment) tui.requestRender();
-          }, 80);
+          const totalRows = content.length;
+          const maxScroll = Math.max(0, totalRows - viewportRows);
+          scrollOffset = clamp(scrollOffset, 0, maxScroll);
+          lastViewportRows = viewportRows;
+          lastTotalRows = totalRows;
 
-          const buildOverlayContent = (renderWidth: number): string[] => {
-            const content = renderDashboardLines(state, renderWidth, theme, 0);
-            if (runtime.runningExperiment) {
-              const elapsed = formatElapsed(Date.now() - runtime.runningExperiment.startedAt);
-              const frame = SPINNER[spinnerFrame % SPINNER.length];
-              const nextIdx = state.results.length + 1;
-              content.push(
-                truncateToWidth(
-                  `  ${theme.fg("dim", String(nextIdx).padEnd(3))}` +
-                    theme.fg("warning", `${frame} running… ${elapsed}`),
-                  renderWidth,
-                  "…",
-                  true
-                )
-              );
-            }
-            return content;
-          };
+          const out: string[] = [];
 
-          return {
-            render(width: number): string[] {
-              const { height } = getTuiSize(tui);
-              const safeWidth = Math.max(1, width || getTuiSize(tui).width);
-              const viewportRows = Math.max(4, height - 4);
-              const content = buildOverlayContent(safeWidth);
+          const title = truncateDisplayText(
+            `🔬 autoresearch${state.name ? `: ${state.name}` : ""}`,
+            Math.max(0, safeWidth - 5)
+          );
+          const fillLen = Math.max(0, safeWidth - 3 - 1 - visibleWidth(title) - 1);
 
-              const totalRows = content.length;
-              const maxScroll = Math.max(0, totalRows - viewportRows);
-              scrollOffset = clamp(scrollOffset, 0, maxScroll);
-              lastViewportRows = viewportRows;
-              lastTotalRows = totalRows;
+          out.push(
+            truncateToWidth(
+              theme.fg("borderMuted", "───") +
+                theme.fg("accent", ` ${title} `) +
+                theme.fg("borderMuted", "─".repeat(fillLen)),
+              safeWidth,
+              "…",
+              true
+            )
+          );
 
-              const out: string[] = [];
+          const visible = content.slice(scrollOffset, scrollOffset + viewportRows);
+          for (const line of visible) out.push(truncateToWidth(line, safeWidth, "…", true));
+          for (let i = visible.length; i < viewportRows; i++) out.push("");
 
-              const title = truncateDisplayText(
-                `🔬 autoresearch${state.name ? `: ${state.name}` : ""}`,
-                Math.max(0, safeWidth - 5)
-              );
-              const fillLen = Math.max(0, safeWidth - 3 - 1 - visibleWidth(title) - 1);
+          const scrollInfo = totalRows > viewportRows
+            ? ` ${scrollOffset + 1}-${Math.min(scrollOffset + viewportRows, totalRows)}/${totalRows}`
+            : "";
+          const helpText = safeWidth >= 85
+            ? ` ↑↓/j/k scroll • pgup/pgdn • g/G • esc close${scrollInfo} `
+            : ` j/k scroll • esc close${scrollInfo} `;
+          const footFill = Math.max(0, safeWidth - visibleWidth(helpText));
 
-              out.push(
-                truncateToWidth(
-                  theme.fg("borderMuted", "───") +
-                    theme.fg("accent", ` ${title} `) +
-                    theme.fg("borderMuted", "─".repeat(fillLen)),
-                  safeWidth,
-                  "…",
-                  true
-                )
-              );
+          out.push(
+            truncateToWidth(
+              theme.fg("borderMuted", "─".repeat(footFill)) + theme.fg("dim", helpText),
+              safeWidth,
+              "…",
+              true
+            )
+          );
 
-              const visible = content.slice(scrollOffset, scrollOffset + viewportRows);
-              for (const line of visible) out.push(truncateToWidth(line, safeWidth, "…", true));
-              for (let i = visible.length; i < viewportRows; i++) out.push("");
+          return out;
+        },
 
-              const scrollInfo = totalRows > viewportRows
-                ? ` ${scrollOffset + 1}-${Math.min(scrollOffset + viewportRows, totalRows)}/${totalRows}`
-                : "";
-              const helpText = safeWidth >= 85
-                ? ` ↑↓/j/k scroll • pgup/pgdn • g/G • esc close${scrollInfo} `
-                : ` j/k scroll • esc close${scrollInfo} `;
-              const footFill = Math.max(0, safeWidth - visibleWidth(helpText));
+        handleInput(data: string): void {
+          const maxScroll = Math.max(0, lastTotalRows - lastViewportRows);
 
-              out.push(
-                truncateToWidth(
-                  theme.fg("borderMuted", "─".repeat(footFill)) + theme.fg("dim", helpText),
-                  safeWidth,
-                  "…",
-                  true
-                )
-              );
-
-              return out;
-            },
-
-            handleInput(data: string): void {
-              const maxScroll = Math.max(0, lastTotalRows - lastViewportRows);
-
-              if (matchesKey(data, "escape") || data === "q") {
-                done(undefined);
-                return;
-              }
-              if (matchesKey(data, "up") || data === "k") {
-                scrollOffset = Math.max(0, scrollOffset - 1);
-              } else if (matchesKey(data, "down") || data === "j") {
-                scrollOffset = Math.min(maxScroll, scrollOffset + 1);
-              } else if (matchesKey(data, "pageUp") || data === "u") {
-                scrollOffset = Math.max(0, scrollOffset - lastViewportRows);
-              } else if (matchesKey(data, "pageDown") || data === "d") {
-                scrollOffset = Math.min(maxScroll, scrollOffset + lastViewportRows);
-              } else if (data === "g") {
-                scrollOffset = 0;
-              } else if (data === "G") {
-                scrollOffset = maxScroll;
-              }
-              tui.requestRender();
-            },
-
-            invalidate(): void {},
-
-            dispose(): void {
-              clearOverlay();
-            },
-          };
-          },
-          {
-            overlay: true,
-            overlayOptions: {
-              width: "95%",
-              maxHeight: "90%",
-              anchor: "center" as const,
-            },
+          if (matchesKey(data, "escape") || data === "q") {
+            done(undefined);
+            return;
           }
-        );
+          if (matchesKey(data, "up") || data === "k") {
+            scrollOffset = Math.max(0, scrollOffset - 1);
+          } else if (matchesKey(data, "down") || data === "j") {
+            scrollOffset = Math.min(maxScroll, scrollOffset + 1);
+          } else if (matchesKey(data, "pageUp") || data === "u") {
+            scrollOffset = Math.max(0, scrollOffset - lastViewportRows);
+          } else if (matchesKey(data, "pageDown") || data === "d") {
+            scrollOffset = Math.min(maxScroll, scrollOffset + lastViewportRows);
+          } else if (data === "g") {
+            scrollOffset = 0;
+          } else if (data === "G") {
+            scrollOffset = maxScroll;
+          }
+          tui.requestRender();
+        },
+
+        invalidate(): void {},
+
+        dispose(): void {
+          clearOverlay();
+        },
+      };
       },
-    });
+      {
+        overlay: true,
+        overlayOptions: {
+          width: "95%",
+          maxHeight: "90%",
+          anchor: "center" as const,
+        },
+      }
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Opt-in keyboard shortcuts (none bound by default; see shortcuts.ts)
+  // -----------------------------------------------------------------------
+
+  const shortcutActions: Record<
+    (typeof SHORTCUT_ACTIONS)[number],
+    { description: string; handler: (ctx: ExtensionContext) => Promise<void> | void }
+  > = {
+    fullscreenDashboard: {
+      description: "Fullscreen autoresearch dashboard",
+      handler: openFullscreenDashboard,
+    },
+    export: {
+      description: "Open the autoresearch browser dashboard",
+      handler: (ctx) => exportDashboard(ctx),
+    },
+    off: {
+      description: "Turn autoresearch mode off",
+      handler: (ctx) => turnAutoresearchOff(ctx),
+    },
+  };
+
+  for (const action of SHORTCUT_ACTIONS) {
+    const chord = shortcuts[action];
+    // Config values are arbitrary user strings; pi validates chords at registration.
+    if (chord) pi.registerShortcut(chord as KeyId, shortcutActions[action]);
   }
 
   // -----------------------------------------------------------------------
@@ -2943,8 +2970,30 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
   // /autoresearch command — enter autoresearch mode
   // -----------------------------------------------------------------------
 
+  function turnAutoresearchOff(ctx: ExtensionContext): void {
+    const runtime = getRuntime(ctx);
+    const wasRunning = !ctx.isIdle();
+    const workDir = resolveWorkDir(ctx.cwd);
+
+    recordAutoresearchActivation(workDir, false);
+    setAutoresearchMode(ctx, false);
+    runtime.autoResumeTurns = 0;
+    runtime.experimentsThisSession = 0;
+    runtime.lastRunChecks = null;
+    runtime.lastRunDuration = null;
+    runtime.runningExperiment = null;
+    cancelPendingResume(runtime);
+    stopDashboardServer();
+    clearSessionUi(ctx);
+    if (wasRunning) ctx.abort();
+    ctx.ui.notify(
+      wasRunning ? "Autoresearch mode OFF — aborting current run" : "Autoresearch mode OFF",
+      "info"
+    );
+  }
+
   pi.registerCommand("autoresearch", {
-    description: "Start, stop, clear, or resume autoresearch mode",
+    description: "Start, stop, clear, export, or open dashboards for autoresearch mode",
     handler: async (args, ctx) => {
       const runtime = getRuntime(ctx);
       const trimmedArgs = (args ?? "").trim();
@@ -2956,29 +3005,17 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       }
 
       if (command === "off") {
-        const wasRunning = !ctx.isIdle();
-        const workDir = resolveWorkDir(ctx.cwd);
-
-        recordAutoresearchActivation(workDir, false);
-        setAutoresearchMode(ctx, false);
-        runtime.autoResumeTurns = 0;
-        runtime.experimentsThisSession = 0;
-        runtime.lastRunChecks = null;
-        runtime.lastRunDuration = null;
-        runtime.runningExperiment = null;
-        cancelPendingResume(runtime);
-        stopDashboardServer();
-        clearSessionUi(ctx);
-        if (wasRunning) ctx.abort();
-        ctx.ui.notify(
-          wasRunning ? "Autoresearch mode OFF — aborting current run" : "Autoresearch mode OFF",
-          "info"
-        );
+        turnAutoresearchOff(ctx);
         return;
       }
 
       if (command === "export") {
         await exportDashboard(ctx);
+        return;
+      }
+
+      if (command === "dashboard") {
+        await openFullscreenDashboard(ctx);
         return;
       }
 

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -2623,8 +2623,10 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
         render(width: number): string[] {
           const { height } = getTuiSize(tui);
           const safeWidth = Math.max(1, width || getTuiSize(tui).width);
-          const viewportRows = Math.max(4, height - 4);
-          const content = buildOverlayContent(safeWidth);
+          // Match overlayOptions.maxHeight so pi doesn't clip the footer.
+          const overlayRows = Math.max(4, Math.floor(height * 0.9));
+          const viewportRows = Math.max(1, overlayRows - 3);
+          const content = buildOverlayContent(Math.max(4, safeWidth - 2));
 
           const totalRows = content.length;
           const maxScroll = Math.max(0, totalRows - viewportRows);
@@ -2634,26 +2636,27 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
 
           const out: string[] = [];
 
+          // Full box border: the overlay floats over the transcript, so every
+          // row must be padded to full width or the background bleeds through.
+          const innerWidth = Math.max(4, safeWidth - 2);
+          const border = (text: string) => theme.fg("border", text);
+          const boxRow = (line: string): string => {
+            const clipped = truncateToWidth(line, innerWidth, "…", true);
+            const pad = " ".repeat(Math.max(0, innerWidth - visibleWidth(clipped)));
+            return border("│") + clipped + pad + border("│");
+          };
+
           const title = truncateDisplayText(
             `🔬 autoresearch${state.name ? `: ${state.name}` : ""}`,
-            Math.max(0, safeWidth - 5)
+            Math.max(0, innerWidth - 2)
           );
-          const fillLen = Math.max(0, safeWidth - 3 - 1 - visibleWidth(title) - 1);
 
-          out.push(
-            truncateToWidth(
-              theme.fg("borderMuted", "───") +
-                theme.fg("accent", ` ${title} `) +
-                theme.fg("borderMuted", "─".repeat(fillLen)),
-              safeWidth,
-              "…",
-              true
-            )
-          );
+          out.push(border(`╭${"─".repeat(innerWidth)}╮`));
+          out.push(boxRow(` ${theme.fg("accent", title)}`));
 
           const visible = content.slice(scrollOffset, scrollOffset + viewportRows);
-          for (const line of visible) out.push(truncateToWidth(line, safeWidth, "…", true));
-          for (let i = visible.length; i < viewportRows; i++) out.push("");
+          for (const line of visible) out.push(boxRow(line));
+          for (let i = visible.length; i < viewportRows; i++) out.push(boxRow(""));
 
           const scrollInfo = totalRows > viewportRows
             ? ` ${scrollOffset + 1}-${Math.min(scrollOffset + viewportRows, totalRows)}/${totalRows}`
@@ -2661,11 +2664,11 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
           const helpText = safeWidth >= 85
             ? ` ↑↓/j/k scroll • pgup/pgdn • g/G • esc close${scrollInfo} `
             : ` j/k scroll • esc close${scrollInfo} `;
-          const footFill = Math.max(0, safeWidth - visibleWidth(helpText));
+          const footFill = Math.max(0, safeWidth - 2 - visibleWidth(helpText));
 
           out.push(
             truncateToWidth(
-              theme.fg("borderMuted", "─".repeat(footFill)) + theme.fg("dim", helpText),
+              border("╰" + "─".repeat(footFill)) + theme.fg("dim", helpText) + border("╯"),
               safeWidth,
               "…",
               true

--- a/extensions/pi-autoresearch/shortcuts.ts
+++ b/extensions/pi-autoresearch/shortcuts.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { KeyId } from "@earendil-works/pi-tui";
 
 // No shortcut is bound by default: pi's built-in keymap grows over time and
 // any hardcoded chord eventually collides with it (see issue #86). Every
@@ -9,9 +10,22 @@ export const SHORTCUT_ACTIONS = ["fullscreenDashboard", "export", "off"] as cons
 
 export type ShortcutAction = (typeof SHORTCUT_ACTIONS)[number];
 
-export type AutoresearchShortcuts = Record<ShortcutAction, string | null>;
+export type AutoresearchShortcuts = Record<ShortcutAction, KeyId | null>;
+
+type AutoresearchShortcutConfig = Partial<Record<ShortcutAction, KeyId | null>>;
 
 const CONFIG_FILE_NAME = "pi-autoresearch.json";
+const SHORTCUT_MODIFIERS = ["ctrl", "shift", "alt", "super"] as const;
+const SHORTCUT_KEYS = new Set([
+  ..."abcdefghijklmnopqrstuvwxyz0123456789",
+  "escape", "esc", "enter", "return", "tab", "space", "backspace",
+  "delete", "insert", "clear", "home", "end", "pageup", "pagedown",
+  "up", "down", "left", "right",
+  ...Array.from({ length: 12 }, (_, index) => `f${index + 1}`),
+  "`", "-", "=", "[", "]", "\\", ";", "'", ",", ".", "/", "!",
+  "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "|",
+  "~", "{", "}", ":", "<", ">", "?",
+]);
 
 export function autoresearchShortcutsConfigPath(agentDir: string = getAgentDir()): string {
   return join(agentDir, "extensions", CONFIG_FILE_NAME);
@@ -32,7 +46,7 @@ export function resolveAutoresearchShortcuts(
   return shortcutsFromConfig(config);
 }
 
-function readShortcutConfig(configPath: string): Record<string, unknown> | null {
+function readShortcutConfig(configPath: string): AutoresearchShortcutConfig | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -51,7 +65,7 @@ function readShortcutConfig(configPath: string): Record<string, unknown> | null 
     return null;
   }
 
-  return shortcuts;
+  return shortcuts as AutoresearchShortcutConfig;
 }
 
 function hasValidShortcutValues(shortcuts: Record<string, unknown>): boolean {
@@ -62,15 +76,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isValidShortcutConfigValue(value: unknown): value is string | null | undefined {
-  return (
-    value === undefined ||
-    value === null ||
-    (typeof value === "string" && value !== "")
-  );
+function isValidShortcutConfigValue(value: unknown): value is KeyId | null | undefined {
+  return value === undefined || value === null || isValidShortcut(value);
 }
 
-function shortcutsFromConfig(config: Record<string, unknown>): AutoresearchShortcuts {
+function isValidShortcut(value: unknown): value is KeyId {
+  if (typeof value !== "string" || value === "") return false;
+
+  let key = value.toLowerCase();
+  const modifiers = new Set<string>();
+  while (true) {
+    const modifier = shortcutModifierPrefix(key);
+    if (!modifier) break;
+    if (modifiers.has(modifier)) return false;
+    modifiers.add(modifier);
+    key = key.slice(modifier.length + 1);
+  }
+  return SHORTCUT_KEYS.has(key);
+}
+
+function shortcutModifierPrefix(value: string): string | null {
+  return SHORTCUT_MODIFIERS.find((modifier) => value.startsWith(`${modifier}+`)) ?? null;
+}
+
+function shortcutsFromConfig(config: AutoresearchShortcutConfig): AutoresearchShortcuts {
   const shortcuts = defaultAutoresearchShortcuts();
   for (const action of SHORTCUT_ACTIONS) {
     const configured = config[action];

--- a/extensions/pi-autoresearch/shortcuts.ts
+++ b/extensions/pi-autoresearch/shortcuts.ts
@@ -2,17 +2,16 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
-export const DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT = "ctrl+shift+f";
+// No shortcut is bound by default: pi's built-in keymap grows over time and
+// any hardcoded chord eventually collides with it (see issue #86). Every
+// action is reachable through /autoresearch subcommands; chords are opt-in.
+export const SHORTCUT_ACTIONS = ["fullscreenDashboard", "export", "off"] as const;
+
+export type ShortcutAction = (typeof SHORTCUT_ACTIONS)[number];
+
+export type AutoresearchShortcuts = Record<ShortcutAction, string | null>;
 
 const CONFIG_FILE_NAME = "pi-autoresearch.json";
-
-export interface AutoresearchShortcuts {
-  fullscreenDashboard: string | null;
-}
-
-interface AutoresearchShortcutConfig {
-  fullscreenDashboard?: unknown;
-}
 
 export function autoresearchShortcutsConfigPath(agentDir: string = getAgentDir()): string {
   return join(agentDir, "extensions", CONFIG_FILE_NAME);
@@ -30,15 +29,10 @@ export function resolveAutoresearchShortcuts(
     return defaultAutoresearchShortcuts();
   }
 
-  return {
-    fullscreenDashboard: shortcutFromConfig(
-      config.fullscreenDashboard,
-      DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT
-    ),
-  };
+  return shortcutsFromConfig(config);
 }
 
-function readShortcutConfig(configPath: string): AutoresearchShortcutConfig | null {
+function readShortcutConfig(configPath: string): Record<string, unknown> | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -61,7 +55,7 @@ function readShortcutConfig(configPath: string): AutoresearchShortcutConfig | nu
 }
 
 function hasValidShortcutValues(shortcuts: Record<string, unknown>): boolean {
-  return isValidShortcutConfigValue(shortcuts.fullscreenDashboard);
+  return SHORTCUT_ACTIONS.every((action) => isValidShortcutConfigValue(shortcuts[action]));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -76,14 +70,22 @@ function isValidShortcutConfigValue(value: unknown): value is string | null | un
   );
 }
 
-function shortcutFromConfig(configured: unknown, fallback: string): string | null {
-  if (configured === null) return null;
-  return typeof configured === "string" ? configured : fallback;
+function shortcutsFromConfig(config: Record<string, unknown>): AutoresearchShortcuts {
+  const shortcuts = defaultAutoresearchShortcuts();
+  for (const action of SHORTCUT_ACTIONS) {
+    const configured = config[action];
+    if (typeof configured === "string") {
+      shortcuts[action] = configured;
+    }
+  }
+  return shortcuts;
 }
 
 function defaultAutoresearchShortcuts(): AutoresearchShortcuts {
   return {
-    fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
+    fullscreenDashboard: null,
+    export: null,
+    off: null,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autoresearch",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "type": "module",
   "description": "Autonomous experiment loop for pi — run, measure, keep or discard. Inspired by karpathy/autoresearch.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autoresearch",
-  "version": "1.7.0",
+  "version": "1.6.2",
   "type": "module",
   "description": "Autonomous experiment loop for pi — run, measure, keep or discard. Inspired by karpathy/autoresearch.",
   "keywords": [

--- a/tests/activation.test.mjs
+++ b/tests/activation.test.mjs
@@ -47,6 +47,7 @@ function createHarness({ cwd, branch = [], initialActiveTools = [] }) {
 
   const ctx = {
     cwd,
+    mode: "tui",
     hasUI: true,
     isIdle: () => true,
     hasPendingMessages: () => false,
@@ -353,6 +354,22 @@ test("/autoresearch off records a manual off decision for same-cwd sessions", as
     assert.equal(harness.appendedEntries[0].customType, ACTIVATION_ENTRY);
     assert.equal(harness.appendedEntries[0].data.active, false);
     assert.equal(harness.appendedEntries[0].data.workDir, await realpath(cwd));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("/autoresearch dashboard explains that the overlay requires TUI mode", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+
+  try {
+    const harness = createHarness({ cwd });
+    harness.ctx.mode = "rpc";
+
+    await harness.commands.get("autoresearch").handler("dashboard", harness.ctx);
+
+    assert.equal(harness.notifications.length, 1);
+    assert.match(harness.notifications[0].message, /only available in TUI mode/i);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/tests/shortcuts.test.mjs
+++ b/tests/shortcuts.test.mjs
@@ -153,6 +153,32 @@ test("invalid known shortcut fields warn and fall back to defaults for the whole
   }
 });
 
+test("invalid shortcut chords warn instead of registering a dead binding", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  const warnings = [];
+  const previousWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    const configPath = autoresearchShortcutsConfigPath(agentDir);
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        shortcuts: {
+          fullscreenDashboard: "ctrl+shift+",
+        },
+      })
+    );
+
+    assert.deepEqual(resolveAutoresearchShortcuts(configPath), UNBOUND_DEFAULTS);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /invalid pi-autoresearch config/i);
+  } finally {
+    console.warn = previousWarn;
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
 function withAgentDir(agentDir, fn) {
   const previous = process.env.PI_CODING_AGENT_DIR;
   try {

--- a/tests/shortcuts.test.mjs
+++ b/tests/shortcuts.test.mjs
@@ -6,25 +6,35 @@ import test from "node:test";
 
 import {
   autoresearchShortcutsConfigPath,
-  DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
   resolveAutoresearchShortcuts,
+  SHORTCUT_ACTIONS,
 } from "../extensions/pi-autoresearch/shortcuts.ts";
 import autoresearchExtension from "../extensions/pi-autoresearch/index.ts";
 
-test("autoresearch shortcuts default to the documented bindings when config is absent", async () => {
+const UNBOUND_DEFAULTS = {
+  fullscreenDashboard: null,
+  export: null,
+  off: null,
+};
+
+test("no shortcuts are bound by default", async () => {
   const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
   try {
     const configPath = autoresearchShortcutsConfigPath(agentDir);
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
     assert.equal(configPath, join(agentDir, "extensions", "pi-autoresearch.json"));
-    assert.equal(shortcuts.fullscreenDashboard, DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT);
+    assert.deepEqual(shortcuts, UNBOUND_DEFAULTS);
   } finally {
     await rm(agentDir, { recursive: true, force: true });
   }
 });
 
-test("autoresearch shortcuts can be overridden by the config file", async () => {
+test("shortcut actions cover every configurable command", () => {
+  assert.deepEqual([...SHORTCUT_ACTIONS], ["fullscreenDashboard", "export", "off"]);
+});
+
+test("shortcuts can be opted into via the config file", async () => {
   const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
   try {
     const configPath = autoresearchShortcutsConfigPath(agentDir);
@@ -34,19 +44,24 @@ test("autoresearch shortcuts can be overridden by the config file", async () => 
       JSON.stringify({
         shortcuts: {
           fullscreenDashboard: "ctrl+shift+u",
+          export: "alt+shift+e",
         },
       })
     );
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.equal(shortcuts.fullscreenDashboard, "ctrl+shift+u");
+    assert.deepEqual(shortcuts, {
+      fullscreenDashboard: "ctrl+shift+u",
+      export: "alt+shift+e",
+      off: null,
+    });
   } finally {
     await rm(agentDir, { recursive: true, force: true });
   }
 });
 
-test("autoresearch shortcuts can be disabled with null in the config file", async () => {
+test("explicit null in the config file keeps a shortcut unbound", async () => {
   const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
   try {
     const configPath = autoresearchShortcutsConfigPath(agentDir);
@@ -68,7 +83,7 @@ test("autoresearch shortcuts can be disabled with null in the config file", asyn
   }
 });
 
-test("partial shortcut config defaults omitted fields independently", async () => {
+test("empty shortcut config leaves every action unbound", async () => {
   const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
   try {
     const configPath = autoresearchShortcutsConfigPath(agentDir);
@@ -82,7 +97,7 @@ test("partial shortcut config defaults omitted fields independently", async () =
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.equal(shortcuts.fullscreenDashboard, DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT);
+    assert.deepEqual(shortcuts, UNBOUND_DEFAULTS);
   } finally {
     await rm(agentDir, { recursive: true, force: true });
   }
@@ -100,9 +115,7 @@ test("malformed shortcut config warns and falls back to defaults", async () => {
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.deepEqual(shortcuts, {
-      fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
-    });
+    assert.deepEqual(shortcuts, UNBOUND_DEFAULTS);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /pi-autoresearch.*config/i);
     assert.match(warnings[0], new RegExp(configPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
@@ -131,9 +144,7 @@ test("invalid known shortcut fields warn and fall back to defaults for the whole
 
     const shortcuts = resolveAutoresearchShortcuts(configPath);
 
-    assert.deepEqual(shortcuts, {
-      fullscreenDashboard: DEFAULT_FULLSCREEN_DASHBOARD_SHORTCUT,
-    });
+    assert.deepEqual(shortcuts, UNBOUND_DEFAULTS);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /invalid pi-autoresearch config/i);
   } finally {
@@ -166,7 +177,18 @@ function collectRegisteredShortcuts() {
   return shortcuts;
 }
 
-test("extension registers shortcuts from the active profile config", async () => {
+test("extension registers no shortcuts without opt-in config", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
+  try {
+    withAgentDir(agentDir, () => {
+      assert.deepEqual(collectRegisteredShortcuts(), []);
+    });
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("extension registers each configured shortcut", async () => {
   const agentDir = await mkdtemp(join(tmpdir(), "pi-autoresearch-test-"));
   try {
     const configPath = autoresearchShortcutsConfigPath(agentDir);
@@ -176,6 +198,8 @@ test("extension registers shortcuts from the active profile config", async () =>
       JSON.stringify({
         shortcuts: {
           fullscreenDashboard: "ctrl+shift+u",
+          export: "alt+shift+e",
+          off: "alt+shift+q",
         },
       })
     );
@@ -183,7 +207,7 @@ test("extension registers shortcuts from the active profile config", async () =>
     withAgentDir(agentDir, () => {
       assert.deepEqual(
         collectRegisteredShortcuts().map((entry) => entry.shortcut),
-        ["ctrl+shift+u"]
+        ["ctrl+shift+u", "alt+shift+e", "alt+shift+q"]
       );
     });
   } finally {


### PR DESCRIPTION
Fixes #86.

## Problem

pi 0.84.2 added a built-in fullscreen transcript search on `ctrl+shift+f`, colliding with this extension's default dashboard shortcut. Extension shortcuts win conflicts, so the extension hijacked the new built-in and every startup logged a conflict warning. Changing the default chord would only be whack-a-mole: pi's built-in keymap grows every release, so any hardcoded default eventually collides.

## Solution

Eliminate the conflict class: **no keyboard shortcuts are bound by default**. Every action is reachable via `/autoresearch` subcommands, and chords are strictly opt-in.

### Changes

- **Breaking:** no default shortcuts. Restore the old behavior in `<agent-dir>/extensions/pi-autoresearch.json`:
  ```json
  { "shortcuts": { "fullscreenDashboard": "ctrl+shift+f" } }
  ```
- New `/autoresearch dashboard` subcommand opens the fullscreen overlay — the keyboard-free path (previously the overlay was only reachable via the chord).
- Three configurable shortcut actions instead of one: `fullscreenDashboard`, `export`, `off`.
- Widget hint shows `/autoresearch dashboard`, or the configured chord when one is set.
- README: rewritten opt-in shortcuts section, plus agent-facing guidance with a verified snippet that checks a candidate chord against the installed pi's built-in keymap (`TAKEN`/`FREE`) before writing config.
- `shortcuts.ts` generalized to a `SHORTCUT_ACTIONS` map; overlay and off-logic extracted into functions shared by commands and shortcuts.
- Shortcut config now validates chord syntax before registration, with coverage for invalid chords, zero-registration by default, per-action opt-in, and multi-shortcut registration. Tests: 50/50 pass.
- CHANGELOG entry under `Unreleased`; versioning remains part of the release process.
