### PR TITLE
docs: fix README autoresearch startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Inspired by [karpathy/autoresearch](https://github.com/karpathy/autoresearch). W
 
 ```bash
 pi install npm:pi-autoresearch
+pi
+```
+
+Or load the package for one session only with `pi -e npm:pi-autoresearch`.
+
+Then start the loop inside pi:
+
+```text
+/autoresearch optimize unit test runtime, monitor correctness
 ```
 
 ## What's included
@@ -44,6 +53,7 @@ pi install npm:pi-autoresearch
 
 | Subcommand | Description |
 |------------|-------------|
+| `/autoresearch` | Show help without activating autoresearch mode. |
 | `/autoresearch <text>` | Enter autoresearch mode. If `.auto/prompt.md` exists, resumes the loop with `<text>` as context. Otherwise, sets up a new session. |
 | `/autoresearch off` | Leave autoresearch mode. Stops auto-resume and clears runtime state but keeps `.auto/log.jsonl` intact. |
 | `/autoresearch clear` | Delete `.auto/log.jsonl`, reset all state, and turn autoresearch mode off. Use this for a clean start. |
@@ -161,9 +171,11 @@ Then `/reload` in pi.
 
 ### 1. Start autoresearch
 
+```text
+/autoresearch optimize unit test runtime, monitor correctness
 ```
-/skill:autoresearch-create
-```
+
+This activates autoresearch mode and makes the experiment tools available. If `.auto/prompt.md` does not exist, it also loads the `autoresearch-create` skill. Calling `/skill:autoresearch-create` directly does not activate the mode, so the tools remain unavailable in a fresh session.
 
 The agent asks about your goal, command, metric, and files in scope — or infers them from context. It then creates a branch, writes `.auto/prompt.md` and `.auto/measure.sh`, runs the baseline, and starts looping immediately.
 


### PR DESCRIPTION
The README still recommends starting with `/skill:autoresearch-create`, but since v1.5.0 the experiment tools are only available while autoresearch mode is active. The skill alone does not activate it.

I hit this after launching `pi -e npm:pi-autoresearch`: the agent reported missing experiment tools and used Bash instead, with no dashboard updates.

This README-only change:
- Uses `/autoresearch <goal>` in both startup examples.
- Completes the quick start, including the temporary `-e` option.
- Explains why calling the skill directly is not enough and that bare `/autoresearch` only shows help.

Verified against the command handler and tool gating in `extensions/pi-autoresearch/index.ts`. `git diff --check` passes. No runtime changes.
