### PR TITLE
fix: expand the autoresearch-create skill kickoff instead of sending it as literal text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `/autoresearch <goal>` without a `.auto/prompt.md` sent the literal text `/skill:autoresearch-create …` to the model instead of the skill's contents, because `pi.sendUserMessage()` does not expand skill commands by default. Models would reply with things like `Unknown command: /skill:autoresearch-create` (#93). The kickoff is now sent with `expandPromptTemplates: true` (pi ≥ 0.84.2).
+
 ## [1.8.0] - 2026-09-08
 
 ### Added

--- a/extensions/pi-autoresearch/index.ts
+++ b/extensions/pi-autoresearch/index.ts
@@ -1220,12 +1220,13 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
     };
   };
 
+  // Without `expandPromptTemplates` a `/skill:<name>` kickoff reaches the model as literal text.
   const sendWhenReady = (ctx: ExtensionContext, message: string): void => {
     if (ctx.isIdle()) {
-      pi.sendUserMessage(message);
+      pi.sendUserMessage(message, { expandPromptTemplates: true });
       return;
     }
-    pi.sendUserMessage(message, { deliverAs: "followUp" });
+    pi.sendUserMessage(message, { expandPromptTemplates: true, deliverAs: "followUp" });
   };
 
   const hasAutoresearchRules = (ctx: ExtensionContext): boolean =>
@@ -3090,8 +3091,8 @@ export default function autoresearchExtension(pi: ExtensionAPI) {
       runtime.autoResumeTurns = 0;
       const rulesLoaded = hasAutoresearchRules(ctx);
       // No .auto/prompt.md yet — load the create skill so the agent follows the
-      // setup guidelines. `/skill:<name>` is expanded to the full SKILL.md by
-      // pi's input pipeline (requires `enableSkillCommands`), and trailing args
+      // setup guidelines. `/skill:<name>` is expanded to the full SKILL.md when
+      // sent with `expandPromptTemplates` (see sendWhenReady), and trailing args
       // are appended as the session goal. Must be sent as its own message that
       // STARTS with `/skill:` so expansion triggers — don't prepend hook output.
       const kickoff = rulesLoaded

--- a/tests/activation.test.mjs
+++ b/tests/activation.test.mjs
@@ -327,6 +327,22 @@ test("starting autoresearch binds redirected workingDir activation to the pi ses
   }
 });
 
+test("starting autoresearch without prompt.md sends the create skill with expansion enabled", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
+
+  try {
+    const harness = createHarness({ cwd });
+    await harness.commands.get("autoresearch").handler("optimize runtime", harness.ctx);
+
+    assert.equal(harness.sentMessages.length, 1);
+    const [kickoff] = harness.sentMessages;
+    assert.match(kickoff.content, /^\/skill:autoresearch-create optimize runtime/);
+    assert.equal(kickoff.options.expandPromptTemplates, true);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("session startup keeps same-cwd sessions inactive when a manual off is recorded", async () => {
   const cwd = await mkdtemp(join(tmpdir(), "pi-autoresearch-cwd-"));
 


### PR DESCRIPTION
Fixes #93

## Problem

`/autoresearch <goal>` without a `.auto/prompt.md` sent the literal string `/skill:autoresearch-create <goal> …` to the model. `pi.sendUserMessage()` doesn't expand skill commands by default, so the skill was never inlined — some models then reply `Unknown command: /skill:autoresearch-create`. That message comes from the LLM, not pi, and it happened on every pi version.

## Fix

Pass `{ expandPromptTemplates: true }` (pi ≥ 0.84.2) so pi inlines the SKILL.md. On older pi the option is ignored — behaviour unchanged, no dependency changes.

## Verified

- `npm test` — 66/66 (one new test for the kickoff message)
- Real pi 0.84.2 / 0.84.3 / 0.84.4 / 0.85.1: model now receives `<skill name="autoresearch-create" …>`; `main` still sends the literal string
